### PR TITLE
feat: add e2e test for toggling base knowledge

### DIFF
--- a/apps/frontend/tests/e2e/chat.spec.ts
+++ b/apps/frontend/tests/e2e/chat.spec.ts
@@ -587,5 +587,16 @@ test.describe("Chat", () => {
 
 		// Verify the context pill appears again
 		await expect(contextPill).toBeVisible();
+
+		// Deselect base knowledge through the dropdown
+		await chatOptionsButton.click();
+		await expect(page.getByText("Wissen erweitern")).toBeVisible();
+
+		// Click on "Verwaltungswissen" again to deselect it
+		await baseKnowledgeOption.click();
+		await expect(page.getByText("Wissen erweitern")).not.toBeVisible();
+
+		// Verify the context pill disappears after deselecting through dropdown
+		await expect(contextPill).not.toBeVisible();
 	});
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests covering the chat "base knowledge" toggle: verifies opening the options menu, enabling/disabling base knowledge, the presence and disappearance of the context pill, and that the feature can be re-enabled reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->