### PR TITLE
ci: remove restore-keys

### DIFF
--- a/.github/workflows/admin-panel-tests.yml
+++ b/.github/workflows/admin-panel-tests.yml
@@ -41,8 +41,6 @@ jobs:
           path: |
             **/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       - name: Install dependencies 📦
         if: steps.cache-npm-deps.outputs.cache-hit != 'true'
@@ -74,8 +72,6 @@ jobs:
           path: |
             ./apps/backend/dist
           key: ${{ runner.os }}-node-backend-${{ hashFiles('./apps/backend/**/*', '!./apps/backend/node_modules/**/*', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-backend-
 
       - name: Build backend 🏗️
         if: steps.cache-backend-build.outputs.cache-hit != 'true'
@@ -105,8 +101,6 @@ jobs:
           path: |
             ./apps/admin-panel/dist
           key: ${{ runner.os }}-node-admin-panel-${{ hashFiles('./apps/admin-panel/**/*', '!./apps/admin-panel/node_modules/**/*', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-admin-panel-
 
       - name: Build admin-panel 🏗️
         if: steps.cache-admin-panel-build.outputs.cache-hit != 'true'

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -35,8 +35,6 @@ jobs:
           path: |
             **/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       - name: Install dependencies 📦
         if: steps.cache-npm-deps.outputs.cache-hit != 'true'
@@ -60,8 +58,6 @@ jobs:
           path: |
             ./apps/backend/dist
           key: ${{ runner.os }}-node-backend-${{ hashFiles('./apps/backend/**/*', '!./apps/backend/node_modules/**/*', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-backend-
 
       - name: Check Build 🏗️
         if: steps.cache-backend-build.outputs.cache-hit != 'true'

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -41,8 +41,6 @@ jobs:
           path: |
             **/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       - name: Install dependencies 📦
         if: steps.cache-npm-deps.outputs.cache-hit != 'true'
@@ -74,8 +72,6 @@ jobs:
           path: |
             ./apps/backend/dist
           key: ${{ runner.os }}-node-backend-${{ hashFiles('./apps/backend/**/*', '!./apps/backend/node_modules/**/*', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-backend-
 
       - name: Build backend 🏗️
         if: steps.cache-backend-build.outputs.cache-hit != 'true'
@@ -115,8 +111,6 @@ jobs:
           path: |
             ./apps/frontend/dist
           key: ${{ runner.os }}-node-frontend-${{ hashFiles('./apps/frontend/**/*', '!./apps/frontend/node_modules/**/*', '**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-frontend-
 
       - name: Build frontend 🏗️
         if: steps.cache-frontend-build.outputs.cache-hit != 'true'


### PR DESCRIPTION
they're unnecessary, our cache keys are deterministic hashes, if they change we should rebuild and not use an older (partial) cache