### PR TITLE
Update recovery.html

### DIFF
--- a/apps/backend/supabase/templates/recovery.html
+++ b/apps/backend/supabase/templates/recovery.html
@@ -127,7 +127,7 @@
 										href="{{ .ConfirmationURL }}"
 										style="color: #0c2753; text-decoration: none"
 									>
-										{{ .ConfirmationURL }}new-password/
+										{{ .ConfirmationURL }}
 									</a>
 								</div>
 


### PR DESCRIPTION
This version and the one currently on cloud based superbase had diverged. This is the one we are currently also using here:
https://gist.githubusercontent.com/tsboter/80df00524bd4cb094cb39a2242d9dc7d/raw/964cbbdf39f341d9b45d3fdf3b3e3638fb336b02/recovery.html 
 
Related to: https://app.asana.com/1/1201970074282735/project/1208836734369129/task/1211708709934695 

We had some issues where Brevo would change the link inside the button thats rendered in the confirmation email. After a bit of back and forth the fix of the email template looked like this:
`{{ .ConfirmationURL }}new-password/`
But now it seems that is no longer necessary as its now working with the original
`{{ .ConfirmationURL }}`
My guess is there was some cache or dns propagation but not sure. 