### PR TITLE
Fix: remove matomo cookies

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -15,6 +15,7 @@
 		<script>
 			var _paq = (window._paq = window._paq || []);
 			/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+			_paq.push(['disableCookies']);
 			_paq.push(["trackPageView"]);
 			_paq.push(["enableLinkTracking"]);
 			(function () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics tracking configuration to disable cookies during page view tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->