### PR TITLE
fix: add sudo to auth restart command in migrations workflow

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Restart the auth service to load latest email templates 🔄
         run: |
           ssh -p $SSH_PORT -o StrictHostKeyChecking=yes $SSH_USER@$SSH_HOST \
-            'cd /opt/supabase-baergpt && sudo -n /usr/bin/docker compose up -d --no-deps --force-recreate auth'
+            'sudo -n $HOME/bin/docker-restart-auth'
 
       - name: Close SSH tunnel 🔒
         if: always()

--- a/apps/backend/supabase/selfhosting/setup-migrations-user.sh
+++ b/apps/backend/supabase/selfhosting/setup-migrations-user.sh
@@ -11,9 +11,12 @@ echo "Setting up restricted migrations user..."
 # 1. Create user
 useradd -r -m -s /bin/bash "$USER" 2>/dev/null || echo "User exists"
 
-# 2. Create wrapper script for docker inspect (restricted to IP only)
+# 2. Create wrapper scripts
+# a) for docker inspect (restricted to IP only)
 USER_HOME=$(getent passwd "$USER" | cut -d: -f6)
 mkdir -p "$USER_HOME/bin"
+chown root:root "$USER_HOME/bin"
+chmod 755 "$USER_HOME/bin"
 tee "$USER_HOME/bin/docker-inspect-db-ip" <<'EOF' >/dev/null
 #!/bin/bash
 # Wrapper script to safely expose only the database IP address
@@ -22,10 +25,19 @@ EOF
 chmod 755 "$USER_HOME/bin/docker-inspect-db-ip"
 chown root:root "$USER_HOME/bin/docker-inspect-db-ip"
 
+# b) for auth restart (hardcoded project directory)
+tee "$USER_HOME/bin/docker-restart-auth" <<'EOF' >/dev/null
+#!/bin/bash
+# Wrapper script to safely restart auth service with hardcoded project directory
+exec /usr/bin/docker compose -f /opt/supabase-baergpt/docker-compose.yml up -d --no-deps --force-recreate auth
+EOF
+chmod 755 "$USER_HOME/bin/docker-restart-auth"
+chown root:root "$USER_HOME/bin/docker-restart-auth"
+
 # Allow only specific commands needed for migrations workflow
 tee /etc/sudoers.d/migrations <<EOF >/dev/null
 $USER ALL=(root) NOPASSWD: $USER_HOME/bin/docker-inspect-db-ip
-$USER ALL=(root) NOPASSWD: /usr/bin/docker compose up -d --no-deps --force-recreate auth
+$USER ALL=(root) NOPASSWD: $USER_HOME/bin/docker-restart-auth
 EOF
 chmod 440 /etc/sudoers.d/migrations
 


### PR DESCRIPTION
The migrations user cannot read /opt/supabase-baergpt/.env without elevated permissions, causing docker compose to fail. The root cause here is that in our ansible scripts we created .env with restricted permissions: 

`apps/backend/supabase/selfhosting/ansible/roles/supabase/tasks/main.yml`


````
- name: Upload resolved .env
  ansible.builtin.copy:
    src: "{{ playbook_dir }}/../staging/.env"
    dest: "{{ supabase_dir }}/.env"
    mode: "0640" # owner read/write, group read, others nothing, ansible=root
````

Running it as root is fine in this case. Docker compose exits relatively quickly and docker daemon is root anyways. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflow updated to use a controlled restart mechanism for the authentication service.
  * Privilege configuration expanded to allow dedicated maintenance utilities to run without interruptions, improving reliability during deployments.
  * No changes to public APIs or end-user functionality; operational behavior is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213084005350004