### PR TITLE
ci: remove running tests on push on branches main, staging

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -3,8 +3,6 @@ name: Backend Tests
 on:
   pull_request:
     branches: [main, staging]
-  push:
-    branches: [main, staging]
 
 jobs:
   backend-tests:


### PR DESCRIPTION
This PR uses the same logic as frontend/admin-panel tests. IMO it's unecessary to run the tests *after* merging into a branch because the tests are run when a PR is opened and the `main` branch has a [branch protection rule](https://github.com/technologiestiftung/baergpt/settings/rules/8227326) to avoid direct pushes. 