### PR TITLE
feat: add typescript as devDependency to apps 

### DIFF
--- a/apps/admin-panel/package.json
+++ b/apps/admin-panel/package.json
@@ -52,6 +52,7 @@
 		"globals": "15.10.0",
 		"postcss": "8.4.47",
 		"tailwindcss": "3.4.13",
+		"typescript": "5.8.3",
 		"vite": "7.1.7",
 		"vitest": "3.2.4"
 	}

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -58,6 +58,7 @@
 		"nodemon": "3.1.4",
 		"supertest": "7.1.0",
 		"tsx": "4.19.3",
+		"typescript": "5.8.3",
 		"vitest": "3.1.1"
 	},
 	"overrides": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -50,6 +50,7 @@
 		"globals": "15.8.0",
 		"postcss": "8.4.40",
 		"tailwindcss": "3.4.7",
+		"typescript": "5.8.3",
 		"vite": "7.1.7",
 		"vitest": "3.2.4"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,8 +60,23 @@
 				"globals": "15.10.0",
 				"postcss": "8.4.47",
 				"tailwindcss": "3.4.13",
+				"typescript": "5.8.3",
 				"vite": "7.1.7",
 				"vitest": "3.2.4"
+			}
+		},
+		"apps/admin-panel/node_modules/typescript": {
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"apps/backend": {
@@ -105,6 +120,7 @@
 				"nodemon": "3.1.4",
 				"supertest": "7.1.0",
 				"tsx": "4.19.3",
+				"typescript": "5.8.3",
 				"vitest": "3.1.1"
 			}
 		},
@@ -215,6 +231,20 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"apps/backend/node_modules/typescript": {
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"apps/backend/node_modules/vitest": {
@@ -436,6 +466,7 @@
 				"globals": "15.8.0",
 				"postcss": "8.4.40",
 				"tailwindcss": "3.4.7",
+				"typescript": "5.8.3",
 				"vite": "7.1.7",
 				"vitest": "3.2.4"
 			}
@@ -646,6 +677,20 @@
 			},
 			"engines": {
 				"node": ">=14.0.0"
+			}
+		},
+		"apps/frontend/node_modules/typescript": {
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"libs/db-schema": {


### PR DESCRIPTION
Using typescript as transitive dependency via the `typescript-config` lib from the monorepo breaks deployments