### PR TITLE
fix: base knowledge document upload

### DIFF
--- a/apps/backend/src/integration/base-knowledge.integration.test.ts
+++ b/apps/backend/src/integration/base-knowledge.integration.test.ts
@@ -440,6 +440,156 @@ describe("Base Knowledge Integration Tests", () => {
 		}
 	});
 
+	describe("RLS Policy Tests for Base Knowledge Inserts", () => {
+		it("should allow admin to insert base knowledge documents through user-scoped client", async () => {
+			const { error: adminError } = await supabaseAdminClient
+				.from("application_admins")
+				.insert({ user_id: testUserId });
+
+			expect(adminError).toBeNull();
+
+			let insertedDocId: number | null = null;
+
+			try {
+				const { data: doc, error: docError } = await supabaseAnonClient
+					.from("documents")
+					.insert({
+						file_name: "rls-test-admin-insert.pdf",
+						source_type: "public_document",
+						source_url: "rls-test-admin-insert.pdf",
+						file_checksum: "rls-admin-test-checksum",
+						file_size: SMALL_FILE_SIZE,
+						num_pages: 1,
+						folder_id: null,
+						owned_by_user_id: null, // Base knowledge = null
+						access_group_id: accessGroupId,
+						processing_finished_at: new Date().toISOString(),
+					})
+					.select("id")
+					.single();
+
+				expect(docError).toBeNull();
+				expect(doc).not.toBeNull();
+				insertedDocId = doc?.id ?? null;
+
+				if (insertedDocId === null) {
+					throw new Error("Document insert failed - no ID returned");
+				}
+
+				const { error: summaryError } = await supabaseAnonClient
+					.from("document_summaries")
+					.insert({
+						document_id: insertedDocId,
+						summary: "RLS test summary for admin insert.",
+						short_summary: "RLS test.",
+						owned_by_user_id: null,
+						folder_id: null,
+						access_group_id: accessGroupId,
+						tags: ["rls-test"],
+					});
+
+				expect(summaryError).toBeNull();
+
+				const testEmbedding = createDeterministicEmbedding();
+				const { error: chunkError } = await supabaseAnonClient
+					.from("document_chunks")
+					.insert({
+						document_id: insertedDocId,
+						content: "RLS test chunk content for admin insert.",
+						page: 1,
+						chunk_index: 0,
+						owned_by_user_id: null,
+						folder_id: null,
+						access_group_id: accessGroupId,
+						chunk_jina_embedding: JSON.stringify(testEmbedding),
+					});
+
+				expect(chunkError).toBeNull();
+			} finally {
+				// Clean up: delete inserted document (cascades to summary/chunks)
+				if (insertedDocId) {
+					await supabaseAdminClient
+						.from("documents")
+						.delete()
+						.eq("id", insertedDocId);
+				}
+
+				await supabaseAdminClient
+					.from("application_admins")
+					.delete()
+					.eq("user_id", testUserId);
+			}
+		});
+
+		it("should prevent non-admin from inserting base knowledge documents", async () => {
+			// Ensure user is NOT an admin
+			const { data: adminCheck } = await supabaseAdminClient
+				.from("application_admins")
+				.select("user_id")
+				.eq("user_id", testUserId)
+				.maybeSingle();
+
+			expect(adminCheck).toBeNull();
+
+			// Try to insert document with owned_by_user_id: null as non-admin
+			// This should fail with RLS violation
+			const { data: doc, error: docError } = await supabaseAnonClient
+				.from("documents")
+				.insert({
+					file_name: "rls-test-non-admin-insert.pdf",
+					source_type: "public_document",
+					source_url: "rls-test-non-admin-insert.pdf",
+					file_checksum: "rls-non-admin-test-checksum",
+					file_size: SMALL_FILE_SIZE,
+					num_pages: 1,
+					folder_id: null,
+					owned_by_user_id: null, // Base knowledge = null, should be blocked
+					access_group_id: accessGroupId,
+					processing_finished_at: new Date().toISOString(),
+				})
+				.select("id")
+				.single();
+
+			expect(docError).not.toBeNull();
+			expect(docError?.code).toBe("42501"); // RLS violation
+			expect(doc).toBeNull();
+
+			// Also verify document_summaries INSERT is blocked for non-admin
+			const { error: summaryError } = await supabaseAnonClient
+				.from("document_summaries")
+				.insert({
+					document_id: documentId, // Use existing document
+					summary: "This should fail.",
+					short_summary: "Fail.",
+					owned_by_user_id: null, // Should be blocked
+					folder_id: null,
+					access_group_id: accessGroupId,
+					tags: ["fail"],
+				});
+
+			expect(summaryError).not.toBeNull();
+			expect(summaryError?.code).toBe("42501"); // RLS violation
+
+			// Also verify document_chunks INSERT is blocked for non-admin
+			const testEmbedding = createDeterministicEmbedding();
+			const { error: chunkError } = await supabaseAnonClient
+				.from("document_chunks")
+				.insert({
+					document_id: documentId, // Use existing document
+					content: "This should fail.",
+					page: 1,
+					chunk_index: 99,
+					owned_by_user_id: null, // Should be blocked
+					folder_id: null,
+					access_group_id: accessGroupId,
+					chunk_jina_embedding: JSON.stringify(testEmbedding),
+				});
+
+			expect(chunkError).not.toBeNull();
+			expect(chunkError?.code).toBe("42501"); // RLS violation
+		});
+	});
+
 	it("should prevent non-admin user from deleting public base knowledge documents", async () => {
 		// Create a test public document
 		const forbiddenTestFileName = "test-forbidden-deletion-doc.pdf";

--- a/apps/backend/supabase/migrations/20260119162507_allow_admins_insert_base_knowledge_docs.sql
+++ b/apps/backend/supabase/migrations/20260119162507_allow_admins_insert_base_knowledge_docs.sql
@@ -1,0 +1,66 @@
+DROP POLICY IF EXISTS "Allow authenticated users to insert documents" ON public.documents;
+
+CREATE POLICY "Allow authenticated users to insert documents" ON public.documents FOR INSERT TO authenticated
+WITH
+    CHECK (
+        (
+            owned_by_user_id = (
+                SELECT
+                    auth.uid ()
+            )
+        )
+        OR (
+            public.is_application_admin ()
+            AND owned_by_user_id IS NULL
+        )
+    );
+
+DROP POLICY IF EXISTS "Allow authenticated users to access own or public document_summ" ON public.document_summaries;
+
+CREATE POLICY "Allow authenticated users to access own or public document_summ" ON public.document_summaries TO authenticated USING (
+    (owned_by_user_id IS NULL)
+    OR (
+        owned_by_user_id = (
+            SELECT
+                auth.uid ()
+        )
+    )
+)
+WITH
+    CHECK (
+        (
+            owned_by_user_id = (
+                SELECT
+                    auth.uid ()
+            )
+        )
+        OR (
+            public.is_application_admin ()
+            AND owned_by_user_id IS NULL
+        )
+    );
+
+DROP POLICY IF EXISTS "Allow authenticated users to access own or public document_chun" ON public.document_chunks;
+
+CREATE POLICY "Allow authenticated users to access own or public document_chun" ON public.document_chunks TO authenticated USING (
+    (owned_by_user_id IS NULL)
+    OR (
+        owned_by_user_id = (
+            SELECT
+                auth.uid ()
+        )
+    )
+)
+WITH
+    CHECK (
+        (
+            owned_by_user_id = (
+                SELECT
+                    auth.uid ()
+            )
+        )
+        OR (
+            public.is_application_admin ()
+            AND owned_by_user_id IS NULL
+        )
+    );

--- a/libs/db-schema/index.ts
+++ b/libs/db-schema/index.ts
@@ -198,7 +198,7 @@ export type Database = {
 					content: string;
 					document_id: number | null;
 					folder_id: number | null;
-					full_text_search: unknown;
+					full_text_search: unknown | null;
 					id: number;
 					owned_by_user_id: string | null;
 					page: number;
@@ -210,7 +210,7 @@ export type Database = {
 					content: string;
 					document_id?: number | null;
 					folder_id?: number | null;
-					full_text_search?: unknown;
+					full_text_search?: unknown | null;
 					id?: number;
 					owned_by_user_id?: string | null;
 					page: number;
@@ -222,7 +222,7 @@ export type Database = {
 					content?: string;
 					document_id?: number | null;
 					folder_id?: number | null;
-					full_text_search?: unknown;
+					full_text_search?: unknown | null;
 					id?: number;
 					owned_by_user_id?: string | null;
 					page?: number;
@@ -515,9 +515,12 @@ export type Database = {
 				Args: { document_id: number };
 				Returns: undefined;
 			};
-			delete_user: { Args: never; Returns: undefined };
+			delete_user: {
+				Args: Record<PropertyKey, never>;
+				Returns: undefined;
+			};
 			find_unprocessed_documents: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: {
 					created_at: string;
 					file_checksum: string;
@@ -532,9 +535,12 @@ export type Database = {
 					source_url: string;
 				}[];
 			};
-			get_account_activation_timestamp: { Args: never; Returns: string };
+			get_account_activation_timestamp: {
+				Args: Record<PropertyKey, never>;
+				Returns: string;
+			};
 			get_allowed_email_domains: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: {
 					domain: string;
 					id: number;
@@ -563,9 +569,12 @@ export type Database = {
 					source_url: string;
 				}[];
 			};
-			get_maintenance_mode_status: { Args: never; Returns: boolean };
+			get_maintenance_mode_status: {
+				Args: Record<PropertyKey, never>;
+				Returns: boolean;
+			};
 			get_users: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: {
 					academic_title: string;
 					deleted_at: string;
@@ -610,9 +619,18 @@ export type Database = {
 					source_url: string;
 				}[];
 			};
-			is_application_admin: { Args: never; Returns: boolean };
-			is_current_user_active: { Args: never; Returns: boolean };
-			log_account_activation: { Args: never; Returns: undefined };
+			is_application_admin: {
+				Args: Record<PropertyKey, never>;
+				Returns: boolean;
+			};
+			is_current_user_active: {
+				Args: Record<PropertyKey, never>;
+				Returns: boolean;
+			};
+			log_account_activation: {
+				Args: Record<PropertyKey, never>;
+				Returns: undefined;
+			};
 			match_jina_document_chunks: {
 				Args: {
 					allowed_document_ids: number[];
@@ -673,11 +691,11 @@ export type Database = {
 				}[];
 			};
 			regenerate_embedding_indices_for_chunks: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: undefined;
 			};
 			regenerate_embedding_indices_for_summaries: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: undefined;
 			};
 			verify_own_password: {


### PR DESCRIPTION
Prreviously RLS policies that ensured that `owned_by_user_id ===   auth.uid ()` for inserts of documents even though owned_by_user_id for base knowledge documents are NULL. These RLS policies were skipped by using the ServiceRoleKey for base knowledge documents in the backend. Since separating the ServiceRoleKey and ClientKey, uploading base knowledge documents failed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can now insert base knowledge documents, summaries, and document chunks.

* **Security**
  * Enhanced role-based access controls prevent non-admin users from inserting base knowledge documents and associated content.

* **Infrastructure**
  * Database schema updates for improved data type flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->