### PR TITLE
fix/supabase-service-role-cleanup

### DIFF
--- a/apps/backend/src/integration/base-knowledge.integration.test.ts
+++ b/apps/backend/src/integration/base-knowledge.integration.test.ts
@@ -10,8 +10,8 @@ import {
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@repo/db-schema";
 import { config } from "../config";
-import { supabase as supabaseAdminClient } from "../supabase";
-import { DatabaseService } from "../services/database-service";
+import { serviceRoleDbClient as supabaseAdminClient } from "../supabase";
+import { PrivilegedDbService } from "../services/db-service/privileged-db-service";
 import { EmbeddingService } from "../services/embedding-service";
 import type { KnowledgeBaseDocument } from "../types/common";
 
@@ -35,7 +35,7 @@ describe("Base Knowledge Integration Tests", () => {
 	let accessGroupId: string;
 	let documentId: number;
 
-	const dbService = new DatabaseService(supabaseAdminClient);
+	const dbService = new PrivilegedDbService(supabaseAdminClient);
 	const embeddingService = new EmbeddingService(dbService);
 
 	beforeAll(async () => {

--- a/apps/backend/src/integration/chunking.test.ts
+++ b/apps/backend/src/integration/chunking.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EmbeddingService } from "../services/embedding-service";
-import type { DatabaseService } from "../services/database-service";
+import type { BaseContentDbService } from "../services/db-service/base-db-service";
 import { countTokens } from "../services/token-utils";
 import { config } from "../config";
 
@@ -25,7 +25,7 @@ describe("Chunking Methods", () => {
 	const mockDbService = {
 		updateUserColumnValue: vi.fn(),
 		logEmbeddings: vi.fn(),
-	} as unknown as DatabaseService;
+	} as unknown as BaseContentDbService;
 
 	beforeEach(() => {
 		service = new EmbeddingService(mockDbService);

--- a/apps/backend/src/integration/db.integration.test.ts
+++ b/apps/backend/src/integration/db.integration.test.ts
@@ -1,5 +1,3 @@
-import { DatabaseService } from "../services/database-service";
-import { type Document } from "../types/common";
 import {
 	afterEach,
 	afterAll,
@@ -9,7 +7,7 @@ import {
 	expect,
 	it,
 } from "vitest";
-import { supabase as supabaseAdminClient } from "../supabase";
+import { serviceRoleDbClient } from "../supabase";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@repo/db-schema";
 import { config } from "../config";
@@ -49,7 +47,7 @@ describe("Integration tests for DB", async () => {
 			expect(signupError).toBeNull();
 
 			const { data: actualProfile, error: profileError } =
-				await supabaseAdminClient
+				await serviceRoleDbClient
 					.from("profiles")
 					.select("first_name, last_name")
 					.eq("id", data.user.id)
@@ -64,7 +62,7 @@ describe("Integration tests for DB", async () => {
 			expect(actualProfile).toStrictEqual(expectedProfile);
 
 			const { error: deleteError } =
-				await supabaseAdminClient.auth.admin.deleteUser(data.user.id);
+				await serviceRoleDbClient.auth.admin.deleteUser(data.user.id);
 			expect(deleteError).toBeNull();
 		});
 	});
@@ -80,7 +78,7 @@ describe("Integration tests for DB", async () => {
 
 		const {
 			data: { id: accessGroupId },
-		} = await supabaseAdminClient
+		} = await serviceRoleDbClient
 			.from("access_groups")
 			.select()
 			.eq("name", "Alle")
@@ -98,12 +96,12 @@ describe("Integration tests for DB", async () => {
 		beforeAll(async () => {
 			// Clean up any leftover users from previous interrupted test runs
 			for (const user of users) {
-				await supabaseAdminClient.auth.admin.deleteUser(user.id);
+				await serviceRoleDbClient.auth.admin.deleteUser(user.id);
 			}
 
 			for (const user of users) {
 				const { error: signupError } =
-					await supabaseAdminClient.auth.admin.createUser({
+					await serviceRoleDbClient.auth.admin.createUser({
 						id: user.id,
 						email: user.email,
 						password: user.password,
@@ -113,7 +111,7 @@ describe("Integration tests for DB", async () => {
 				expect(signupError).toBeNull();
 			}
 
-			const { error: setAdminError } = await supabaseAdminClient
+			const { error: setAdminError } = await serviceRoleDbClient
 				.from("application_admins")
 				.insert({ user_id: givenAdminId });
 
@@ -127,7 +125,7 @@ describe("Integration tests for DB", async () => {
 		afterAll(async () => {
 			for (const { id } of users) {
 				const { error: deleteError } =
-					await supabaseAdminClient.auth.admin.deleteUser(id);
+					await serviceRoleDbClient.auth.admin.deleteUser(id);
 				expect(deleteError).toBeNull();
 			}
 		});
@@ -140,7 +138,7 @@ describe("Integration tests for DB", async () => {
 
 			it("should validate the email domain during registration", async () => {
 				const { data, error: signupError } =
-					await supabaseAdminClient.auth.admin.createUser({
+					await serviceRoleDbClient.auth.admin.createUser({
 						email: validEmail,
 						password: givenUserPassword,
 						email_confirm: true,
@@ -152,7 +150,7 @@ describe("Integration tests for DB", async () => {
 
 			it("should reject registration with invalid email domain", async () => {
 				const { error: signupError } =
-					await supabaseAdminClient.auth.admin.createUser({
+					await serviceRoleDbClient.auth.admin.createUser({
 						email: invalidEmail,
 						password: givenUserPassword,
 						email_confirm: true,
@@ -170,7 +168,7 @@ describe("Integration tests for DB", async () => {
 				expect(sessionData.session).not.toBeNull();
 				expect(userId).not.toBe("");
 				const { error: updateError } =
-					await supabaseAdminClient.auth.admin.updateUserById(userId, {
+					await serviceRoleDbClient.auth.admin.updateUserById(userId, {
 						email: validEmail2,
 					});
 				expect(updateError).toBeNull();
@@ -179,14 +177,14 @@ describe("Integration tests for DB", async () => {
 			it("should reject email change to invalid domain", async () => {
 				expect(userId).not.toBe("");
 				const { error: updateError } =
-					await supabaseAdminClient.auth.admin.updateUserById(userId, {
+					await serviceRoleDbClient.auth.admin.updateUserById(userId, {
 						email: invalidEmail,
 					});
 				expect(updateError).not.toBeNull();
 			});
 
 			it("should reject emails with invalid format", async () => {
-				const { error } = await supabaseAdminClient.auth.admin.createUser({
+				const { error } = await serviceRoleDbClient.auth.admin.createUser({
 					email: "@local.berlin.de",
 					password: givenUserPassword,
 					email_confirm: true,
@@ -195,7 +193,7 @@ describe("Integration tests for DB", async () => {
 			});
 
 			it("should allow registration with exact domain match", async () => {
-				const { data, error } = await supabaseAdminClient.auth.admin.createUser(
+				const { data, error } = await serviceRoleDbClient.auth.admin.createUser(
 					{
 						email: "test@ts.berlin",
 						password: givenUserPassword,
@@ -204,13 +202,13 @@ describe("Integration tests for DB", async () => {
 				);
 				expect(error).toBeNull();
 				if (data.user?.id) {
-					await supabaseAdminClient.auth.admin.deleteUser(data.user.id);
+					await serviceRoleDbClient.auth.admin.deleteUser(data.user.id);
 				}
 			});
 
 			afterAll(async () => {
 				if (userId) {
-					await supabaseAdminClient.auth.admin.deleteUser(userId);
+					await serviceRoleDbClient.auth.admin.deleteUser(userId);
 				}
 			});
 		});
@@ -414,7 +412,7 @@ describe("Integration tests for DB", async () => {
 
 				// Get user IDs from auth.users table using admin client
 				const { data: allUsers, error: listUsersError } =
-					await supabaseAdminClient.auth.admin.listUsers();
+					await serviceRoleDbClient.auth.admin.listUsers();
 
 				expect(listUsersError).toBeNull();
 
@@ -439,7 +437,7 @@ describe("Integration tests for DB", async () => {
 
 				// Check that the admin and the user were added to the default access group
 				const { data: accessGroupMembers, error: memberError } =
-					await supabaseAdminClient
+					await serviceRoleDbClient
 						.from("access_group_members")
 						.select("user_id, access_group_id")
 						.in("user_id", [adminUserId, regularUserId])
@@ -455,7 +453,7 @@ describe("Integration tests for DB", async () => {
 			let givenChatId: number;
 
 			beforeEach(async () => {
-				const { data: chatData, error: chatError } = await supabaseAdminClient
+				const { data: chatData, error: chatError } = await serviceRoleDbClient
 					.from("chats")
 					.insert({
 						user_id: givenAdminId,
@@ -467,7 +465,7 @@ describe("Integration tests for DB", async () => {
 
 				expect(chatError).toBeNull();
 
-				const { error: chatMessageError } = await supabaseAdminClient
+				const { error: chatMessageError } = await serviceRoleDbClient
 					.from("chat_messages")
 					.insert({
 						chat_id: givenChatId,
@@ -481,7 +479,7 @@ describe("Integration tests for DB", async () => {
 
 				expect(chatMessageError).toBeNull();
 
-				const { error: documentFoldersError } = await supabaseAdminClient
+				const { error: documentFoldersError } = await serviceRoleDbClient
 					.from("document_folders")
 					.insert({
 						user_id: givenAdminId,
@@ -525,13 +523,13 @@ describe("Integration tests for DB", async () => {
 
 				// Verify the user no longer exists
 				const { error: getUserError } =
-					await supabaseAdminClient.auth.admin.getUserById(givenAdminId);
+					await serviceRoleDbClient.auth.admin.getUserById(givenAdminId);
 
 				// After successful deletion, we should get a "user not found" error
 				expect(getUserError?.message).toBe("User not found");
 
 				const { data: accessGroupMembersData, error: accessGroupMembersError } =
-					await supabaseAdminClient
+					await serviceRoleDbClient
 						.from("access_group_members")
 						.select("*")
 						.eq("user_id", givenAdminId);
@@ -540,7 +538,7 @@ describe("Integration tests for DB", async () => {
 				expect(accessGroupMembersData?.length).toBe(0);
 
 				const { data: applicationAdminsData, error: applicationAdminsError } =
-					await supabaseAdminClient
+					await serviceRoleDbClient
 						.from("application_admins")
 						.select("*")
 						.eq("user_id", givenAdminId);
@@ -549,7 +547,7 @@ describe("Integration tests for DB", async () => {
 				expect(applicationAdminsData?.length).toBe(0);
 
 				const { data: chatMessages, error: chatMessagesError } =
-					await supabaseAdminClient
+					await serviceRoleDbClient
 						.from("chat_messages")
 						.select("*")
 						.eq("chat_id", givenChatId);
@@ -557,7 +555,7 @@ describe("Integration tests for DB", async () => {
 				expect(chatMessagesError).toBeNull();
 				expect(chatMessages?.length).toBe(0);
 
-				const { data: chatsData, error: chatsError } = await supabaseAdminClient
+				const { data: chatsData, error: chatsError } = await serviceRoleDbClient
 					.from("chats")
 					.select("*")
 					.eq("user_id", givenAdminId);
@@ -566,7 +564,7 @@ describe("Integration tests for DB", async () => {
 				expect(chatsData?.length).toBe(0);
 
 				const { data: documentChunksData, error: documentChunksError } =
-					await supabaseAdminClient
+					await serviceRoleDbClient
 						.from("document_chunks")
 						.select("*")
 						.eq("owned_by_user_id", givenAdminId);
@@ -575,7 +573,7 @@ describe("Integration tests for DB", async () => {
 				expect(documentChunksData?.length).toBe(0);
 
 				const { data: documentFoldersData, error: documentFoldersError } =
-					await supabaseAdminClient
+					await serviceRoleDbClient
 						.from("document_folders")
 						.select("*")
 						.eq("user_id", givenAdminId);
@@ -584,7 +582,7 @@ describe("Integration tests for DB", async () => {
 				expect(documentFoldersData?.length).toBe(0);
 
 				const { data: documentSummariesData, error: documentSummariesError } =
-					await supabaseAdminClient
+					await serviceRoleDbClient
 						.from("document_summaries")
 						.select("*")
 						.eq("owned_by_user_id", givenAdminId);
@@ -593,7 +591,7 @@ describe("Integration tests for DB", async () => {
 				expect(documentSummariesData?.length).toBe(0);
 
 				const { data: documentsData, error: documentsError } =
-					await supabaseAdminClient
+					await serviceRoleDbClient
 						.from("documents")
 						.select("*")
 						.eq("owned_by_user_id", givenAdminId);
@@ -602,7 +600,7 @@ describe("Integration tests for DB", async () => {
 				expect(documentsData?.length).toBe(0);
 
 				const { data: profileData, error: profileError } =
-					await supabaseAdminClient
+					await serviceRoleDbClient
 						.from("profiles")
 						.select("*")
 						.eq("id", givenAdminId);
@@ -611,7 +609,7 @@ describe("Integration tests for DB", async () => {
 				expect(profileData?.length).toBe(0);
 
 				const { data: userActiveStatusData, error: userActiveStatusError } =
-					await supabaseAdminClient
+					await serviceRoleDbClient
 						.from("user_active_status")
 						.select("*")
 						.eq("id", givenAdminId);
@@ -620,7 +618,7 @@ describe("Integration tests for DB", async () => {
 				expect(userActiveStatusData?.length).toBe(0);
 
 				const { data: storageData, error: storageError } =
-					await supabaseAdminClient.storage
+					await serviceRoleDbClient.storage
 						.from("documents")
 						.list(givenAdminId);
 
@@ -631,7 +629,7 @@ describe("Integration tests for DB", async () => {
 				 * Re-create the user to avoid side effects on other tests
 				 */
 				const { error: signupError } =
-					await supabaseAdminClient.auth.admin.createUser({
+					await serviceRoleDbClient.auth.admin.createUser({
 						id: givenAdminId,
 						email: givenAdminEmail,
 						password: givenAdminPassword,
@@ -641,7 +639,7 @@ describe("Integration tests for DB", async () => {
 				expect(signupError).toBeNull();
 
 				// Re-add the user to application_admins
-				const { error: setAdminError } = await supabaseAdminClient
+				const { error: setAdminError } = await serviceRoleDbClient
 					.from("application_admins")
 					.insert({ user_id: givenAdminId });
 
@@ -914,74 +912,6 @@ describe("Integration tests for DB", async () => {
 					expect(actualCitationDetails).toMatchObject(expectedCitationDetails);
 				});
 			});
-		});
-	});
-
-	describe("DatabaseService Transaction", () => {
-		const testUserId = "a18922bb-7f9a-4e15-a9c9-6788fe81842d";
-		const testEmail = "db-transaction-test@local.berlin.de";
-
-		beforeAll(async () => {
-			await supabaseAdminClient.auth.admin.deleteUser(testUserId);
-
-			const { error } = await supabaseAdminClient.auth.admin.createUser({
-				id: testUserId,
-				email: testEmail,
-				password: "Password123!",
-				email_confirm: true,
-			});
-			expect(error).toBeNull();
-		});
-
-		afterAll(async () => {
-			await supabaseAdminClient.auth.admin.deleteUser(testUserId);
-		});
-
-		class TestDatabaseService extends DatabaseService {
-			constructor() {
-				super(supabaseAdminClient);
-			}
-			async logSummarizedDocument() {
-				throw new Error("Forced Summary Failure");
-			}
-		}
-
-		it("should rollback document creation on summary failure", async () => {
-			const service = new TestDatabaseService();
-			await supabaseAnonClient.auth.signInWithPassword({
-				email: testEmail,
-				password: "Password123!",
-			});
-
-			const doc: Document = {
-				source_url: "test-url-rollback",
-				source_type: "personal_document",
-				file_checksum: "sum",
-				file_size: 100,
-				num_pages: 1,
-				owned_by_user_id: testUserId,
-				uploaded_by_user_id: testUserId,
-				created_at: new Date().toISOString(),
-			};
-
-			const summaryData = {
-				summary: "test",
-				shortSummary: "test",
-				tags: [],
-				summaryEmbedding: [],
-			};
-
-			await expect(
-				service.logProcessedDocument(doc, summaryData, []),
-			).rejects.toThrow("Forced Summary Failure");
-
-			// Verify document is gone from DB
-			const { count } = await supabaseAdminClient
-				.from("documents")
-				.select("*", { count: "exact", head: true })
-				.eq("source_url", "test-url-rollback");
-
-			expect(count).toBe(0);
 		});
 	});
 });

--- a/apps/backend/src/integration/default-document.integration.test.ts
+++ b/apps/backend/src/integration/default-document.integration.test.ts
@@ -2,12 +2,12 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { config } from "../config";
-import { supabase as supabaseAdminClient } from "../supabase";
-import { DatabaseService } from "../services/database-service";
 import { GenerationService } from "../services/generation-service";
 import { EmbeddingService } from "../services/embedding-service";
 import type { Document } from "../types/common";
 import { initQueues } from "../services/distributed-limiter";
+import { PrivilegedDbService } from "../services/db-service/privileged-db-service";
+import { serviceRoleDbClient } from "../supabase";
 
 const DEFAULT_DOCUMENT_FILE_NAME = "BaerGPT-Handbuch.pdf";
 const DEFAULT_DOCUMENT_SOURCE_TYPE = "default_document";
@@ -18,7 +18,7 @@ const cleanupDefaultDocuments = async (accessGroupId: string) => {
 		const sourceUrl = `${accessGroupId}/${DEFAULT_DOCUMENT_FILE_NAME}`;
 
 		// Delete all default documents
-		const { data: documents } = await supabaseAdminClient
+		const { data: documents } = await serviceRoleDbClient
 			.from("documents")
 			.select("id")
 			.eq("source_type", DEFAULT_DOCUMENT_SOURCE_TYPE)
@@ -28,7 +28,7 @@ const cleanupDefaultDocuments = async (accessGroupId: string) => {
 
 		// Delete related document_chunks
 		if (documentIds.length > 0) {
-			await supabaseAdminClient
+			await serviceRoleDbClient
 				.from("document_chunks")
 				.delete()
 				.in("document_id", documentIds);
@@ -36,21 +36,21 @@ const cleanupDefaultDocuments = async (accessGroupId: string) => {
 
 		// Delete related document_summaries
 		if (documentIds.length > 0) {
-			await supabaseAdminClient
+			await serviceRoleDbClient
 				.from("document_summaries")
 				.delete()
 				.in("document_id", documentIds);
 		}
 
 		// Delete document records
-		await supabaseAdminClient
+		await serviceRoleDbClient
 			.from("documents")
 			.delete()
 			.eq("source_type", DEFAULT_DOCUMENT_SOURCE_TYPE)
 			.eq("source_url", sourceUrl);
 
 		// Delete from storage
-		const { error: removeError } = await supabaseAdminClient.storage
+		const { error: removeError } = await serviceRoleDbClient.storage
 			.from(PUBLIC_DOCUMENTS_BUCKET)
 			.remove([sourceUrl]);
 
@@ -68,13 +68,13 @@ describe("Default Document Integration Tests", () => {
 	let accessGroupId: string;
 	let documentId: number;
 
-	const dbService = new DatabaseService(supabaseAdminClient);
+	const dbService = new PrivilegedDbService(serviceRoleDbClient);
 	const generationService = new GenerationService(dbService);
 	const embeddingService = new EmbeddingService(dbService);
 
 	beforeAll(async () => {
 		// Ensure default access group exists
-		const { data: accessGroup, error } = await supabaseAdminClient
+		const { data: accessGroup, error } = await serviceRoleDbClient
 			.from("access_groups")
 			.select("id")
 			.eq("name", "Alle")
@@ -118,7 +118,7 @@ describe("Default Document Integration Tests", () => {
 		const sourceUrl = `${accessGroupId}/${DEFAULT_DOCUMENT_FILE_NAME}`;
 
 		// Upload file to storage
-		const { error: uploadError } = await supabaseAdminClient.storage
+		const { error: uploadError } = await serviceRoleDbClient.storage
 			.from(PUBLIC_DOCUMENTS_BUCKET)
 			.upload(sourceUrl, file, {
 				upsert: true,
@@ -170,7 +170,7 @@ describe("Default Document Integration Tests", () => {
 		);
 
 		// Get the document ID from the database
-		const { data: savedDocument } = await supabaseAdminClient
+		const { data: savedDocument } = await serviceRoleDbClient
 			.from("documents")
 			.select("id")
 			.eq("source_url", sourceUrl)
@@ -183,7 +183,7 @@ describe("Default Document Integration Tests", () => {
 		documentId = savedDocument.id;
 
 		// Verify document was created in database
-		const { data: verifiedDoc, error: docError } = await supabaseAdminClient
+		const { data: verifiedDoc, error: docError } = await serviceRoleDbClient
 			.from("documents")
 			.select("*")
 			.eq("id", documentId)
@@ -203,7 +203,7 @@ describe("Default Document Integration Tests", () => {
 
 	it("should create document summary and chunks after processing", async () => {
 		// Verify summary was created
-		const { data: summary, error: summaryError } = await supabaseAdminClient
+		const { data: summary, error: summaryError } = await serviceRoleDbClient
 			.from("document_summaries")
 			.select("*")
 			.eq("document_id", documentId)
@@ -215,7 +215,7 @@ describe("Default Document Integration Tests", () => {
 		expect(summary?.short_summary).toBeDefined();
 
 		// Verify chunks were created
-		const { data: chunks, error: chunksError } = await supabaseAdminClient
+		const { data: chunks, error: chunksError } = await serviceRoleDbClient
 			.from("document_chunks")
 			.select("*")
 			.eq("document_id", documentId);
@@ -244,7 +244,7 @@ describe("Default Document Integration Tests", () => {
 		const sourceUrl = `${accessGroupId}/${DEFAULT_DOCUMENT_FILE_NAME}`;
 
 		// Upload file to storage
-		const { error: uploadError } = await supabaseAdminClient.storage
+		const { error: uploadError } = await serviceRoleDbClient.storage
 			.from(PUBLIC_DOCUMENTS_BUCKET)
 			.upload(sourceUrl, file, {
 				upsert: true,
@@ -258,7 +258,7 @@ describe("Default Document Integration Tests", () => {
 
 		// Verify file exists in storage (list files in access group folder)
 		const { data: fileData, error: listError } =
-			await supabaseAdminClient.storage
+			await serviceRoleDbClient.storage
 				.from(PUBLIC_DOCUMENTS_BUCKET)
 				.list(accessGroupId);
 
@@ -270,7 +270,7 @@ describe("Default Document Integration Tests", () => {
 
 		// Verify file can be downloaded
 		const { data: downloadedFile, error: downloadError } =
-			await supabaseAdminClient.storage
+			await serviceRoleDbClient.storage
 				.from(PUBLIC_DOCUMENTS_BUCKET)
 				.download(sourceUrl);
 

--- a/apps/backend/src/integration/fixtures/documents.ts
+++ b/apps/backend/src/integration/fixtures/documents.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { supabase as supabaseAdminClient } from "../../supabase";
+import { serviceRoleDbClient } from "../../supabase";
 import { createClient } from "@supabase/supabase-js";
 import {
 	chunk_index,
@@ -64,7 +64,7 @@ export async function mockDocumentUpload({
 	expect(uploadError).toBeNull();
 
 	const { data: documentData, error: documentsInsertError } =
-		await supabaseAdminClient
+		await serviceRoleDbClient
 			.from("documents")
 			.insert({
 				owned_by_user_id: accessGroupId ? null : userId,
@@ -86,7 +86,7 @@ export async function mockDocumentUpload({
 	expect(documentsInsertError).toBeNull();
 	expect(documentData).not.toBeNull();
 
-	const { error: documentSummariesInsertError } = await supabaseAdminClient
+	const { error: documentSummariesInsertError } = await serviceRoleDbClient
 		.from("document_summaries")
 		.insert({
 			owned_by_user_id: accessGroupId ? null : userId,
@@ -102,7 +102,7 @@ export async function mockDocumentUpload({
 	expect(documentSummariesInsertError).toBeNull();
 
 	const { data: chunkData, error: documentChunksInsertError } =
-		await supabaseAdminClient
+		await serviceRoleDbClient
 			.from("document_chunks")
 			.insert({
 				owned_by_user_id: accessGroupId ? null : userId,
@@ -124,32 +124,32 @@ export async function mockDocumentUpload({
 }
 
 export async function cleanupDocuments(userId: string) {
-	const { error: deleteDocumentsError } = await supabaseAdminClient
+	const { error: deleteDocumentsError } = await serviceRoleDbClient
 		.from("documents")
 		.delete()
 		.eq("owned_by_user_id", userId);
 	expect(deleteDocumentsError).toBeNull();
 
-	const { error: deleteFoldersError } = await supabaseAdminClient
+	const { error: deleteFoldersError } = await serviceRoleDbClient
 		.from("document_folders")
 		.delete()
 		.eq("user_id", userId);
 	expect(deleteFoldersError).toBeNull();
 
-	const { error: deleteDocumentChunksError } = await supabaseAdminClient
+	const { error: deleteDocumentChunksError } = await serviceRoleDbClient
 		.from("document_chunks")
 		.delete()
 		.eq("owned_by_user_id", userId);
 	expect(deleteDocumentChunksError).toBeNull();
 
-	const { error: deleteDocumentSummariesError } = await supabaseAdminClient
+	const { error: deleteDocumentSummariesError } = await serviceRoleDbClient
 		.from("document_summaries")
 		.delete()
 		.eq("owned_by_user_id", userId);
 	expect(deleteDocumentSummariesError).toBeNull();
 
 	const { data: personalDocumentsData, error: personalDocumentsError } =
-		await supabaseAdminClient.storage.from("documents").list(`${userId}`);
+		await serviceRoleDbClient.storage.from("documents").list(`${userId}`);
 
 	expect(personalDocumentsError).toBeNull();
 
@@ -159,14 +159,14 @@ export async function cleanupDocuments(userId: string) {
 
 	if (personalDocumentsToRemove.length > 0) {
 		const { error: deletePersonalDocumentsError } =
-			await supabaseAdminClient.storage
+			await serviceRoleDbClient.storage
 				.from("documents")
 				.remove(personalDocumentsToRemove);
 		expect(deletePersonalDocumentsError).toBeNull();
 	}
 
 	const { data: publicDocumentsData, error: publicDocumentsError } =
-		await supabaseAdminClient.storage
+		await serviceRoleDbClient.storage
 			.from("public_documents")
 			.list(`${userId}`);
 
@@ -178,7 +178,7 @@ export async function cleanupDocuments(userId: string) {
 
 	if (publicDocumentsToRemove.length > 0) {
 		const { error: deletePublicDocumentsError } =
-			await supabaseAdminClient.storage
+			await serviceRoleDbClient.storage
 				.from("public_documents")
 				.remove(publicDocumentsToRemove);
 

--- a/apps/backend/src/integration/routes/admin.integration.test.ts
+++ b/apps/backend/src/integration/routes/admin.integration.test.ts
@@ -11,7 +11,7 @@ import { createClient, type Session } from "@supabase/supabase-js";
 import type { Database } from "@repo/db-schema";
 import app from "../../index";
 import { config } from "../../config";
-import { supabase as supabaseAdminClient } from "../../supabase";
+import { serviceRoleDbClient } from "../../supabase";
 import { addDays } from "date-fns";
 
 const supabaseAnonClient = createClient<Database>(
@@ -41,7 +41,7 @@ describe("/admin/", () => {
 	beforeAll(async () => {
 		for (const user of users) {
 			const { data, error: signupError } =
-				await supabaseAdminClient.auth.admin.createUser({
+				await serviceRoleDbClient.auth.admin.createUser({
 					email: user.email,
 					password: user.password,
 					email_confirm: true,
@@ -55,12 +55,12 @@ describe("/admin/", () => {
 		const {
 			data: { users: adminUsers },
 			error: listUsersError,
-		} = await supabaseAdminClient.auth.admin.listUsers();
+		} = await serviceRoleDbClient.auth.admin.listUsers();
 		expect(listUsersError).toBeNull();
 
 		const adminUser = adminUsers.find(({ email }) => email === givenAdminEmail);
 
-		const { error: setAdminError } = await supabaseAdminClient
+		const { error: setAdminError } = await serviceRoleDbClient
 			.from("application_admins")
 			.insert({ user_id: adminUser.id });
 
@@ -88,7 +88,7 @@ describe("/admin/", () => {
 	});
 
 	afterAll(async () => {
-		const { data, error } = await supabaseAdminClient.auth.admin.listUsers({});
+		const { data, error } = await serviceRoleDbClient.auth.admin.listUsers({});
 
 		expect(error).toBeNull();
 
@@ -102,7 +102,7 @@ describe("/admin/", () => {
 			}
 
 			const { error: deleteError } =
-				await supabaseAdminClient.auth.admin.deleteUser(user.id);
+				await serviceRoleDbClient.auth.admin.deleteUser(user.id);
 			expect(deleteError).toBeNull();
 		}
 	});
@@ -133,10 +133,10 @@ describe("/admin/", () => {
 		const {
 			data: { users: updatedUsers },
 			error: listUsersError,
-		} = await supabaseAdminClient.auth.admin.listUsers();
+		} = await serviceRoleDbClient.auth.admin.listUsers();
 		expect(listUsersError).toBeNull();
 
-		const { data: profile, error: getUserError } = await supabaseAdminClient
+		const { data: profile, error: getUserError } = await serviceRoleDbClient
 			.from("profiles")
 			.select("*")
 			.eq("id", givenUserId)
@@ -216,7 +216,7 @@ describe("/admin/", () => {
 			message: "User admin status updated successfully",
 		});
 
-		const { count } = await supabaseAdminClient
+		const { count } = await serviceRoleDbClient
 			.from("application_admins")
 			.select("*", { count: "exact", head: true })
 			.eq("user_id", givenUserId);
@@ -226,7 +226,7 @@ describe("/admin/", () => {
 		expect(expected).toBe(true);
 
 		// revert the changes
-		const { error } = await supabaseAdminClient
+		const { error } = await serviceRoleDbClient
 			.from("application_admins")
 			.delete()
 			.eq("user_id", givenUserId);
@@ -272,7 +272,7 @@ describe("/admin/", () => {
 			message: "User soft deleted successfully",
 		});
 
-		const { data: profile, error: getUserError } = await supabaseAdminClient
+		const { data: profile, error: getUserError } = await serviceRoleDbClient
 			.from("user_active_status")
 			.select("*")
 			.eq("id", givenUserId)
@@ -284,7 +284,7 @@ describe("/admin/", () => {
 		expect(profile.deleted_at).toBeDefined();
 
 		// revert the soft delete
-		const { error } = await supabaseAdminClient
+		const { error } = await serviceRoleDbClient
 			.from("user_active_status")
 			.update({
 				is_active: true,
@@ -319,7 +319,7 @@ describe("/admin/", () => {
 		const givenUserId = userIds[givenUserEmail];
 
 		// soft delete a given user first
-		const { error } = await supabaseAdminClient
+		const { error } = await serviceRoleDbClient
 			.from("user_active_status")
 			.update({
 				is_active: false,
@@ -340,7 +340,7 @@ describe("/admin/", () => {
 			message: "User restored successfully",
 		});
 
-		const { data: profile, error: getUserError } = await supabaseAdminClient
+		const { data: profile, error: getUserError } = await serviceRoleDbClient
 			.from("user_active_status")
 			.select("*")
 			.eq("id", givenUserId)
@@ -397,7 +397,7 @@ describe("/admin/", () => {
 		const {
 			data: { users: usersAfterDeletion },
 			error: listUsersError,
-		} = await supabaseAdminClient.auth.admin.listUsers();
+		} = await serviceRoleDbClient.auth.admin.listUsers();
 		const foundUser = usersAfterDeletion.find(
 			(user) => user.id === givenUserId,
 		);
@@ -405,7 +405,7 @@ describe("/admin/", () => {
 		expect(listUsersError).toBeNull();
 		expect(foundUser).toBeUndefined();
 
-		const { data: profile, error: getUserError } = await supabaseAdminClient
+		const { data: profile, error: getUserError } = await serviceRoleDbClient
 			.from("profiles")
 			.select("*")
 			.eq("id", givenUserId);
@@ -416,7 +416,7 @@ describe("/admin/", () => {
 
 		// revert the hard delete
 		const { error: restoreError } =
-			await supabaseAdminClient.auth.admin.createUser({
+			await serviceRoleDbClient.auth.admin.createUser({
 				email: givenUserEmail,
 				password: givenUserPassword,
 				email_confirm: true,
@@ -476,7 +476,7 @@ describe("/admin/", () => {
 		const {
 			data: { users: userList },
 			error: listUsersError,
-		} = await supabaseAdminClient.auth.admin.listUsers();
+		} = await serviceRoleDbClient.auth.admin.listUsers();
 		expect(listUsersError).toBeNull();
 
 		const invitedUser = userList.find((user) => user.email === givenEmail);
@@ -485,7 +485,7 @@ describe("/admin/", () => {
 		expect(invitedUser).not.toBeNull();
 
 		// Check if the user has been added to the profiles table with the correct first and last name
-		const { data: profile, error: getUserError } = await supabaseAdminClient
+		const { data: profile, error: getUserError } = await serviceRoleDbClient
 			.from("profiles")
 			.select("*")
 			.eq("id", invitedUser.id)
@@ -501,7 +501,7 @@ describe("/admin/", () => {
 
 		// Clean up: delete the invited user
 		const { error: deleteError } =
-			await supabaseAdminClient.auth.admin.deleteUser(invitedUser.id);
+			await serviceRoleDbClient.auth.admin.deleteUser(invitedUser.id);
 		expect(deleteError).toBeNull();
 	});
 
@@ -511,7 +511,7 @@ describe("/admin/", () => {
 		const givenLastName = "Doe";
 
 		const { data, error } =
-			await supabaseAdminClient.auth.admin.inviteUserByEmail(givenEmail, {
+			await serviceRoleDbClient.auth.admin.inviteUserByEmail(givenEmail, {
 				data: {
 					first_name: givenFirstName,
 					last_name: givenLastName,
@@ -541,7 +541,7 @@ describe("/admin/", () => {
 
 		// Clean up: delete the invited user
 		const { error: deleteError } =
-			await supabaseAdminClient.auth.admin.deleteUser(invitedUser.id);
+			await serviceRoleDbClient.auth.admin.deleteUser(invitedUser.id);
 		expect(deleteError).toBeNull();
 	});
 

--- a/apps/backend/src/integration/routes/basic-auth.integration.test.ts
+++ b/apps/backend/src/integration/routes/basic-auth.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import app from "../../index";
 import { createClient, type Session } from "@supabase/supabase-js";
-import { supabase as supabaseAdminClient } from "../../supabase";
+import { serviceRoleDbClient } from "../../supabase";
 import type { Database } from "@repo/db-schema";
 import { config } from "../../config";
 
@@ -30,7 +30,7 @@ describe("basic auth middleware", () => {
 
 		beforeEach(async () => {
 			const { data, error: signUpError } =
-				await supabaseAdminClient.auth.admin.createUser({
+				await serviceRoleDbClient.auth.admin.createUser({
 					email: givenUserEmail,
 					password: givenUserPassword,
 					email_confirm: true,
@@ -52,7 +52,7 @@ describe("basic auth middleware", () => {
 
 		afterEach(async () => {
 			const { error: deleteUserError } =
-				await supabaseAdminClient.auth.admin.deleteUser(session.user.id);
+				await serviceRoleDbClient.auth.admin.deleteUser(session.user.id);
 			expect(deleteUserError).toBeNull();
 		});
 

--- a/apps/backend/src/integration/routes/documents-security.integration.test.ts
+++ b/apps/backend/src/integration/routes/documents-security.integration.test.ts
@@ -3,7 +3,7 @@ import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@repo/db-schema";
 import app from "../../index";
 import { config } from "../../config";
-import { supabase } from "../../supabase";
+import { serviceRoleDbClient } from "../../supabase";
 import { initQueues } from "../../services/distributed-limiter";
 
 const supabaseAnonClient = createClient<Database>(
@@ -27,13 +27,13 @@ describe("Document Process Security Tests", () => {
 	beforeAll(async () => {
 		// Create test users
 		await Promise.all([
-			supabase.auth.admin.createUser({
+			serviceRoleDbClient.auth.admin.createUser({
 				id: USER_A_ID,
 				email: USER_A_EMAIL,
 				password: USER_A_PASSWORD,
 				email_confirm: true,
 			}),
-			supabase.auth.admin.createUser({
+			serviceRoleDbClient.auth.admin.createUser({
 				id: USER_B_ID,
 				email: USER_B_EMAIL,
 				password: USER_B_PASSWORD,
@@ -62,8 +62,8 @@ describe("Document Process Security Tests", () => {
 	afterAll(async () => {
 		// Cleanup test users and their data
 		await Promise.all([
-			supabase.auth.admin.deleteUser(USER_A_ID).catch(() => {}),
-			supabase.auth.admin.deleteUser(USER_B_ID).catch(() => {}),
+			serviceRoleDbClient.auth.admin.deleteUser(USER_A_ID).catch(() => {}),
+			serviceRoleDbClient.auth.admin.deleteUser(USER_B_ID).catch(() => {}),
 		]);
 	});
 
@@ -224,7 +224,7 @@ describe("Document Process Security Tests", () => {
 
 		beforeAll(async () => {
 			// Create a folder for User A
-			const { data, error } = await supabase
+			const { data, error } = await serviceRoleDbClient
 				.from("document_folders")
 				.insert({ user_id: USER_A_ID, name: "User A's Folder" })
 				.select("id")
@@ -239,7 +239,7 @@ describe("Document Process Security Tests", () => {
 		afterAll(async () => {
 			// Cleanup folder
 			try {
-				await supabase
+				await serviceRoleDbClient
 					.from("document_folders")
 					.delete()
 					.eq("id", userAFolderId);

--- a/apps/backend/src/integration/routes/documents.integration.test.ts
+++ b/apps/backend/src/integration/routes/documents.integration.test.ts
@@ -8,7 +8,7 @@ import {
 	afterAll,
 } from "vitest";
 import app from "../../index";
-import { supabase as supabaseAdminClient } from "../../supabase";
+import { serviceRoleDbClient } from "../../supabase";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@repo/db-schema";
 import { config } from "../../config";
@@ -33,10 +33,10 @@ describe("Documents Route Integration", () => {
 
 	beforeAll(async () => {
 		// Cleanup in case of previous test failures
-		await supabaseAdminClient.auth.admin.deleteUser(givenUserId);
+		await serviceRoleDbClient.auth.admin.deleteUser(givenUserId);
 
 		// Create user
-		await supabaseAdminClient.auth.admin.createUser({
+		await serviceRoleDbClient.auth.admin.createUser({
 			id: givenUserId,
 			email: givenUserEmail,
 			password: givenUserPassword,
@@ -47,7 +47,7 @@ describe("Documents Route Integration", () => {
 	}, 20_000);
 
 	afterAll(async () => {
-		await supabaseAdminClient.auth.admin.deleteUser(givenUserId);
+		await serviceRoleDbClient.auth.admin.deleteUser(givenUserId);
 	});
 
 	beforeEach(async () => {
@@ -62,7 +62,7 @@ describe("Documents Route Integration", () => {
 		// 1. Upload file to storage
 		const sourceUrl = `${givenUserId}/${defaultDocumentName}`;
 		const file = readFileSync(defaultDocumentPath);
-		const { error: uploadError } = await supabaseAdminClient.storage
+		const { error: uploadError } = await supabaseAnonClient.storage
 			.from("documents")
 			.upload(sourceUrl, file, {
 				contentType: "application/pdf",
@@ -71,7 +71,7 @@ describe("Documents Route Integration", () => {
 		expect(uploadError).toBeNull();
 
 		// Verify it exists
-		const { data: listBefore } = await supabaseAdminClient.storage
+		const { data: listBefore } = await serviceRoleDbClient.storage
 			.from("documents")
 			.list(givenUserId);
 		expect(
@@ -107,7 +107,7 @@ describe("Documents Route Integration", () => {
 
 		// 4. Verify file is gone
 
-		const { data: listAfter } = await supabaseAdminClient.storage
+		const { data: listAfter } = await serviceRoleDbClient.storage
 			.from("documents")
 			.list(givenUserId);
 		const found = listAfter?.find((f) => f.name === defaultDocumentName);

--- a/apps/backend/src/integration/routes/user.integration.test.ts
+++ b/apps/backend/src/integration/routes/user.integration.test.ts
@@ -5,7 +5,7 @@ import app from "../../index";
 import { config } from "../../config";
 import { sign } from "hono/jwt";
 import { PDFDocument } from "pdf-lib";
-import { supabase } from "../../supabase";
+import { serviceRoleDbClient } from "../../supabase";
 import { initQueues } from "../../services/distributed-limiter";
 
 let validToken: string;
@@ -41,11 +41,18 @@ const uploadToStorage = async (args: {
 	bytes: Uint8Array;
 	sourceUrl: string;
 	fileName: string;
+	userToken: string;
 }): Promise<void> => {
-	const { bytes, sourceUrl, fileName } = args;
+	const { bytes, sourceUrl, fileName, userToken } = args;
 	const file = new File([bytes.slice()], fileName, { type: "application/pdf" });
 
-	const { error } = await supabase.storage
+	const userClient = createClient(
+		process.env.SUPABASE_URL as string,
+		process.env.SUPABASE_ANON_KEY as string,
+		{ global: { headers: { Authorization: `Bearer ${userToken}` } } },
+	);
+
+	const { error } = await userClient.storage
 		.from("documents")
 		.upload(sourceUrl, file, {
 			contentType: "application/pdf",
@@ -60,7 +67,7 @@ async function getLatestDocumentIdBySourceUrl(
 	ownerId: string,
 	sourceUrl: string,
 ): Promise<number | undefined> {
-	const { data } = await supabase
+	const { data } = await serviceRoleDbClient
 		.from("documents")
 		.select("id")
 		.eq("source_url", sourceUrl)
@@ -81,13 +88,13 @@ const cleanupTestDocuments = async () => {
 		const testUserId2 = OTHER_USER_ID;
 
 		// Delete all documents for the test user
-		await supabase
+		await serviceRoleDbClient
 			.from("documents")
 			.delete()
 			.in("owned_by_user_id", [testUserId, testUserId2]);
 
 		const removeUserFiles = async (userId: string) => {
-			const { data, error } = await supabase.storage
+			const { data, error } = await serviceRoleDbClient.storage
 				.from("documents")
 				.list(userId);
 
@@ -104,7 +111,7 @@ const cleanupTestDocuments = async () => {
 				return;
 			}
 
-			const { error: removeError } = await supabase.storage
+			const { error: removeError } = await serviceRoleDbClient.storage
 				.from("documents")
 				.remove(pathsToRemove);
 
@@ -134,12 +141,13 @@ const delay = (ms: number): Promise<void> => {
  */
 const createTestUser = async (userId: string, email: string) => {
 	try {
-		const { error: createError } = await supabase.auth.admin.createUser({
-			id: userId,
-			email: email,
-			password: "SecureTestPassword123!",
-			email_confirm: true,
-		});
+		const { error: createError } =
+			await serviceRoleDbClient.auth.admin.createUser({
+				id: userId,
+				email: email,
+				password: "SecureTestPassword123!",
+				email_confirm: true,
+			});
 
 		if (createError && !createError.message.includes("already registered")) {
 			console.error("Error creating test user:", createError);
@@ -171,9 +179,9 @@ const createValidJwtToken = async (
 const deleteTestUser = async () => {
 	try {
 		const { error: deleteError } =
-			await supabase.auth.admin.deleteUser(OWNER_USER_ID);
+			await serviceRoleDbClient.auth.admin.deleteUser(OWNER_USER_ID);
 		const { error: deleteError2 } =
-			await supabase.auth.admin.deleteUser(OTHER_USER_ID);
+			await serviceRoleDbClient.auth.admin.deleteUser(OTHER_USER_ID);
 
 		if (deleteError && !deleteError.message.includes("not found")) {
 			console.error("Error deleting test user:", deleteError);
@@ -214,6 +222,7 @@ describe("Integration Tests for Routes", () => {
 			bytes: pdfBytes,
 			sourceUrl,
 			fileName,
+			userToken: validToken,
 		});
 
 		const payload = {
@@ -261,6 +270,7 @@ describe("Integration Tests for Routes", () => {
 				bytes: pdfBytes,
 				sourceUrl: sourceUrls[i],
 				fileName: fileNames[i],
+				userToken: validToken,
 			});
 
 			const payload = {
@@ -340,6 +350,7 @@ describe("Integration Tests for Routes", () => {
 			bytes: pdfBytes,
 			sourceUrl,
 			fileName,
+			userToken: validToken,
 		});
 
 		const newDocPayload = {
@@ -378,7 +389,7 @@ describe("Integration Tests for Routes", () => {
 		expect(deleteError).toBeNull();
 
 		// document should be deleted
-		const { data: deletedDocuments } = await supabase
+		const { data: deletedDocuments } = await serviceRoleDbClient
 			.from("documents")
 			.select("id")
 			.eq("source_url", sourceUrl)
@@ -400,6 +411,7 @@ describe("Integration Tests for Routes", () => {
 			bytes: pdfBytes,
 			sourceUrl,
 			fileName,
+			userToken: validToken,
 		});
 
 		const newDocPayload = {
@@ -430,13 +442,13 @@ describe("Integration Tests for Routes", () => {
 		expect(documentId).toBeDefined();
 
 		// Verify the summaries and chunks exist
-		const { data: preSummaries } = await supabase
+		const { data: preSummaries } = await serviceRoleDbClient
 			.from("document_summaries")
 			.select("document_id")
 			.eq("document_id", documentId as number);
 		expect((preSummaries?.length ?? 0) > 0).toBe(true);
 
-		const { data: preChunks } = await supabase
+		const { data: preChunks } = await serviceRoleDbClient
 			.from("document_chunks")
 			.select("document_id")
 			.eq("document_id", documentId as number);
@@ -451,13 +463,13 @@ describe("Integration Tests for Routes", () => {
 		expect(deleteError).toBeNull();
 
 		// Validate cascade: no summaries and chunks remain
-		const { data: postSummaries } = await supabase
+		const { data: postSummaries } = await serviceRoleDbClient
 			.from("document_summaries")
 			.select("document_id")
 			.eq("document_id", documentId as number);
 		expect(postSummaries?.length ?? 0).toBe(0);
 
-		const { data: postChunks } = await supabase
+		const { data: postChunks } = await serviceRoleDbClient
 			.from("document_chunks")
 			.select("document_id")
 			.eq("document_id", documentId as number);
@@ -525,6 +537,7 @@ describe("Integration Tests for Routes", () => {
 			bytes: pdfBytes,
 			sourceUrl,
 			fileName,
+			userToken: validToken2,
 		});
 
 		const payload2 = {
@@ -560,7 +573,7 @@ describe("Integration Tests for Routes", () => {
 		expect(deleteError).not.toBeNull();
 		expect(deleteError?.message).toContain("not_found");
 		// Cleanup
-		await supabase
+		await serviceRoleDbClient
 			.from("documents")
 			.delete()
 			.eq("id", docId as number);

--- a/apps/backend/src/integration/storage.integration.test.ts
+++ b/apps/backend/src/integration/storage.integration.test.ts
@@ -9,7 +9,7 @@ import {
 } from "vitest";
 import { cleanupDocuments, mockDocumentUpload } from "./fixtures/documents";
 import { defaultDocumentName, defaultDocumentPath } from "./fixtures/constants";
-import { supabase as supabaseAdminClient } from "../supabase";
+import { serviceRoleDbClient as supabaseAdminClient } from "../supabase";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@repo/db-schema";
 import { config } from "../config";

--- a/apps/backend/src/middleware/admin-auth.ts
+++ b/apps/backend/src/middleware/admin-auth.ts
@@ -1,13 +1,12 @@
 import { createMiddleware } from "hono/factory";
 import type { Context, Next } from "hono";
-import { DatabaseService } from "../services/database-service";
+import { UserScopedDbService } from "../services/db-service/user-scoped-db-service";
 import { captureError } from "../monitoring/capture-error";
-import { getAuthContext } from "./basic-auth";
-import { adminDatabaseService } from "../supabase";
 
 export const adminAuth = createMiddleware(async (c: Context, next: Next) => {
-	const dbService = new DatabaseService(adminDatabaseService);
-	const { userId } = getAuthContext(c);
+	const UserScopedDbClient = c.get("UserScopedDbClient");
+	const userScopedDbService = new UserScopedDbService(UserScopedDbClient);
+	const userId = c.get("authenticatedUserId");
 
 	if (!userId) {
 		return c.json({ error: "Unauthorized or invalid token" }, 401);
@@ -15,7 +14,7 @@ export const adminAuth = createMiddleware(async (c: Context, next: Next) => {
 
 	let isAdmin = false;
 	try {
-		isAdmin = await dbService.getUserAdminStatus(userId);
+		isAdmin = await userScopedDbService.getUserAdminStatus();
 	} catch (error) {
 		captureError(error);
 	}

--- a/apps/backend/src/middleware/basic-auth.ts
+++ b/apps/backend/src/middleware/basic-auth.ts
@@ -3,38 +3,14 @@ import { verify } from "hono/jwt";
 import type { Context, Next } from "hono";
 import { config } from "../config";
 import { captureError } from "../monitoring/capture-error";
-import { createUserClient } from "../supabase";
+import { createUserScopedDbClient } from "../supabase";
 
-const AUTH_CONTEXT_KEY = "supabaseAuth" as const;
-
-type AuthContextValue = {
-	userId: string;
-	accessToken: string;
-};
-
-export function getAuthContext(c: Context): AuthContextValue {
-	const value = c.get(AUTH_CONTEXT_KEY) as AuthContextValue | undefined;
-	if (!value) {
-		throw new Error("Auth context missing on request");
-	}
-	return value;
-}
-
-export function getUserClient(c: Context) {
-	const { accessToken } = getAuthContext(c);
-	return createUserClient(accessToken);
-}
-
-/**
- * Validates the Supabase session and extracts the authenticated user ID.
- * Returns the user ID if valid, null otherwise.
- */
-async function validateSupabaseSession(c: Context): Promise<string | null> {
+const basicAuth = createMiddleware(async (c: Context, next: Next) => {
 	const authorizationHeader = c.req.header("authorization") || "";
 	const token = authorizationHeader.replace("Bearer ", "");
 
 	if (!token) {
-		return null;
+		return c.json({ error: "Unauthorized: Invalid or expired session" }, 401);
 	}
 
 	let decodedToken: null | { exp?: number; sub?: string } = null;
@@ -46,73 +22,37 @@ async function validateSupabaseSession(c: Context): Promise<string | null> {
 		};
 	} catch (error) {
 		captureError(error);
-		return null;
+		return c.json({ error: "Unauthorized: Invalid or expired session" }, 401);
 	}
 
 	if (decodedToken.exp && decodedToken.exp < Date.now() / 1000) {
 		captureError(new Error("Supabase session token expired"));
-		return null;
+		return c.json({ error: "Unauthorized: Invalid or expired session" }, 401);
 	}
 
 	if (!decodedToken.sub) {
 		captureError(new Error("Supabase session token missing user ID"));
-		return null;
+		return c.json({ error: "Unauthorized: Invalid or expired session" }, 401);
 	}
 
-	// Store auth context first so getUserClient() works
-	c.set(AUTH_CONTEXT_KEY, {
-		userId: decodedToken.sub,
-		accessToken: token,
-	});
-
-	// Use user's own JWT to check active status via RPC (no service role needed)
-	const userClient = createUserClient(token);
+	const userClient = createUserScopedDbClient(token);
 	const { data: isActive, error } = await userClient.rpc(
 		"is_current_user_active",
 	);
 
 	if (error) {
 		captureError(error);
-		return false;
+		return c.json({ error: "Unauthorized: Invalid or expired session" }, 401);
 	}
 
 	if (!isActive) {
 		captureError(new Error("User account is deactivated or not found"));
-		return null;
-	}
-
-	return decodedToken.sub;
-}
-
-const basicAuth = createMiddleware(async (c: Context, next: Next) => {
-	try {
-		const userId = await validateSupabaseSession(c);
-
-		if (userId) {
-			// Store authenticated user ID in context for use by route handlers
-			c.set("authenticatedUserId", userId);
-			return next();
-		}
-
 		return c.json({ error: "Unauthorized: Invalid or expired session" }, 401);
-	} catch (error) {
-		captureError(error);
-		return c.json({ error: "Internal Server Error" }, 500);
 	}
-});
 
-/**
- * Helper function to get the authenticated user ID from context.
- * Should only be called after basicAuth middleware has run.
- */
-export function getAuthenticatedUserId(c: Context): string {
-	const userId = c.get("authenticatedUserId");
-	if (!userId) {
-		throw new Error(
-			"authenticatedUserId not found in context - basicAuth middleware may not have run",
-		);
-	}
-	return userId;
-}
+	c.set("UserScopedDbClient", userClient);
+	c.set("authenticatedUserId", decodedToken.sub);
+	return next();
+});
 
 export default basicAuth;

--- a/apps/backend/src/monitoring/instrumentation.ts
+++ b/apps/backend/src/monitoring/instrumentation.ts
@@ -1,15 +1,13 @@
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
 import { LangfuseSpanProcessor, ShouldExportSpan } from "@langfuse/otel";
-import { config } from "../config";
-import { SentryPropagator, SentrySampler } from "@sentry/opentelemetry";
 import * as Sentry from "@sentry/node";
-import { supabase } from "../supabase";
+import { SentryPropagator, SentrySampler } from "@sentry/opentelemetry";
+import { config } from "../config";
 
 export const sentryClient = Sentry.init({
 	dsn: config.sentryDsn || "",
 	environment: config.nodeEnv || "development",
-	integrations: [Sentry.supabaseIntegration({ supabaseClient: supabase })],
 	tracesSampleRate: 1.0,
 	enabled: ["production", "staging", "test"].includes(config.nodeEnv),
 	skipOpenTelemetrySetup: true,

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -1,16 +1,15 @@
 import { Hono } from "hono";
-import { AdminService } from "../services/admin-service";
+import { PrivilegedDbService } from "../services/db-service/privileged-db-service";
 import { adminAuth } from "../middleware/admin-auth";
 import { captureError } from "../monitoring/capture-error";
 import basicAuth from "../middleware/basic-auth";
-import { adminDatabaseService } from "../supabase";
+import { serviceRoleDbClient } from "../supabase";
 
 const admin = new Hono();
 admin.use(basicAuth);
 admin.use(adminAuth);
 
-// Singleton AdminService using service role key for privileged operations
-const adminService = new AdminService(adminDatabaseService);
+const serviceRoleAdminService = new PrivilegedDbService(serviceRoleDbClient);
 
 // Route: update user profile (first_name, last_name, academic_title, email, personal_title)
 admin.put("/users/:userId/profile", async (c) => {
@@ -42,7 +41,7 @@ admin.put("/users/:userId/profile", async (c) => {
 		}
 
 		// Update profile fields (requires service role for auth.admin.updateUserById)
-		await adminService.updateUserProfile({
+		await serviceRoleAdminService.updateUserProfile({
 			userId,
 			firstName,
 			lastName,
@@ -75,8 +74,7 @@ admin.put("/users/:userId/admin", async (c) => {
 			return c.json({ error: "isAdmin must be a boolean value" }, 400);
 		}
 
-		// Requires service role to write to application_admins table
-		await adminService.updateUserAdminStatus(userId, isAdmin);
+		await serviceRoleAdminService.updateUserAdminStatus(userId, isAdmin);
 		return c.json({ message: "User admin status updated successfully" });
 	} catch (error) {
 		captureError(error);
@@ -101,13 +99,11 @@ admin.delete("/users/:userId", async (c) => {
 		const hardDelete = c.req.query("hard") === "true";
 
 		if (hardDelete) {
-			// Requires service role for auth.admin.deleteUser
-			await adminService.hardDeleteUser(userId);
+			await serviceRoleAdminService.hardDeleteUser(userId);
 			return c.json({ message: "User permanently deleted successfully" });
 		}
 
-		// Requires service role to update user_active_status
-		await adminService.softDeleteUser(userId);
+		await serviceRoleAdminService.softDeleteUser(userId);
 		return c.json({ message: "User soft deleted successfully" });
 	} catch (error) {
 		captureError(error);
@@ -123,8 +119,7 @@ admin.put("/users/:userId/restore", async (c) => {
 			return c.json({ error: "User ID is required" }, 400);
 		}
 
-		// Requires service role to update user_active_status
-		await adminService.restoreUser(userId);
+		await serviceRoleAdminService.restoreUser(userId);
 		return c.json({ message: "User restored successfully" });
 	} catch (error) {
 		captureError(error);
@@ -140,8 +135,7 @@ admin.post("/users/invite", async (c) => {
 			return c.json({ error: "Email is required" }, 400);
 		}
 
-		// Requires service role for auth.admin.inviteUserByEmail
-		await adminService.sendInviteLink(email, firstName, lastName);
+		await serviceRoleAdminService.sendInviteLink(email, firstName, lastName);
 		return c.json({ message: "Invite link sent successfully" });
 	} catch (error) {
 		captureError(error);

--- a/apps/backend/src/routes/documents.ts
+++ b/apps/backend/src/routes/documents.ts
@@ -1,34 +1,30 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
-import { DatabaseService } from "../services/database-service";
+import { UserScopedDbService } from "../services/db-service/user-scoped-db-service";
 import { EmbeddingService } from "../services/embedding-service";
 import { GenerationService } from "../services/generation-service";
 import { config } from "../config";
 import { captureError } from "../monitoring/capture-error";
 import { Document } from "../types/common";
-import { getUserClient } from "../middleware/basic-auth";
-
-import { getAuthenticatedUserId } from "../middleware/basic-auth";
 import { documentProcessSchema } from "../schemas/document-process-schema";
 import { ZodError } from "zod";
 import { ValidationService } from "../services/validation-service";
 
 const documents = new Hono();
-const validationService = new ValidationService();
 
 documents.post("/process", async (c: Context) => {
-	const userClient = getUserClient(c);
-	const dbService = new DatabaseService(userClient);
-	const embeddingService = new EmbeddingService(dbService);
-	const generationService = new GenerationService(dbService);
+	const userClient = c.get("UserScopedDbClient");
+	const userScopedDbService = new UserScopedDbService(userClient);
+	const embeddingService = new EmbeddingService(userScopedDbService);
+	const generationService = new GenerationService(userScopedDbService);
+	const validationService = new ValidationService(userScopedDbService);
 
 	let sourceUrl: string | null = null;
 	let bucket: string | null = null;
 
 	try {
 		// Get authenticated user ID from context (set by basicAuth middleware)
-		const authenticatedUserId = getAuthenticatedUserId(c);
-
+		const authenticatedUserId = c.get("authenticatedUserId");
 		// Parse and validate request body
 		const body = await c.req.json();
 		const parseResult = documentProcessSchema.parse(body);
@@ -55,7 +51,7 @@ documents.post("/process", async (c: Context) => {
 			source_type: inputDocument.source_type,
 			created_at: inputDocument.created_at || new Date().toISOString(),
 		};
-		const extractionResult = await dbService.extractDocument(
+		const extractionResult = await userScopedDbService.extractDocument(
 			documentForExtraction,
 		);
 
@@ -93,7 +89,7 @@ documents.post("/process", async (c: Context) => {
 		]);
 
 		// Step 3: Create complete document record
-		await dbService.logProcessedDocument(
+		await userScopedDbService.logProcessedDocument(
 			documentForProcessing,
 			summaryData,
 			embeddings,
@@ -114,7 +110,7 @@ documents.post("/process", async (c: Context) => {
 		// If processing failed, clean up the storage file
 		if (sourceUrl !== null && bucket !== null) {
 			try {
-				await dbService.deleteFileFromStorage(sourceUrl, bucket);
+				await userScopedDbService.deleteFileFromStorage(sourceUrl, bucket);
 			} catch (cleanupError) {
 				captureError(
 					new Error(

--- a/apps/backend/src/routes/llms.ts
+++ b/apps/backend/src/routes/llms.ts
@@ -6,15 +6,14 @@ import { ModelService } from "../services/model-service";
 import { GenerationService } from "../services/generation-service";
 import { config } from "../config";
 import { captureError } from "../monitoring/capture-error";
-import { getUserClient } from "../middleware/basic-auth";
-import { DatabaseService } from "../services/database-service";
+import { UserScopedDbService } from "../services/db-service/user-scoped-db-service";
 
 const llms = new Hono();
 const modelService = new ModelService();
 llms.post("/just-chatting", async (c: Context) => {
-	const userClient = getUserClient(c);
-	const dbService = new DatabaseService(userClient);
-	const generationService = new GenerationService(dbService);
+	const userClient = c.get("UserScopedDbClient");
+	const userScopedDbService = new UserScopedDbService(userClient);
+	const generationService = new GenerationService(userScopedDbService);
 	try {
 		const body = (await c.req.json()) as ChatMessageBody;
 		const llmIdentifier = config.defaultModelIdentifier;

--- a/apps/backend/src/services/db-service/base-db-service.ts
+++ b/apps/backend/src/services/db-service/base-db-service.ts
@@ -1,6 +1,7 @@
-import { StorageApiError, StorageUnknownError } from "@supabase/storage-js";
 import { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@repo/db-schema";
+
+import { StorageApiError, StorageUnknownError } from "@supabase/storage-js";
 
 import {
 	type Document,
@@ -9,23 +10,18 @@ import {
 	type HybridSearchResult,
 	type KnowledgeBaseDocument,
 	DocumentNotFoundError,
-} from "../types/common";
-import { ragSearchDefaults } from "../constants";
+} from "../../types/common";
+import { ragSearchDefaults } from "../../constants";
 import {
 	DocumentExtractionService,
 	WordDocumentExtractionService,
-} from "./document-extraction-service";
-import { captureError } from "../monitoring/capture-error";
-
+} from "../document-extraction-service";
+import { captureError } from "../../monitoring/capture-error";
 const documentExtraction = new DocumentExtractionService();
 const wordExtractionService = new WordDocumentExtractionService();
 
-export class DatabaseService {
-	private readonly client: SupabaseClient<Database>;
-
-	constructor(client: SupabaseClient<Database>) {
-		this.client = client;
-	}
+export abstract class BaseContentDbService {
+	protected abstract client: SupabaseClient<Database>;
 
 	async logSummarizedDocument(
 		summaryData: {
@@ -140,21 +136,11 @@ export class DatabaseService {
 		throw deletionError;
 	}
 
-	async updateUserColumnValue(
+	abstract updateUserColumnValue(
 		userId: string,
 		columnName: string,
-		amount: number = 1,
-	): Promise<void> {
-		const { error } = await this.client.rpc("change_value_for_user_by", {
-			amount,
-			column_name: columnName,
-			user_id_to_update: userId,
-		});
-
-		if (error) {
-			throw error;
-		}
-	}
+		amount: number,
+	): Promise<void>;
 
 	/**
 	 * Creates a complete document record with all metadata, summary, and embeddings in the database.
@@ -352,33 +338,9 @@ export class DatabaseService {
 		}
 	}
 
-	// get user admin status from application_admins table
-	async getUserAdminStatus(userId: string): Promise<boolean> {
-		const { count, error } = await this.client
-			.from("application_admins")
-			.select("user_id", { count: "exact", head: true })
-			.eq("user_id", userId);
-
-		if (error) {
-			throw error;
-		}
-
-		const isAdmin = count > 0;
+	async getUserAdminStatus(): Promise<boolean> {
+		const { data: isAdmin } = await this.client.rpc("is_application_admin");
 		return isAdmin;
-	}
-
-	async getUserActiveStatus(userId: string) {
-		const { data, error } = await this.client
-			.from("user_active_status")
-			.select("*")
-			.eq("id", userId)
-			.single();
-
-		if (error) {
-			throw error;
-		}
-
-		return data;
 	}
 
 	async getMaintenanceModeStatus(): Promise<{ is_enabled: boolean }> {
@@ -394,7 +356,7 @@ export class DatabaseService {
 	}
 
 	async deleteDocument(documentId: number, userId: string): Promise<void> {
-		const isAdmin = await this.getUserAdminStatus(userId);
+		const isAdmin = await this.getUserAdminStatus();
 
 		let query = this.client
 			.from("documents")
@@ -472,7 +434,7 @@ export class DatabaseService {
 		folderId: number,
 		userId: string,
 	): Promise<boolean> {
-		const { data, error } = await supabase
+		const { data, error } = await this.client
 			.from("document_folders")
 			.select("id")
 			.eq("id", folderId)
@@ -507,9 +469,11 @@ export class DatabaseService {
 		const folder = pathParts.slice(0, -1).join("/");
 		const fileName = pathParts[pathParts.length - 1];
 
-		const { data, error } = await supabase.storage.from(bucket).list(folder, {
-			search: fileName,
-		});
+		const { data, error } = await this.client.storage
+			.from(bucket)
+			.list(folder, {
+				search: fileName,
+			});
 
 		if (error) {
 			console.error(

--- a/apps/backend/src/services/db-service/privileged-db-service.ts
+++ b/apps/backend/src/services/db-service/privileged-db-service.ts
@@ -1,20 +1,19 @@
-import { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "@repo/db-schema";
-
+import type { ServiceRoleDbClient } from "../../supabase";
+import { BaseContentDbService } from "./base-db-service";
 /**
  * AdminService handles operations that require the Supabase service role key.
- * These operations cannot be performed with user JWTs and must use elevated privileges.
  *
  * Operations include:
  * - Auth Admin API calls (updateUserById, deleteUser, inviteUserByEmail)
  * - Writing to privileged tables (application_admins)
  * - Soft/hard user deletion and restoration
  */
-export class AdminService {
-	private readonly adminClient: SupabaseClient<Database>;
+export class PrivilegedDbService extends BaseContentDbService {
+	protected readonly client: ServiceRoleDbClient;
 
-	constructor(adminClient: SupabaseClient<Database>) {
-		this.adminClient = adminClient;
+	constructor(client: ServiceRoleDbClient) {
+		super();
+		this.client = client;
 	}
 
 	/**
@@ -57,11 +56,10 @@ export class AdminService {
 
 		// Update user in auth (requires service role)
 		if (Object.keys(authUpdateData).length > 0) {
-			const { error: authError } =
-				await this.adminClient.auth.admin.updateUserById(
-					userId,
-					authUpdateData,
-				);
+			const { error: authError } = await this.client.auth.admin.updateUserById(
+				userId,
+				authUpdateData,
+			);
 
 			if (authError) {
 				throw authError;
@@ -79,7 +77,7 @@ export class AdminService {
 		);
 
 		if (Object.keys(updateData).length > 0) {
-			const { error: profileError } = await this.adminClient
+			const { error: profileError } = await this.client
 				.from("profiles")
 				.update(updateData)
 				.eq("id", userId);
@@ -95,13 +93,9 @@ export class AdminService {
 	 * Requires service role to write to application_admins table.
 	 */
 	async updateUserAdminStatus(userId: string, isAdmin: boolean): Promise<void> {
-		if (typeof isAdmin !== "boolean") {
-			throw new Error("isAdmin must be a boolean value");
-		}
-
 		if (isAdmin) {
 			// Add user to application_admins table
-			const { error } = await this.adminClient
+			const { error } = await this.client
 				.from("application_admins")
 				.insert({ user_id: userId });
 
@@ -113,7 +107,7 @@ export class AdminService {
 		}
 
 		// Remove user from application_admins table
-		const { error } = await this.adminClient
+		const { error } = await this.client
 			.from("application_admins")
 			.delete()
 			.eq("user_id", userId);
@@ -128,7 +122,7 @@ export class AdminService {
 	 * Requires service role to update user_active_status.
 	 */
 	async softDeleteUser(userId: string): Promise<void> {
-		const { error } = await this.adminClient
+		const { error } = await this.client
 			.from("user_active_status")
 			.update({ deleted_at: new Date().toISOString(), is_active: false })
 			.eq("id", userId);
@@ -143,7 +137,7 @@ export class AdminService {
 	 * Requires service role for auth.admin.deleteUser().
 	 */
 	async hardDeleteUser(userId: string): Promise<void> {
-		const { error } = await this.adminClient.auth.admin.deleteUser(userId);
+		const { error } = await this.client.auth.admin.deleteUser(userId);
 
 		if (error) {
 			throw error;
@@ -155,7 +149,7 @@ export class AdminService {
 	 * Requires service role to update user_active_status.
 	 */
 	async restoreUser(userId: string): Promise<void> {
-		const { error } = await this.adminClient
+		const { error } = await this.client
 			.from("user_active_status")
 			.update({ deleted_at: null, is_active: true })
 			.eq("id", userId);
@@ -183,15 +177,24 @@ export class AdminService {
 			data.last_name = lastName;
 		}
 
-		const { error } = await this.adminClient.auth.admin.inviteUserByEmail(
-			email,
-			{
-				data,
-			},
-		);
+		const { error } = await this.client.auth.admin.inviteUserByEmail(email, {
+			data,
+		});
 
 		if (error) {
 			throw error;
 		}
+	}
+
+	async updateUserColumnValue(
+		_userId: string,
+		_columnName: string,
+		_amount: number = 1,
+	): Promise<void> {
+		// No-op: Referenced by some services but guarded against if there is no user.
+		throw new Error(
+			"updateUserColumnValue should not be called on PrivilegedDbService. " +
+				"Ensure userId is checked before calling this method.",
+		);
 	}
 }

--- a/apps/backend/src/services/db-service/user-scoped-db-service.ts
+++ b/apps/backend/src/services/db-service/user-scoped-db-service.ts
@@ -1,0 +1,26 @@
+import type { UserScopedDbClient } from "../../supabase";
+import { BaseContentDbService } from "./base-db-service";
+
+export class UserScopedDbService extends BaseContentDbService {
+	protected readonly client: UserScopedDbClient;
+
+	constructor(client: UserScopedDbClient) {
+		super();
+		this.client = client;
+	}
+	async updateUserColumnValue(
+		userId: string,
+		columnName: string,
+		amount: number = 1,
+	): Promise<void> {
+		const { error } = await this.client.rpc("change_value_for_user_by", {
+			amount,
+			column_name: columnName,
+			user_id_to_update: userId,
+		});
+
+		if (error) {
+			throw error;
+		}
+	}
+}

--- a/apps/backend/src/services/embedding-service.ts
+++ b/apps/backend/src/services/embedding-service.ts
@@ -10,12 +10,12 @@ import type {
 	JinaEmbeddingResponse,
 } from "../types/common";
 import { countTokens, trimToTokenLimitByWords } from "./token-utils";
-import { DatabaseService } from "./database-service";
+import { BaseContentDbService } from "./db-service/base-db-service";
 import { resilientCall } from "../utils";
 
 export class EmbeddingService {
-	private readonly dbService: DatabaseService;
-	constructor(dbService: DatabaseService) {
+	private readonly dbService: BaseContentDbService;
+	constructor(dbService: BaseContentDbService) {
 		this.dbService = dbService;
 	}
 	async chunkWithJinaSegmenter(

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -21,7 +21,7 @@ import {
 	type KnowledgeBaseDocument,
 	type LLMHandler,
 } from "../types/common";
-import { DatabaseService } from "./database-service";
+import { BaseContentDbService } from "./db-service/base-db-service";
 import { LLM_PARAMETERS } from "../constants";
 import type { ParsedPage } from "../types/common";
 import { baseKnowledgeSearchTool } from "../tools/base-knowledge-search-tool";
@@ -39,10 +39,10 @@ const langfuse = new LangfuseClient();
 const modelService = new ModelService();
 
 export class GenerationService {
-	private readonly dbService: DatabaseService;
+	private readonly dbService: BaseContentDbService;
 	private readonly embeddingService: EmbeddingService;
 
-	constructor(dbService: DatabaseService) {
+	constructor(dbService: BaseContentDbService) {
 		this.dbService = dbService;
 		this.embeddingService = new EmbeddingService(this.dbService);
 	}

--- a/apps/backend/src/services/validation-service.ts
+++ b/apps/backend/src/services/validation-service.ts
@@ -1,10 +1,13 @@
 import { DocumentProcessInput } from "../schemas/document-process-schema";
 import { ValidationResult } from "../types/common";
-import { DatabaseService } from "./database-service";
-
-const dbService = new DatabaseService();
+import { BaseContentDbService } from "./db-service/base-db-service";
 
 export class ValidationService {
+	private readonly dbService: BaseContentDbService;
+	constructor(dbService: BaseContentDbService) {
+		this.dbService = dbService;
+	}
+
 	validatePersonalSourceUrlPath(
 		sourceUrl: string,
 		authenticatedUserId: string,
@@ -72,7 +75,7 @@ export class ValidationService {
 
 		// Folder ownership validation
 		if (inputDocument.folder_id !== null) {
-			const folderBelongsToUser = await dbService.validateFolderOwnership(
+			const folderBelongsToUser = await this.dbService.validateFolderOwnership(
 				inputDocument.folder_id,
 				authenticatedUserId,
 			);
@@ -87,7 +90,7 @@ export class ValidationService {
 		}
 
 		// File existence validation
-		const fileExists = await dbService.validateFileExistsInStorage(
+		const fileExists = await this.dbService.validateFileExistsInStorage(
 			sourceUrl,
 			bucket,
 		);

--- a/apps/backend/src/supabase.ts
+++ b/apps/backend/src/supabase.ts
@@ -2,17 +2,24 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@repo/db-schema";
 import { config } from "./config";
 
-export const adminDatabaseService = createClient<Database>(
+export type UserScopedDbClient = SupabaseClient<Database> & {
+	readonly __brand: "user-scoped";
+};
+export type ServiceRoleDbClient = SupabaseClient<Database> & {
+	readonly __brand: "service-role";
+};
+
+export const serviceRoleDbClient = createClient<Database>(
 	config.supabaseUrl,
 	config.supabaseServiceRoleKey,
 	{
 		auth: { persistSession: false },
 	},
-);
+) as ServiceRoleDbClient;
 
-export function createUserClient(
+export function createUserScopedDbClient(
 	accessToken: string,
-): SupabaseClient<Database> {
+): UserScopedDbClient {
 	return createClient<Database>(config.supabaseUrl, config.supabaseAnonKey, {
 		auth: { persistSession: false },
 		global: {
@@ -20,8 +27,5 @@ export function createUserClient(
 				Authorization: `Bearer ${accessToken}`,
 			},
 		},
-	});
+	}) as UserScopedDbClient;
 }
-
-// Only use this throughout integration tests and scripts but not in any services.
-export const supabase = adminDatabaseService;

--- a/apps/backend/src/tools/base-knowledge-search-tool.ts
+++ b/apps/backend/src/tools/base-knowledge-search-tool.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import type { DatabaseService } from "../services/database-service";
+import { BaseContentDbService } from "../services/db-service/base-db-service";
 import type { EmbeddingService } from "../services/embedding-service";
 import { z } from "zod";
 
@@ -13,7 +13,7 @@ type KnowledgeBaseDocument = {
 };
 
 type BaseKnowledgeSearchToolOptions = {
-	dbService: DatabaseService;
+	dbService: BaseContentDbService;
 	embeddingService: EmbeddingService;
 	userId: string;
 	knowledgeBaseDocuments: KnowledgeBaseDocument[];

--- a/apps/backend/src/tools/rag-search-tool.ts
+++ b/apps/backend/src/tools/rag-search-tool.ts
@@ -1,10 +1,10 @@
 import { tool } from "ai";
-import type { DatabaseService } from "../services/database-service";
+import { BaseContentDbService } from "../services/db-service/base-db-service";
 import type { EmbeddingService } from "../services/embedding-service";
 import { z } from "zod";
 
 type RagSearchToolOptions = {
-	dbService: DatabaseService;
+	dbService: BaseContentDbService;
 	embeddingService: EmbeddingService;
 	userId: string;
 	allowedDocumentIds: number[];

--- a/apps/backend/supabase/local-seed.ts
+++ b/apps/backend/supabase/local-seed.ts
@@ -1,4 +1,4 @@
-import { adminDatabaseService as supabase } from "../src/supabase";
+import { serviceRoleDbClient as supabase } from "../src/supabase";
 
 export async function seedLocalAdmin() {
 	const id = crypto.randomUUID();

--- a/apps/backend/supabase/upload-default-documents.ts
+++ b/apps/backend/supabase/upload-default-documents.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { resolve } from "node:path";
-import { adminDatabaseService as supabase } from "../src/supabase";
-import { DatabaseService } from "../src/services/database-service";
+import { PrivilegedDbService } from "../src/services/db-service/privileged-db-service";
+import { serviceRoleDbClient } from "../src/supabase";
 import { GenerationService } from "../src/services/generation-service";
 import { EmbeddingService } from "../src/services/embedding-service";
 import { config } from "../src/config";
@@ -40,7 +40,7 @@ async function checkExistingDocument(
 	accessGroupId: string,
 ): Promise<boolean> {
 	const sourceUrl = `${accessGroupId}/${fileName}`;
-	const { data, error } = await supabase
+	const { data, error } = await serviceRoleDbClient
 		.from("documents")
 		.select("id, processing_finished_at")
 		.eq("source_url", sourceUrl)
@@ -57,7 +57,7 @@ async function checkExistingDocument(
 }
 
 async function getDefaultAccessGroupId(): Promise<string> {
-	const { data: accessGroup, error } = await supabase
+	const { data: accessGroup, error } = await serviceRoleDbClient
 		.from("access_groups")
 		.select("id")
 		.eq("name", "Alle")
@@ -88,7 +88,7 @@ async function processDocument(
 	const sourceUrl = `${accessGroupId}/${fileName}`;
 	// eslint-disable-next-line no-console
 	console.log(`Uploading ${fileName} to ${bucketName}/${sourceUrl}...`);
-	const { error: uploadError } = await supabase.storage
+	const { error: uploadError } = await serviceRoleDbClient.storage
 		.from(bucketName)
 		.upload(sourceUrl, file, { upsert: true });
 
@@ -100,9 +100,9 @@ async function processDocument(
 	// eslint-disable-next-line no-console
 	console.log(`File uploaded successfully to ${bucketName}/${sourceUrl}`);
 
-	const dbService = new DatabaseService();
-	const generationService = new GenerationService();
-	const embeddingService = new EmbeddingService();
+	const dbService = new PrivilegedDbService(serviceRoleDbClient);
+	const generationService = new GenerationService(dbService);
+	const embeddingService = new EmbeddingService(dbService);
 
 	const document: Document = {
 		source_url: sourceUrl,


### PR DESCRIPTION
This is still very much wip. Only leaving this here as a PR for anyone who wants to pick up this ticket when I'm on holidays. 

The core idea was:
1. Create a userClient with just the users JWT.
2. Inject this in process, just-chatting and the different service classes
3. Keep explicit adminDatabaseService and AdminService for the things that really need the service role

I'm also very happy if someone has a better / cleaner approach. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211963338530650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Backend refactor introducing clear separation between privileged and user-scoped database clients, moving services to per-request dependency injection for safer, isolated operations.
  * Admin routes now use explicit privileged service instances for protected actions; authentication middleware uses per-request scoped clients and RPC checks.

* **Tests**
  * Integration and unit tests updated to reflect the new client/service wiring.

* **Chores**
  * Platform client exports and tooling updated to support the new scoped clients.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->