### PR TITLE
feat: add clickjacking headers to vercel config

### DIFF
--- a/apps/admin-panel/vercel.json
+++ b/apps/admin-panel/vercel.json
@@ -1,3 +1,12 @@
 {
-	"rewrites": [{ "source": "/(.*)", "destination": "/" }]
+	"rewrites": [{ "source": "/(.*)", "destination": "/" }],
+	"headers": [
+		{
+			"source": "/(.*)",
+			"headers": [
+				{ "key": "X-Frame-Options", "value": "DENY" },
+				{ "key": "Content-Security-Policy", "value": "frame-ancestors 'none'" }
+			]
+		}
+	]
 }

--- a/apps/frontend/vercel.json
+++ b/apps/frontend/vercel.json
@@ -1,3 +1,12 @@
 {
-	"rewrites": [{ "source": "/(.*)", "destination": "/" }]
+	"rewrites": [{ "source": "/(.*)", "destination": "/" }],
+	"headers": [
+		{
+			"source": "/(.*)",
+			"headers": [
+				{ "key": "X-Frame-Options", "value": "DENY" },
+				{ "key": "Content-Security-Policy", "value": "frame-ancestors 'none'" }
+			]
+		}
+	]
 }

--- a/apps/maintenance-mode/vercel.json
+++ b/apps/maintenance-mode/vercel.json
@@ -1,3 +1,12 @@
 {
-	"rewrites": [{ "source": "/(.*)", "destination": "/" }]
+	"rewrites": [{ "source": "/(.*)", "destination": "/" }],
+	"headers": [
+		{
+			"source": "/(.*)",
+			"headers": [
+				{ "key": "X-Frame-Options", "value": "DENY" },
+				{ "key": "Content-Security-Policy", "value": "frame-ancestors 'none'" }
+			]
+		}
+	]
 }


### PR DESCRIPTION
I just checked and saw that we Vercel does not set these automatically. Relevant Asana Ticket: https://app.asana.com/1/1201970074282735/project/1208836734369129/task/1211963338530655?focus=true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved clickjacking protection by adding HTTP headers to all routes in admin-panel, frontend, and maintenance-mode, reinforcing site-wide security without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->