### PR TITLE
fix: do not reactive base-knowledge on first chat

### DIFF
--- a/apps/frontend/src/store/current-chat-id-store.ts
+++ b/apps/frontend/src/store/current-chat-id-store.ts
@@ -56,9 +56,8 @@ export const useCurrentChatIdStore = create<CurrentChatIdStore>()(
 			const { abortStreaming } = useChatStreamingStore.getState();
 			abortStreaming();
 
-			useChatsStore.getState().resetToDefaultChatOptions();
-
 			if (!isFirstChat) {
+				useChatsStore.getState().resetToDefaultChatOptions();
 				resetPreviousChatState();
 			}
 			if (chatId !== null) {

--- a/apps/frontend/tests/e2e/chat.spec.ts
+++ b/apps/frontend/tests/e2e/chat.spec.ts
@@ -639,4 +639,60 @@ test.describe("Chat", () => {
 		// Verify the context pill disappears after deselecting through dropdown
 		await expect(contextPill).not.toBeVisible();
 	});
+
+	testDesktopOnly(
+		"Disabling base knowledge should re-activate it when swapping between two chats",
+		async ({ page }) => {
+			await page.goto("/");
+
+			const chatInput = page.getByPlaceholder("Stellen Sie eine Frage");
+			await chatInput.fill("hallo");
+
+			const sendButton = page.getByRole("button", {
+				name: "Ein weißer Pfeil nach rechts",
+			});
+			await sendButton.click();
+
+			await page.waitForLoadState("networkidle");
+
+			const baseKnowledgePill = page.getByRole("button", {
+				name: /Verwaltungswissen entfernen/,
+			});
+			await baseKnowledgePill.click();
+
+			await expect(baseKnowledgePill).not.toBeVisible();
+
+			const startNewChatButton = page.getByRole("button", {
+				name: "Neuen Chat erstellen",
+			});
+			await startNewChatButton.click();
+
+			await expect(baseKnowledgePill).toBeVisible();
+		},
+	);
+
+	testDesktopOnly(
+		"Disabling base knowledge should not re-activate it when starting the first chat",
+		async ({ page }) => {
+			await page.goto("/");
+
+			// Disable the base knowledge feature
+			const baseKnowledgePill = page.getByRole("button", {
+				name: /Verwaltungswissen entfernen/,
+			});
+			await baseKnowledgePill.click();
+
+			// Start a new chat by asking a question
+			await page.getByPlaceholder("Stellen Sie eine Frage").fill("hallo");
+
+			// Click the send button
+			await page
+				.getByRole("button", { name: "Ein weißer Pfeil nach rechts" })
+				.click();
+
+			await page.waitForLoadState("networkidle");
+
+			await expect(baseKnowledgePill).not.toBeVisible();
+		},
+	);
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed base knowledge feature toggle reactivation behavior when users switch between multiple chats, ensuring the feature state properly resets on new chat creation and transitions

* **Tests**
  * Added comprehensive desktop end-to-end tests for the base knowledge feature to verify correct behavior when transitioning between existing chats and starting the first chat session

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->