### PR TITLE
feat: remove web search prompt and move prompts to Langfuse

### DIFF
--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -446,131 +446,61 @@ export class GenerationService {
 											snippet: match.snippet,
 										}),
 									);
-									let citationPromptClient: ChatPromptClient;
 									try {
-										citationPromptClient = await langfuse.prompt.get(
-											"document-citation-extraction",
-											{
-												type: "chat",
-												label:
-													config.nodeEnv === "test"
-														? "development"
-														: config.nodeEnv,
-											},
+										const citationPromptClient = await resilientCall(
+											() =>
+												langfuse.prompt.get("document-citation-extraction", {
+													type: "chat",
+													label:
+														config.nodeEnv === "test"
+															? "development"
+															: config.nodeEnv,
+												}),
+											{ queueType: "llm" },
 										);
-									} catch (error) {
-										captureError(error);
-										throw error;
-									}
-									const compiledDocumentCitationExtractionPrompts =
-										citationPromptClient.compile({
-											generatedAnswer: text,
-											availableSources: availableSources
-												.map((s) => `[ID: ${s.id}]\n Snippet: ${s.snippet}`)
-												.join("\n\n"),
-										}) as ModelMessage[];
+										const compiledDocumentCitationExtractionPrompts =
+											citationPromptClient.compile({
+												generatedAnswer: text,
+												availableSources: availableSources
+													.map((s) => `[ID: ${s.id}]\n Snippet: ${s.snippet}`)
+													.join("\n\n"),
+											}) as ModelMessage[];
 
-									const { output: citationObject, usage: generateObjectUsage } =
-										await generateText({
-											model: llmHandler.languageModel,
-											messages: compiledDocumentCitationExtractionPrompts,
-											temperature: LLM_PARAMETERS.temperature,
-											output: Output.object({
-												schema: citationAnswerSchema,
-											}),
-											experimental_telemetry: {
-												isEnabled:
-													config.nodeEnv !== "test" &&
-													config.nodeEnv !== "production", // Disable telemetry in CI and production
-												functionId: "citation-extraction",
-												metadata: {
-													sessionId: sessionId ? sessionId : "unknown",
-												},
-											},
+										const {
+											output: citationObject,
+											usage: generateObjectUsage,
+										} = await resilientCall(
+											() =>
+												generateText({
+													model: llmHandler.languageModel,
+													messages: compiledDocumentCitationExtractionPrompts,
+													temperature: LLM_PARAMETERS.temperature,
+													output: Output.object({
+														schema: citationAnswerSchema,
+													}),
+													experimental_telemetry: {
+														isEnabled:
+															config.nodeEnv !== "test" &&
+															config.nodeEnv !== "production", // Disable telemetry in CI and production
+														functionId: "citation-extraction",
+														metadata: {
+															sessionId: sessionId ? sessionId : "unknown",
+														},
+													},
+												}),
+											{ queueType: "llm" },
+										);
+
+										writer.write({
+											type: "data-citations",
+											data: citationObject.citations,
 										});
 
-									writer.write({
-										type: "data-citations",
-										data: citationObject.citations,
-									});
-
-									try {
-										await this.dbService.updateUserColumnValue(
-											userId,
-											"num_inference_tokens",
-											generateObjectUsage.totalTokens,
-										);
-										await this.dbService.updateUserColumnValue(
-											userId,
-											"num_inferences",
-											1,
-										);
-									} catch (error) {
-										captureError(error);
-									}
-								}
-								if (allWebSources.length > 0) {
-									let webCitationPromptClient: ChatPromptClient;
-									try {
-										webCitationPromptClient = await langfuse.prompt.get(
-											"web-citation-extraction",
-											{
-												label:
-													config.nodeEnv === "test"
-														? "development"
-														: config.nodeEnv,
-												type: "chat",
-											},
-										);
-									} catch (error) {
-										captureError(error);
-										throw error;
-									}
-									const compiledWebCitationExtractionPrompts =
-										webCitationPromptClient.compile({
-											generatedAnswer: text,
-											availableSources: allWebSources
-												.map(
-													(s) =>
-														`[URL: ${s.url}]\n Snippet: ${s.snippet}\n Titel: ${s.title}`,
-												)
-												.join("\n\n"),
-										}) as ModelMessage[];
-
-									const { output: webObject, usage: webCitationUsage } =
-										await generateText({
-											model: llmHandler.languageModel,
-											messages: compiledWebCitationExtractionPrompts,
-											temperature: LLM_PARAMETERS.temperature,
-											output: Output.object({
-												schema: webCitationAnswerSchema,
-											}),
-											experimental_telemetry: {
-												isEnabled:
-													config.nodeEnv !== "test" &&
-													config.nodeEnv !== "production",
-												functionId: "web-citation-extraction",
-												metadata: {
-													sessionId: sessionId ? sessionId : "unknown",
-												},
-											},
-										});
-
-									const citedSources = allWebSources.filter((s) =>
-										webObject.citations.some((c) => c.url === s.url),
-									);
-
-									writer.write({
-										type: "data-web-citations",
-										data: citedSources,
-									});
-
-									if (userId) {
 										try {
 											await this.dbService.updateUserColumnValue(
 												userId,
 												"num_inference_tokens",
-												webCitationUsage.totalTokens,
+												generateObjectUsage.totalTokens,
 											);
 											await this.dbService.updateUserColumnValue(
 												userId,
@@ -580,6 +510,84 @@ export class GenerationService {
 										} catch (error) {
 											captureError(error);
 										}
+									} catch (error) {
+										captureError(error);
+									}
+								}
+								if (allWebSources.length > 0) {
+									try {
+										const webCitationPromptClient = await resilientCall(
+											() =>
+												langfuse.prompt.get("web-citation-extraction", {
+													label:
+														config.nodeEnv === "test"
+															? "development"
+															: config.nodeEnv,
+													type: "chat",
+												}),
+											{ queueType: "llm" },
+										);
+										const compiledWebCitationExtractionPrompts =
+											webCitationPromptClient.compile({
+												generatedAnswer: text,
+												availableSources: allWebSources
+													.map(
+														(s) =>
+															`[URL: ${s.url}]\n Snippet: ${s.snippet}\n Titel: ${s.title}`,
+													)
+													.join("\n\n"),
+											}) as ModelMessage[];
+
+										const { output: webObject, usage: webCitationUsage } =
+											await resilientCall(
+												() =>
+													generateText({
+														model: llmHandler.languageModel,
+														messages: compiledWebCitationExtractionPrompts,
+														temperature: LLM_PARAMETERS.temperature,
+														output: Output.object({
+															schema: webCitationAnswerSchema,
+														}),
+														experimental_telemetry: {
+															isEnabled:
+																config.nodeEnv !== "test" &&
+																config.nodeEnv !== "production",
+															functionId: "web-citation-extraction",
+															metadata: {
+																sessionId: sessionId ? sessionId : "unknown",
+															},
+														},
+													}),
+												{ queueType: "llm" },
+											);
+
+										const citedSources = allWebSources.filter((s) =>
+											webObject.citations.some((c) => c.url === s.url),
+										);
+
+										writer.write({
+											type: "data-web-citations",
+											data: citedSources,
+										});
+
+										if (userId) {
+											try {
+												await this.dbService.updateUserColumnValue(
+													userId,
+													"num_inference_tokens",
+													webCitationUsage.totalTokens,
+												);
+												await this.dbService.updateUserColumnValue(
+													userId,
+													"num_inferences",
+													1,
+												);
+											} catch (error) {
+												captureError(error);
+											}
+										}
+									} catch (error) {
+										captureError(error);
 									}
 								}
 

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -432,6 +432,7 @@ export class GenerationService {
 										"document-citation-extraction",
 										{
 											type: "chat",
+											label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
 										},
 									);
 
@@ -486,6 +487,7 @@ export class GenerationService {
 									const webCitationPromptClient = await langfuse.prompt.get(
 										"web-citation-extraction",
 										{
+											label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
 											type: "chat",
 										},
 									);

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -432,7 +432,10 @@ export class GenerationService {
 										"document-citation-extraction",
 										{
 											type: "chat",
-											label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
+											label:
+												config.nodeEnv === "test"
+													? "development"
+													: config.nodeEnv,
 										},
 									);
 
@@ -487,7 +490,10 @@ export class GenerationService {
 									const webCitationPromptClient = await langfuse.prompt.get(
 										"web-citation-extraction",
 										{
-											label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
+											label:
+												config.nodeEnv === "test"
+													? "development"
+													: config.nodeEnv,
 											type: "chat",
 										},
 									);

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -428,19 +428,25 @@ export class GenerationService {
 										}),
 									);
 
+									const citationPromptClient = await langfuse.prompt.get(
+										"document-citation-extraction",
+										{
+											type: "chat",
+										},
+									);
+
+									const compiledDocumentCitationExtractionPrompts =
+										citationPromptClient.compile({
+											generatedAnswer: text,
+											availableSources: availableSources
+												.map((s) => `[ID: ${s.id}]\n Snippet: ${s.snippet}`)
+												.join("\n\n"),
+										}) as ModelMessage[];
+
 									const { output: citationObject, usage: generateObjectUsage } =
 										await generateText({
 											model: llmHandler.languageModel,
-											system: `Du bist ein Assistent, der Quellenangaben extrahiert. Analysiere die gegebene Antwort und identifiziere, welche der verfügbaren Quellen tatsächlich verwendet wurden, um diese Antwort zu generieren. Gib NUR die IDs der Quellen zurück, deren Inhalt direkt in der Antwort verwendet oder paraphrasiert wurde.`,
-											prompt: `Generierte Antwort:
-"""
-${text}
-"""
-
-Verfügbare Quellen:
-${availableSources.map((s: { id: number; snippet: string }) => `[ID: ${s.id}]\n Snippet: ${s.snippet}`).join("\n\n")}
-
-Analysiere die Antwort und identifiziere, welche Quellen-IDs für die Antwort verwendet wurden. Gib NUR diese IDs als Array zurück.`,
+											messages: compiledDocumentCitationExtractionPrompts,
 											temperature: LLM_PARAMETERS.temperature,
 											output: Output.object({
 												schema: citationAnswerSchema,
@@ -477,19 +483,28 @@ Analysiere die Antwort und identifiziere, welche Quellen-IDs für die Antwort ve
 									}
 								}
 								if (allWebSources.length > 0) {
+									const webCitationPromptClient = await langfuse.prompt.get(
+										"web-citation-extraction",
+										{
+											type: "chat",
+										},
+									);
+
+									const compiledWebCitationExtractionPrompts =
+										webCitationPromptClient.compile({
+											generatedAnswer: text,
+											availableSources: allWebSources
+												.map(
+													(s) =>
+														`[URL: ${s.url}]\n Snippet: ${s.snippet}\n Titel: ${s.title}`,
+												)
+												.join("\n\n"),
+										}) as ModelMessage[];
+
 									const { output: webObject, usage: webCitationUsage } =
 										await generateText({
 											model: llmHandler.languageModel,
-											system: `Du bist ein Assistent, der Quellenangaben extrahiert. Analysiere die gegebene Antwort und identifiziere, welche der verfügbaren Webquellen tatsächlich verwendet wurden, um diese Antwort zu generieren. Gib NUR die Quellen zurück, deren Inhalt direkt in der Antwort verwendet oder paraphrasiert wurde.`,
-											prompt: `Generierte Antwort:
-"""
-${text}
-"""
-
-Verfügbare Webquellen:
-${allWebSources.map((s) => `[URL: ${s.url}]\n Snippet: ${s.snippet}\n Titel: ${s.title}`).join("\n\n")}
-
-Analysiere die Antwort und identifiziere, welche Webquellen für die Antwort verwendet wurden. Gib NUR diese Webquellen im Feld "citations" als Array von Objekten mit "url", "title" und "snippet" zurück.`,
+											messages: compiledWebCitationExtractionPrompts,
 											temperature: LLM_PARAMETERS.temperature,
 											output: Output.object({
 												schema: webCitationAnswerSchema,
@@ -764,7 +779,10 @@ Analysiere die Antwort und identifiziere, welche Webquellen für die Antwort ver
 			optionsCopy.activeTools.push("webSearchTool");
 		}
 
-		if (!config.featureFlagMcpParlaAllowed) {
+		if (
+			!config.featureFlagMcpParlaAllowed &&
+			!config.featureFlagWebSearchAllowed
+		) {
 			return this.getRelevantToolsV1(optionsCopy);
 		}
 

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -137,18 +137,31 @@ export class GenerationService {
 				: docInput.map((page) => page.content).join("\n");
 
 		if (oneSentenceSummary) {
-			summaryPromptClient = await langfuse.prompt.get("one-sentence-summary", {
-				label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
-				type: "chat",
-			});
+			try {
+				summaryPromptClient = await langfuse.prompt.get(
+					"one-sentence-summary",
+					{
+						label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
+						type: "chat",
+					},
+				);
+			} catch (error) {
+				captureError(error);
+				throw error;
+			}
 			compiledSummaryPrompt = summaryPromptClient.compile({
 				docContent: docContent,
 			}) as ModelMessage[];
 		} else {
-			summaryPromptClient = await langfuse.prompt.get("summary", {
-				label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
-				type: "chat",
-			});
+			try {
+				summaryPromptClient = await langfuse.prompt.get("summary", {
+					label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
+					type: "chat",
+				});
+			} catch (error) {
+				captureError(error);
+				throw error;
+			}
 			compiledSummaryPrompt = summaryPromptClient.compile({
 				docContent: docContent,
 			}) as ModelMessage[];
@@ -176,10 +189,16 @@ export class GenerationService {
 				? docInput
 				: docInput.map((page) => page.content).join("\n");
 
-		const taggingPromptClient = await langfuse.prompt.get("tagging", {
-			label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
-			type: "chat",
-		});
+		let taggingPromptClient: ChatPromptClient;
+		try {
+			taggingPromptClient = await langfuse.prompt.get("tagging", {
+				label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
+				type: "chat",
+			});
+		} catch (error) {
+			captureError(error);
+			throw error;
+		}
 		const compiledTaggingPrompt = taggingPromptClient.compile({
 			docContent: docContent,
 		}) as ModelMessage[];
@@ -427,18 +446,22 @@ export class GenerationService {
 											snippet: match.snippet,
 										}),
 									);
-
-									const citationPromptClient = await langfuse.prompt.get(
-										"document-citation-extraction",
-										{
-											type: "chat",
-											label:
-												config.nodeEnv === "test"
-													? "development"
-													: config.nodeEnv,
-										},
-									);
-
+									let citationPromptClient: ChatPromptClient;
+									try {
+										citationPromptClient = await langfuse.prompt.get(
+											"document-citation-extraction",
+											{
+												type: "chat",
+												label:
+													config.nodeEnv === "test"
+														? "development"
+														: config.nodeEnv,
+											},
+										);
+									} catch (error) {
+										captureError(error);
+										throw error;
+									}
 									const compiledDocumentCitationExtractionPrompts =
 										citationPromptClient.compile({
 											generatedAnswer: text,
@@ -487,17 +510,22 @@ export class GenerationService {
 									}
 								}
 								if (allWebSources.length > 0) {
-									const webCitationPromptClient = await langfuse.prompt.get(
-										"web-citation-extraction",
-										{
-											label:
-												config.nodeEnv === "test"
-													? "development"
-													: config.nodeEnv,
-											type: "chat",
-										},
-									);
-
+									let webCitationPromptClient: ChatPromptClient;
+									try {
+										webCitationPromptClient = await langfuse.prompt.get(
+											"web-citation-extraction",
+											{
+												label:
+													config.nodeEnv === "test"
+														? "development"
+														: config.nodeEnv,
+												type: "chat",
+											},
+										);
+									} catch (error) {
+										captureError(error);
+										throw error;
+									}
 									const compiledWebCitationExtractionPrompts =
 										webCitationPromptClient.compile({
 											generatedAnswer: text,
@@ -752,10 +780,16 @@ export class GenerationService {
 
 		const addressForm = isAddressedFormal ? "Sieze" : "Duze";
 		// Always use free-chat prompt
-		const freeChatPromptClient = await langfuse.prompt.get(
-			"free-chat",
-			{ label: config.nodeEnv === "test" ? "development" : config.nodeEnv }, // Fallback to development prompt version during tests
-		);
+		let freeChatPromptClient: TextPromptClient;
+		try {
+			freeChatPromptClient = await langfuse.prompt.get(
+				"free-chat",
+				{ label: config.nodeEnv === "test" ? "development" : config.nodeEnv }, // Fallback to development prompt version during tests
+			);
+		} catch (error) {
+			captureError(error);
+			throw error;
+		}
 		const compiledFreeChatPrompt = freeChatPromptClient.compile({
 			currentDate: currentDate,
 			addressForm: addressForm,

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -728,30 +728,6 @@ Analysiere die Antwort und identifiziere, welche Webquellen für die Antwort ver
 		});
 
 		const addressForm = isAddressedFormal ? "Sieze" : "Duze";
-		if (config.nodeEnv === "development") {
-			const freeChatPrompt = `
-Du bist ein hilfreicher Assistent mit Zugang zu aktuellen Webinhalten über ein Websuch-Tool.
-
-Aktuelles Datum: ${currentDate}
-
-Antworte immer auf Deutsch. ${addressForm} die Nutzerin bzw. den Nutzer.
-
-Du hast Zugriff auf ein Websuch-Tool (webSearchTool). Nutze es aktiv, wenn:
-- die Frage aktuelle Informationen erfordert (Nachrichten, Preise, Ereignisse, Gesetze, etc.)
-- dein Trainingswissen möglicherweise veraltet ist
-- die Nutzerin / der Nutzer explizit nach aktuellen Informationen fragt
-
-Nenne keine URLs, Domains oder Quellnamen direkt in deiner Antwort. Quellen werden dem Nutzer separat angezeigt.
-Wenn die Suche keine nützlichen Ergebnisse liefert, teile das transparent mit.
-`;
-			return {
-				messages: [
-					{ role: "system", content: freeChatPrompt },
-					...previousMessages,
-				],
-				promptClient: undefined,
-			};
-		}
 		// Always use free-chat prompt
 		const freeChatPromptClient = await langfuse.prompt.get(
 			"free-chat",


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213632467916365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Citation extraction for documents and web sources now runs per-output, emits citation events, and updates token/inference counters.

* **Refactor**
  * Replaced static prompts with per-message prompt flows; free-chat prompt always fetched with guarded retrieval and added telemetry (session and prompt metadata) outside test/CI.

* **Bug Fixes**
  * Prompt acquisition wrapped with try/catch and resilient flows for more consistent error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->