### PR TITLE
fix: guard redis secrets in limiter errors

### DIFF
--- a/apps/backend/src/services/distributed-limiter.ts
+++ b/apps/backend/src/services/distributed-limiter.ts
@@ -59,13 +59,13 @@ export function initQueues(): Promise<void> {
 	});
 
 	llmLimiter.on("error", (error: Error) => {
-		console.error(error);
-		captureError(error);
+		console.error(error.message);
+		captureError(`Redis limiter failed: ${error.message}`);
 	});
 
 	embeddingsLimiter.on("error", (error: Error) => {
-		console.error(error);
-		captureError(error);
+		console.error(error.message);
+		captureError(`Redis limiter failed: ${error.message}`);
 	});
 
 	// Ensure scripts are loaded and clients are ready before any schedule() calls.


### PR DESCRIPTION
This should stop our redis informaiton from leaking through the CI. As part of the fix I've also upgraded our staging redis instance so our tests shouldn't hit `ReplyError: Too many requests. Please try again later.`