### PR TITLE
feat: add backfill script for embeddings

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -18,7 +18,8 @@
 		"db:reset": "supabase db reset && npm run db:typegen && npm run db:upload-default-documents && npm run db:localseed",
 		"db:typegen": "supabase gen types --lang typescript --local > ../../libs/db-schema/index.ts && prettier --write ../../libs/db-schema/index.ts && ESLINT_USE_FLAT_CONFIG=true eslint --fix ../../libs/db-schema/index.ts",
 		"db:localseed": "tsx ./supabase/local-seed.ts",
-		"db:upload-default-documents": "tsx ./supabase/upload-default-documents.ts"
+		"db:upload-default-documents": "tsx ./supabase/upload-default-documents.ts",
+		"db:backfill-mistral": "tsx ./supabase/backfill-mistral-embeddings.ts"
 	},
 	"dependencies": {
 		"@ai-sdk/mcp": "1.0.23",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -44,6 +44,7 @@
 		"ioredis": "5.8.2",
 		"jsonwebtoken": "9.0.2",
 		"mammoth": "1.11.0",
+		"mistral-tokenizer-ts": "2.2.1",
 		"pdf-lib": "1.17.1",
 		"throttled-queue": "3.0.0",
 		"unpdf": "1.4.0",

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -133,7 +133,7 @@ export const config: Config = {
 		10,
 	),
 	mistralEmbedMaxTotalTokensPerRequest: parseInt(
-		process.env.MISTRAL_EMBED_MAX_TOTAL_TOKENS_PER_REQUEST ?? "131072",
+		process.env.MISTRAL_EMBED_MAX_TOTAL_TOKENS_PER_REQUEST,
 		10,
 	),
 	mistralEmbeddingDimensions: parseInt(

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -6,6 +6,7 @@ export interface Config {
 	mistralEmbeddingModel: string;
 	mistralEmbedMaxContextTokens: number;
 	mistralEmbedMaxDocumentsPerRequest: number;
+	mistralEmbedMaxTotalTokensPerRequest: number;
 	mistralEmbeddingDimensions: number;
 	mistralMaxRPS: number;
 	supabaseUrl: string;
@@ -129,6 +130,10 @@ export const config: Config = {
 	),
 	mistralEmbedMaxDocumentsPerRequest: parseInt(
 		process.env.MISTRAL_EMBED_MAX_DOCUMENTS_PER_REQUEST,
+		10,
+	),
+	mistralEmbedMaxTotalTokensPerRequest: parseInt(
+		process.env.MISTRAL_EMBED_MAX_TOTAL_TOKENS_PER_REQUEST ?? "131072",
 		10,
 	),
 	mistralEmbeddingDimensions: parseInt(

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -48,6 +48,9 @@ export function verifyConfig(): void {
 	if (!process.env.MISTRAL_EMBED_MAX_CONTEXT_TOKENS) {
 		throw new Error("MISTRAL_EMBED_MAX_CONTEXT_TOKENS must be defined");
 	}
+	if (!process.env.MISTRAL_EMBED_MAX_TOTAL_TOKENS_PER_REQUEST) {
+		throw new Error("MISTRAL_EMBED_MAX_TOTAL_TOKENS_PER_REQUEST must be defined");
+	}
 	if (!process.env.MISTRAL_EMBED_MAX_DOCUMENTS_PER_REQUEST) {
 		throw new Error("MISTRAL_EMBED_MAX_DOCUMENTS_PER_REQUEST must be defined");
 	}

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -49,7 +49,9 @@ export function verifyConfig(): void {
 		throw new Error("MISTRAL_EMBED_MAX_CONTEXT_TOKENS must be defined");
 	}
 	if (!process.env.MISTRAL_EMBED_MAX_TOTAL_TOKENS_PER_REQUEST) {
-		throw new Error("MISTRAL_EMBED_MAX_TOTAL_TOKENS_PER_REQUEST must be defined");
+		throw new Error(
+			"MISTRAL_EMBED_MAX_TOTAL_TOKENS_PER_REQUEST must be defined",
+		);
 	}
 	if (!process.env.MISTRAL_EMBED_MAX_DOCUMENTS_PER_REQUEST) {
 		throw new Error("MISTRAL_EMBED_MAX_DOCUMENTS_PER_REQUEST must be defined");

--- a/apps/backend/src/integration/chunking.test.ts
+++ b/apps/backend/src/integration/chunking.test.ts
@@ -11,6 +11,7 @@ vi.mock("../config", () => ({
 		mistralEmbeddingModel: "embedding-model-1",
 		mistralEmbedMaxContextTokens: 8000,
 		mistralEmbedMaxDocumentsPerRequest: 512,
+		mistralEmbedMaxTotalTokensPerRequest: 8000,
 		mistralEmbeddingDimensions: 1024,
 		mistralMaxRPS: 10,
 	},
@@ -44,7 +45,7 @@ describe("Chunking Methods", () => {
 		});
 
 		it("should split by newlines when text exceeds limit", () => {
-			const longLine = "a ".repeat(40000);
+			const longLine = "a ".repeat(3000);
 			const text = `${longLine}\n${longLine}\n${longLine}`;
 			const chunks = service.recursiveChunking(text);
 
@@ -57,7 +58,7 @@ describe("Chunking Methods", () => {
 		});
 
 		it("should split by sentences when no newlines available", () => {
-			const longSentence = "word ".repeat(30000);
+			const longSentence = "word ".repeat(3000);
 			const text = `${longSentence}. ${longSentence}. ${longSentence}.`;
 			const chunks = service.recursiveChunking(text);
 
@@ -69,11 +70,10 @@ describe("Chunking Methods", () => {
 			});
 		});
 
-		it("should split by words when no sentence boundaries available", () => {
+		it("should use fixed-size word chunking when only word boundaries are available", () => {
 			// Create text that exceeds the token limit without new lines or sentence boundaries
-			const text = "word ".repeat(40000);
+			const text = "word ".repeat(8100);
 			const chunks = service.recursiveChunking(text);
-
 			expect(chunks.length).toBeGreaterThan(1);
 			chunks.forEach((chunk) => {
 				expect(countTokens(chunk)).toBeLessThanOrEqual(
@@ -87,11 +87,10 @@ describe("Chunking Methods", () => {
 				.fill(0)
 				.map((_, i) => `item${i}`)
 				.join(";");
-			// Add some spaces to make it chunkable
 			const csvWithSpaces = csvItems.replace(/;/g, "; ");
 			const chunks = service.recursiveChunking(csvWithSpaces);
 
-			expect(chunks.length).toBeGreaterThan(0);
+			expect(chunks.length).toBe(1);
 			chunks.forEach((chunk) => {
 				expect(countTokens(chunk)).toBeLessThanOrEqual(
 					config.mistralEmbedMaxContextTokens,
@@ -106,7 +105,7 @@ describe("Chunking Methods", () => {
 				);
 			const chunks = service.recursiveChunking(arabicText);
 
-			expect(chunks.length).toBeGreaterThan(0);
+			expect(chunks.length).toBeGreaterThan(1);
 			chunks.forEach((chunk) => {
 				expect(countTokens(chunk)).toBeLessThanOrEqual(
 					config.mistralEmbedMaxContextTokens,
@@ -115,13 +114,13 @@ describe("Chunking Methods", () => {
 			});
 		});
 
-		it("should handle Chinese text with punctuation boundaries", () => {
+		it("should use fixed-size character chunking for Chinese text without word boundaries", () => {
 			const chineseText = "这是一个很长的中文文本，包含许多字符和句子。".repeat(
 				500,
 			);
 			const chunks = service.recursiveChunking(chineseText);
 
-			expect(chunks.length).toBeGreaterThan(0);
+			expect(chunks.length).toBeGreaterThan(1);
 			chunks.forEach((chunk) => {
 				expect(countTokens(chunk)).toBeLessThanOrEqual(
 					config.mistralEmbedMaxContextTokens,
@@ -129,7 +128,7 @@ describe("Chunking Methods", () => {
 			});
 		});
 
-		it("should skip minified JSON without spaces", () => {
+		it("should use fixed-size character chunking for minified JSON without spaces", () => {
 			const minifiedJson = `{"key":"value","nested":{"deep":"data"}}${JSON.stringify(
 				Array(5000)
 					.fill(0)
@@ -137,12 +136,16 @@ describe("Chunking Methods", () => {
 			).replace(/\s/g, "")}`; // Remove all spaces
 
 			const tokenCount = countTokens(minifiedJson);
-			// With 5000 items, this should exceed the limit
 			expect(tokenCount).toBeGreaterThan(config.mistralEmbedMaxContextTokens);
 
 			const chunks = service.recursiveChunking(minifiedJson);
 
-			expect(chunks).toEqual([]);
+			expect(chunks.length).toBeGreaterThan(1);
+			chunks.forEach((chunk) => {
+				expect(countTokens(chunk)).toBeLessThanOrEqual(
+					config.mistralEmbedMaxContextTokens,
+				);
+			});
 		});
 
 		it("should handle edge case of empty string", () => {
@@ -190,7 +193,7 @@ More content after code block.
 `;
 			const chunks = service.markdownStructuralChunking(text);
 
-			expect(chunks.length).toBeGreaterThan(0);
+			expect(chunks.length).toBe(1);
 			chunks.forEach((chunk) => {
 				expect(countTokens(chunk)).toBeLessThanOrEqual(
 					config.mistralEmbedMaxContextTokens,

--- a/apps/backend/src/services/embedding-service.ts
+++ b/apps/backend/src/services/embedding-service.ts
@@ -56,30 +56,60 @@ export class EmbeddingService {
 		inputs: string[],
 		userId?: string,
 	): Promise<EmbeddingsResponse> {
-		const { embeddings, usage } = await resilientCall(
-			async () => {
-				return await embedMany({
-					model: mistral.embeddingModel(config.mistralEmbeddingModel),
-					values: inputs,
-				});
-			},
-			{ queueType: "embeddings" },
-		);
+		const maxPerCall = config.mistralEmbedMaxDocumentsPerRequest;
+		const maxTotalTokens = config.mistralEmbedMaxTotalTokensPerRequest;
 
-		if (!embeddings) {
-			throw new Error("Failed to create embeddings");
+		const subBatches: string[][] = [];
+		let current: string[] = [];
+		let currentTokens = 0;
+
+		for (const input of inputs) {
+			const tokens = countMistralTokens(input);
+			if (
+				current.length > 0 &&
+				(current.length >= maxPerCall ||
+					currentTokens + tokens > maxTotalTokens)
+			) {
+				subBatches.push(current);
+				current = [];
+				currentTokens = 0;
+			}
+			current.push(input);
+			currentTokens += tokens;
+		}
+		if (current.length > 0) subBatches.push(current);
+
+		const allEmbeddings: number[][] = [];
+		let totalTokenUsage = 0;
+
+		for (const subBatch of subBatches) {
+			const { embeddings, usage } = await resilientCall(
+				async () => {
+					return await embedMany({
+						model: mistral.embeddingModel(config.mistralEmbeddingModel),
+						values: subBatch,
+					});
+				},
+				{ queueType: "embeddings" },
+			);
+
+			if (!embeddings) {
+				throw new Error("Failed to create embeddings");
+			}
+
+			allEmbeddings.push(...embeddings);
+			totalTokenUsage += usage.tokens;
 		}
 
-		// Increase num_embedding_tokens by the amount of tokens from the response if userId is provided
 		if (userId) {
 			await this.dbService.updateUserColumnValue(
 				userId,
 				"num_embedding_tokens",
-				usage.tokens,
+				totalTokenUsage,
 			);
 		}
 
-		return { embeddings: embeddings, tokenUsage: usage.tokens };
+		return { embeddings: allEmbeddings, tokenUsage: totalTokenUsage };
 	}
 
 	// Utility s for chunking and batch processing
@@ -331,7 +361,10 @@ export class EmbeddingService {
 				console.warn(
 					`[WARNING] Chunk exceeds ${maxTokensPerChunk} tokens (${chunk.tokenCount}), truncating chunk from page ${chunk.page}`,
 				);
-				chunk.content = trimToMistralTokenLimitByWords(chunk.content, maxTokensPerChunk);
+				chunk.content = trimToMistralTokenLimitByWords(
+					chunk.content,
+					maxTokensPerChunk,
+				);
 				chunk.tokenCount = maxTokensPerChunk;
 			}
 

--- a/apps/backend/src/services/embedding-service.ts
+++ b/apps/backend/src/services/embedding-service.ts
@@ -120,7 +120,8 @@ export class EmbeddingService {
 		size: number = 100,
 		splitBy: "words" | "characters" = "words",
 	): string[] {
-		const parts = splitBy === "words" ? content.split(/\s+/) : Array.from(content);
+		const parts =
+			splitBy === "words" ? content.split(/\s+/) : Array.from(content);
 		const chunks: string[] = [];
 		const joiner = splitBy === "words" ? " " : "";
 

--- a/apps/backend/src/services/embedding-service.ts
+++ b/apps/backend/src/services/embedding-service.ts
@@ -65,6 +65,13 @@ export class EmbeddingService {
 
 		for (const input of inputs) {
 			const tokens = countMistralTokens(input);
+			if (tokens > maxTotalTokens) {
+				// Skip inputs that exceed the max token limit individually
+				console.warn(
+					`Skipping embedding input: ${tokens} tokens exceeds max ${maxTotalTokens}`,
+				);
+				continue;
+			}
 			if (
 				current.length > 0 &&
 				(current.length >= maxPerCall ||

--- a/apps/backend/src/services/embedding-service.ts
+++ b/apps/backend/src/services/embedding-service.ts
@@ -7,7 +7,10 @@ import type {
 	EmbeddingResponse,
 	EmbeddingsResponse,
 } from "../types/common";
-import { countTokens, trimToTokenLimitByWords } from "./token-utils";
+import {
+	countMistralTokens,
+	trimToMistralTokenLimitByWords,
+} from "./token-utils";
 import { BaseContentDbService } from "./db-service/base-db-service";
 import { resilientCall } from "../utils";
 import { embed, embedMany } from "ai";
@@ -103,7 +106,7 @@ export class EmbeddingService {
 	recursiveChunking(text: string): string[] {
 		const maxTokens = config.mistralEmbedMaxContextTokens;
 		// Base case: if text is small enough, return as single chunk
-		const textTokens = countTokens(text);
+		const textTokens = countMistralTokens(text);
 		if (textTokens <= maxTokens) {
 			return text.trim() ? [text.trim()] : [];
 		}
@@ -136,7 +139,7 @@ export class EmbeddingService {
 			if (name === "word") {
 				let remaining = text;
 				while (remaining.trim()) {
-					const trimmed = trimToTokenLimitByWords(remaining, maxTokens);
+					const trimmed = trimToMistralTokenLimitByWords(remaining, maxTokens);
 					if (!trimmed) {
 						break;
 					}
@@ -149,7 +152,7 @@ export class EmbeddingService {
 			for (const part of parts) {
 				// Reconstruct with separator
 				const testChunk = currentChunk ? currentChunk + pattern + part : part;
-				const testTokens = countTokens(testChunk);
+				const testTokens = countMistralTokens(testChunk);
 				if (testTokens <= maxTokens) {
 					currentChunk = testChunk;
 					continue;
@@ -166,7 +169,7 @@ export class EmbeddingService {
 			// Recursively process any chunks that are still too large
 			const finalChunks: string[] = [];
 			for (const chunk of chunks) {
-				const chunkTokens = countTokens(chunk);
+				const chunkTokens = countMistralTokens(chunk);
 				if (chunkTokens > maxTokens) {
 					finalChunks.push(...this.recursiveChunking(chunk));
 				} else if (chunk.trim()) {
@@ -208,7 +211,7 @@ export class EmbeddingService {
 					continue;
 				}
 
-				const paragraphTokens = countTokens(trimmed);
+				const paragraphTokens = countMistralTokens(trimmed);
 
 				// If single paragraph exceeds max, use recursive chunking
 				if (paragraphTokens > maxTokens) {
@@ -254,7 +257,7 @@ export class EmbeddingService {
 		let buffer = "";
 
 		for (const chunk of chunks) {
-			const chunkTokenCount = countTokens(chunk);
+			const chunkTokenCount = countMistralTokens(chunk);
 
 			if (chunkTokenCount >= minTokens) {
 				if (buffer) {
@@ -264,7 +267,7 @@ export class EmbeddingService {
 				merged.push(chunk);
 			} else {
 				const testBuffer = buffer ? `${buffer} ${chunk}` : chunk;
-				const testBufferTokens = countTokens(testBuffer);
+				const testBufferTokens = countMistralTokens(testBuffer);
 
 				// If adding this chunk would exceed maxTokens, flush buffer first
 				if (testBufferTokens > maxTokens && buffer) {
@@ -309,7 +312,7 @@ export class EmbeddingService {
 
 			for (let index = 0; index < chunkContents.length; index++) {
 				const chunkContent = chunkContents[index];
-				const tokenCount = countTokens(chunkContent);
+				const tokenCount = countMistralTokens(chunkContent);
 				allChunks.push({
 					content: chunkContent,
 					page: page.pageNumber,
@@ -326,9 +329,10 @@ export class EmbeddingService {
 		for (const chunk of allChunks) {
 			if (chunk.tokenCount > maxTokensPerChunk) {
 				console.warn(
-					`[WARNING] Chunk exceeds ${maxTokensPerChunk} tokens (${chunk.tokenCount}), skipping chunk from page ${chunk.page}`,
+					`[WARNING] Chunk exceeds ${maxTokensPerChunk} tokens (${chunk.tokenCount}), truncating chunk from page ${chunk.page}`,
 				);
-				continue;
+				chunk.content = trimToMistralTokenLimitByWords(chunk.content, maxTokensPerChunk);
+				chunk.tokenCount = maxTokensPerChunk;
 			}
 
 			if (currentBatch.length >= maxChunksPerRequest) {

--- a/apps/backend/src/services/embedding-service.ts
+++ b/apps/backend/src/services/embedding-service.ts
@@ -115,14 +115,21 @@ export class EmbeddingService {
 	}
 
 	// Utility s for chunking and batch processing
-	fixedSizeChunking(content: string, wordsPerChunk: number = 100): string[] {
-		const words = content.split(/\s+/);
+	fixedSizeChunking(
+		content: string,
+		size: number = 100,
+		splitBy: "words" | "characters" = "words",
+	): string[] {
+		const parts = splitBy === "words" ? content.split(/\s+/) : Array.from(content);
 		const chunks: string[] = [];
+		const joiner = splitBy === "words" ? " " : "";
 
-		for (let i = 0; i < words.length; i += wordsPerChunk) {
-			const chunkWords = words.slice(i, i + wordsPerChunk);
-			const chunk = chunkWords.join(" ");
-			chunks.push(chunk);
+		for (let i = 0; i < parts.length; i += size) {
+			const chunkParts = parts.slice(i, i + size);
+			const chunk = chunkParts.join(joiner);
+			if (chunk.trim()) {
+				chunks.push(chunk.trim());
+			}
 		}
 
 		return chunks;
@@ -143,12 +150,12 @@ export class EmbeddingService {
 			return text.trim() ? [text.trim()] : [];
 		}
 
-		// Early exit: if text has no word boundaries at all, it's unchunkable
+		// Early exit: if text has no word boundaries at all, use fixed character chunking
 		if (!text.includes(" ") && !text.includes("\n") && !text.includes(". ")) {
-			console.warn(
-				`[WARNING] Skipping unchunkable content with ${textTokens} tokens (no word boundaries found). Preview: ${text.slice(0, 100)}...`,
+			const charsPerChunk = Math.floor(
+				(text.length / textTokens) * (maxTokens / 2),
 			);
-			return [];
+			return this.fixedSizeChunking(text, charsPerChunk, "characters");
 		}
 
 		// Try separators in priority order
@@ -167,19 +174,10 @@ export class EmbeddingService {
 			const chunks: string[] = [];
 			let currentChunk = "";
 
-			// For word splitting, use binary search optimization to avoid O(n²) complexity
+			// For word splitting, use fixed-size chunking to avoid O(n log n) tokenization complexity
 			if (name === "word") {
-				let remaining = text;
-				while (remaining.trim()) {
-					const trimmed = trimToMistralTokenLimitByWords(remaining, maxTokens);
-					if (!trimmed) {
-						break;
-					}
-
-					chunks.push(trimmed.trim());
-					remaining = remaining.slice(trimmed.length).trim();
-				}
-				return chunks.filter((c) => c.trim().length > 0);
+				const wordsPerChunk = Math.floor(maxTokens / 2);
+				return this.fixedSizeChunking(text, wordsPerChunk, "words");
 			}
 			for (const part of parts) {
 				// Reconstruct with separator

--- a/apps/backend/src/services/embedding-service.ts
+++ b/apps/backend/src/services/embedding-service.ts
@@ -77,7 +77,9 @@ export class EmbeddingService {
 			current.push(input);
 			currentTokens += tokens;
 		}
-		if (current.length > 0) subBatches.push(current);
+		if (current.length > 0) {
+			subBatches.push(current);
+		}
 
 		const allEmbeddings: number[][] = [];
 		let totalTokenUsage = 0;

--- a/apps/backend/src/services/token-utils.ts
+++ b/apps/backend/src/services/token-utils.ts
@@ -1,4 +1,37 @@
 import { enc } from "../constants";
+import { getTokenizerForModel } from "mistral-tokenizer-ts";
+
+const mistralTokenizer = getTokenizerForModel("mistral-embed");
+
+export function countMistralTokens(text: string): number {
+	// Include the BOS token (shouldAddBosToken=true) to match what the Mistral API counts.
+	return mistralTokenizer.encode(text, true, false).length;
+}
+
+export function trimToMistralTokenLimitByWords(
+	text: string,
+	tokenLimit: number,
+): string {
+	// Reserve 1 extra token to absorb minor tokenization differences caused by
+	// whitespace normalization when splitting/rejoining words.
+	const safeLimit = tokenLimit - 1;
+	if (countMistralTokens(text) <= safeLimit) {
+		return text;
+	}
+	const words = text.split(/\s+/);
+	let lo = 0;
+	let hi = words.length;
+	while (lo < hi) {
+		const mid = Math.floor((lo + hi + 1) / 2);
+		const candidate = words.slice(0, mid).join(" ");
+		if (countMistralTokens(candidate) <= safeLimit) {
+			lo = mid;
+		} else {
+			hi = mid - 1;
+		}
+	}
+	return words.slice(0, lo).join(" ");
+}
 
 export type SafePayloadOptions = {
 	providerTokenRatio?: number;

--- a/apps/backend/src/services/token-utils.ts
+++ b/apps/backend/src/services/token-utils.ts
@@ -4,8 +4,7 @@ import { getTokenizerForModel } from "mistral-tokenizer-ts";
 const mistralTokenizer = getTokenizerForModel("mistral-embed");
 
 export function countMistralTokens(text: string): number {
-	// Include the BOS token (shouldAddBosToken=true) to match what the Mistral API counts.
-	return mistralTokenizer.encode(text, true, false).length;
+	return mistralTokenizer.encode(text, true, true).length;
 }
 
 export function trimToMistralTokenLimitByWords(

--- a/apps/backend/supabase/backfill-mistral-embeddings.ts
+++ b/apps/backend/supabase/backfill-mistral-embeddings.ts
@@ -1,0 +1,112 @@
+import { serviceRoleDbClient } from "../src/supabase";
+import { PrivilegedDbService } from "../src/services/db-service/privileged-db-service";
+import { EmbeddingService } from "../src/services/embedding-service";
+import { config } from "../src/config";
+import { initQueues } from "../src/services/distributed-limiter";
+
+/**
+ * Backfills missing Mistral embeddings for document chunks.
+ * This script finds all rows in document_chunks where chunk_mistral_embedding is null,
+ * generates embeddings using the Mistral API, and updates the database.
+ */
+async function backfillMistralEmbeddings() {
+	// eslint-disable-next-line no-console
+	console.log("Starting backfill of Mistral embeddings...");
+
+	const dbService = new PrivilegedDbService(serviceRoleDbClient);
+	const embeddingService = new EmbeddingService(dbService);
+
+	await initQueues();
+
+	let totalProcessed = 0;
+	let hasMore = true;
+	const fetchBatchSize = 1000;
+	const embeddingBatchSize = config.mistralEmbedMaxDocumentsPerRequest;
+
+	while (hasMore) {
+		// eslint-disable-next-line no-console
+		console.log(
+			`Fetching next ${fetchBatchSize} chunks without Mistral embeddings...`,
+		);
+
+		const { data: chunks, error } = await serviceRoleDbClient
+			.from("document_chunks")
+			.select("id, content")
+			.is("chunk_mistral_embedding", null)
+			.order("id", { ascending: true })
+			.limit(fetchBatchSize);
+
+		if (error) {
+			console.error("Error fetching chunks:", error);
+			process.exit(1);
+		}
+
+		if (!chunks || chunks.length === 0) {
+			// eslint-disable-next-line no-console
+			console.log("No more chunks to process.");
+			hasMore = false;
+			break;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log(
+			`Processing ${chunks.length} chunks in batches of ${embeddingBatchSize}...`,
+		);
+
+		for (let i = 0; i < chunks.length; i += embeddingBatchSize) {
+			const batch = chunks.slice(i, i + embeddingBatchSize);
+			const contents = batch.map((c) => c.content);
+
+			try {
+				// eslint-disable-next-line no-console
+				console.log(`Generating embeddings for batch of ${batch.length}...`);
+				const { embeddings } =
+					await embeddingService.generateMistralBatchEmbeddings(contents);
+
+				if (embeddings.length !== batch.length) {
+					throw new Error(
+						`Expected ${batch.length} embeddings, got ${embeddings.length}`,
+					);
+				}
+
+				// Update chunks in DB
+				// eslint-disable-next-line no-console
+				console.log(`Updating ${batch.length} chunks in database...`);
+				const updatePromises = batch.map((chunk, index) => {
+					return serviceRoleDbClient
+						.from("document_chunks")
+						.update({
+							chunk_mistral_embedding: JSON.stringify(embeddings[index]),
+						})
+						.eq("id", chunk.id);
+				});
+
+				const results = await Promise.all(updatePromises);
+				const batchErrors = results.filter((r) => r.error).map((r) => r.error);
+
+				if (batchErrors.length > 0) {
+					console.error(`Errors updating chunks in batch:`, batchErrors);
+				}
+
+				totalProcessed += batch.length;
+				// eslint-disable-next-line no-console
+				console.log(`Successfully processed ${totalProcessed} chunks so far.`);
+			} catch (err) {
+				console.error("Error processing batch:", err);
+				// For embedding generation errors (API issues), we exit to avoid infinite loops or wasted credits
+				process.exit(1);
+			}
+		}
+	}
+
+	// eslint-disable-next-line no-console
+	console.log(
+		`\n=== Backfill complete! Total chunks processed: ${totalProcessed} ===`,
+	);
+	process.exit(0);
+}
+
+backfillMistralEmbeddings().catch((err) => {
+	console.error("Unhandled error during backfill:", err);
+	process.exit(1);
+});

--- a/apps/backend/supabase/backfill-mistral-embeddings.ts
+++ b/apps/backend/supabase/backfill-mistral-embeddings.ts
@@ -60,7 +60,10 @@ async function backfillMistralEmbeddings() {
 				console.warn(
 					`Chunk id=${c.id} has ${tokens} tokens, truncating to ${MISTRAL_EMBED_MAX_TOKENS}`,
 				);
-				return trimToMistralTokenLimitByWords(c.content, MISTRAL_EMBED_MAX_TOKENS);
+				return trimToMistralTokenLimitByWords(
+					c.content,
+					MISTRAL_EMBED_MAX_TOKENS,
+				);
 			}
 			return c.content;
 		});

--- a/apps/backend/supabase/backfill-mistral-embeddings.ts
+++ b/apps/backend/supabase/backfill-mistral-embeddings.ts
@@ -96,6 +96,7 @@ async function backfillMistralEmbeddings() {
 
 			if (batchErrors.length > 0) {
 				console.error(`Errors updating chunks in batch:`, batchErrors);
+				process.exit(1);
 			}
 
 			totalProcessed += chunks.length;
@@ -103,7 +104,6 @@ async function backfillMistralEmbeddings() {
 			console.log(`Successfully processed ${totalProcessed} chunks so far.`);
 		} catch (err) {
 			console.error("Error processing batch:", err);
-			// For embedding generation errors (API issues), we exit to avoid infinite loops or wasted credits
 			process.exit(1);
 		}
 	}

--- a/apps/backend/supabase/backfill-mistral-embeddings.ts
+++ b/apps/backend/supabase/backfill-mistral-embeddings.ts
@@ -3,6 +3,12 @@ import { PrivilegedDbService } from "../src/services/db-service/privileged-db-se
 import { EmbeddingService } from "../src/services/embedding-service";
 import { config } from "../src/config";
 import { initQueues } from "../src/services/distributed-limiter";
+import {
+	trimToMistralTokenLimitByWords,
+	countMistralTokens,
+} from "../src/services/token-utils";
+
+const MISTRAL_EMBED_MAX_TOKENS = config.mistralEmbedMaxContextTokens;
 
 /**
  * Backfills missing Mistral embeddings for document chunks.
@@ -47,7 +53,17 @@ async function backfillMistralEmbeddings() {
 			break;
 		}
 
-		const contents = chunks.map((c) => c.content);
+		const contents = chunks.map((c) => {
+			const tokens = countMistralTokens(c.content);
+			if (tokens > MISTRAL_EMBED_MAX_TOKENS) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					`Chunk id=${c.id} has ${tokens} tokens, truncating to ${MISTRAL_EMBED_MAX_TOKENS}`,
+				);
+				return trimToMistralTokenLimitByWords(c.content, MISTRAL_EMBED_MAX_TOKENS);
+			}
+			return c.content;
+		});
 
 		try {
 			// eslint-disable-next-line no-console

--- a/apps/backend/supabase/backfill-mistral-embeddings.ts
+++ b/apps/backend/supabase/backfill-mistral-embeddings.ts
@@ -20,13 +20,12 @@ async function backfillMistralEmbeddings() {
 
 	let totalProcessed = 0;
 	let hasMore = true;
-	const fetchBatchSize = 1000;
-	const embeddingBatchSize = config.mistralEmbedMaxDocumentsPerRequest;
+	const batchSize = config.mistralEmbedMaxDocumentsPerRequest;
 
 	while (hasMore) {
 		// eslint-disable-next-line no-console
 		console.log(
-			`Fetching next ${fetchBatchSize} chunks without Mistral embeddings...`,
+			`Fetching next ${batchSize} chunks without Mistral embeddings...`,
 		);
 
 		const { data: chunks, error } = await serviceRoleDbClient
@@ -34,7 +33,7 @@ async function backfillMistralEmbeddings() {
 			.select("id, content")
 			.is("chunk_mistral_embedding", null)
 			.order("id", { ascending: true })
-			.limit(fetchBatchSize);
+			.limit(batchSize);
 
 		if (error) {
 			console.error("Error fetching chunks:", error);
@@ -48,54 +47,45 @@ async function backfillMistralEmbeddings() {
 			break;
 		}
 
-		// eslint-disable-next-line no-console
-		console.log(
-			`Processing ${chunks.length} chunks in batches of ${embeddingBatchSize}...`,
-		);
+		const contents = chunks.map((c) => c.content);
 
-		for (let i = 0; i < chunks.length; i += embeddingBatchSize) {
-			const batch = chunks.slice(i, i + embeddingBatchSize);
-			const contents = batch.map((c) => c.content);
+		try {
+			// eslint-disable-next-line no-console
+			console.log(`Generating embeddings for batch of ${chunks.length}...`);
+			const { embeddings } =
+				await embeddingService.generateMistralBatchEmbeddings(contents);
 
-			try {
-				// eslint-disable-next-line no-console
-				console.log(`Generating embeddings for batch of ${batch.length}...`);
-				const { embeddings } =
-					await embeddingService.generateMistralBatchEmbeddings(contents);
-
-				if (embeddings.length !== batch.length) {
-					throw new Error(
-						`Expected ${batch.length} embeddings, got ${embeddings.length}`,
-					);
-				}
-
-				// Update chunks in DB
-				// eslint-disable-next-line no-console
-				console.log(`Updating ${batch.length} chunks in database...`);
-				const updatePromises = batch.map((chunk, index) => {
-					return serviceRoleDbClient
-						.from("document_chunks")
-						.update({
-							chunk_mistral_embedding: JSON.stringify(embeddings[index]),
-						})
-						.eq("id", chunk.id);
-				});
-
-				const results = await Promise.all(updatePromises);
-				const batchErrors = results.filter((r) => r.error).map((r) => r.error);
-
-				if (batchErrors.length > 0) {
-					console.error(`Errors updating chunks in batch:`, batchErrors);
-				}
-
-				totalProcessed += batch.length;
-				// eslint-disable-next-line no-console
-				console.log(`Successfully processed ${totalProcessed} chunks so far.`);
-			} catch (err) {
-				console.error("Error processing batch:", err);
-				// For embedding generation errors (API issues), we exit to avoid infinite loops or wasted credits
-				process.exit(1);
+			if (embeddings.length !== chunks.length) {
+				throw new Error(
+					`Expected ${chunks.length} embeddings, got ${embeddings.length}`,
+				);
 			}
+
+			// eslint-disable-next-line no-console
+			console.log(`Updating ${chunks.length} chunks in database...`);
+			const updatePromises = chunks.map((chunk, index) => {
+				return serviceRoleDbClient
+					.from("document_chunks")
+					.update({
+						chunk_mistral_embedding: JSON.stringify(embeddings[index]),
+					})
+					.eq("id", chunk.id);
+			});
+
+			const results = await Promise.all(updatePromises);
+			const batchErrors = results.filter((r) => r.error).map((r) => r.error);
+
+			if (batchErrors.length > 0) {
+				console.error(`Errors updating chunks in batch:`, batchErrors);
+			}
+
+			totalProcessed += chunks.length;
+			// eslint-disable-next-line no-console
+			console.log(`Successfully processed ${totalProcessed} chunks so far.`);
+		} catch (err) {
+			console.error("Error processing batch:", err);
+			// For embedding generation errors (API issues), we exit to avoid infinite loops or wasted credits
+			process.exit(1);
 		}
 	}
 

--- a/apps/backend/supabase/find-oversized-chunks.ts
+++ b/apps/backend/supabase/find-oversized-chunks.ts
@@ -1,0 +1,84 @@
+import { serviceRoleDbClient } from "../src/supabase";
+import { countMistralTokens } from "../src/services/token-utils";
+import { config } from "../src/config";
+
+const MAX_TOKENS = config.mistralEmbedMaxContextTokens;
+const FETCH_BATCH_SIZE = 500;
+
+async function findOversizedChunks() {
+	// eslint-disable-next-line no-console
+	console.log(
+		`Scanning all document_chunks for content exceeding ${MAX_TOKENS} Mistral tokens...\n`,
+	);
+
+	const oversized: {
+		id: number;
+		document_id: number;
+		tokens: number;
+		chars: number;
+	}[] = [];
+	let offset = 0;
+	let totalScanned = 0;
+
+	while (true) {
+		const { data: chunks, error } = await serviceRoleDbClient
+			.from("document_chunks")
+			.select("id, document_id, content")
+			.range(offset, offset + FETCH_BATCH_SIZE - 1)
+			.order("id", { ascending: true });
+
+		if (error) {
+			console.error("Error fetching chunks:", error);
+			process.exit(1);
+		}
+
+		if (!chunks || chunks.length === 0) break;
+
+		for (const chunk of chunks) {
+			if (chunk.document_id == null) continue;
+			const tokens = countMistralTokens(chunk.content);
+			if (tokens > MAX_TOKENS) {
+				oversized.push({
+					id: chunk.id,
+					document_id: chunk.document_id,
+					tokens,
+					chars: chunk.content.length,
+				});
+			}
+		}
+
+		totalScanned += chunks.length;
+		process.stdout.write(
+			`\rScanned ${totalScanned} chunks, found ${oversized.length} oversized so far...`,
+		);
+
+		if (chunks.length < FETCH_BATCH_SIZE) break;
+		offset += FETCH_BATCH_SIZE;
+	}
+
+	console.log(`\n\nDone. Scanned ${totalScanned} chunks total.\n`);
+
+	if (oversized.length === 0) {
+		console.log("No oversized chunks found.");
+		return;
+	}
+
+	console.log(
+		`Found ${oversized.length} chunks exceeding ${MAX_TOKENS} tokens:\n`,
+	);
+	console.log("id\t\tdocument_id\ttokens\t\tchars");
+	console.log("─".repeat(60));
+	for (const c of oversized.sort((a, b) => b.tokens - a.tokens)) {
+		console.log(`${c.id}\t\t${c.document_id}\t\t${c.tokens}\t\t${c.chars}`);
+	}
+
+	const uniqueDocs = [...new Set(oversized.map((c) => c.document_id))];
+	console.log(
+		`\nAffected document IDs (${uniqueDocs.length} unique): ${uniqueDocs.join(", ")}`,
+	);
+}
+
+findOversizedChunks().catch((err) => {
+	console.error("Unhandled error:", err);
+	process.exit(1);
+});

--- a/apps/backend/supabase/rechunk-documents.ts
+++ b/apps/backend/supabase/rechunk-documents.ts
@@ -64,17 +64,21 @@ async function rechunkDocuments(targetDocIds: number[]) {
 		const docForStorage: Document = { ...baseDoc };
 
 		try {
-			// 2. Delete existing chunks
+			// 2. Fetch existing chunk IDs for the document
 			// eslint-disable-next-line no-console
-			console.log(`Deleting existing chunks for document ${docId}...`);
-			const { error: deleteError } = await serviceRoleDbClient
-				.from("document_chunks")
-				.delete()
-				.eq("document_id", docId);
+			console.log(`Fetching existing chunk IDs for document ${docId}...`);
+			const { data: oldChunks, error: fetchChunksError } =
+				await serviceRoleDbClient
+					.from("document_chunks")
+					.select("id")
+					.eq("document_id", docId);
 
-			if (deleteError) {
-				throw new Error(`Failed to delete chunks: ${deleteError.message}`);
+			if (fetchChunksError) {
+				throw new Error(
+					`Failed to fetch existing chunks: ${fetchChunksError.message}`,
+				);
 			}
+			const oldChunkIds = oldChunks?.map((c) => c.id) || [];
 
 			// 3. Re-extract document content from storage
 			// eslint-disable-next-line no-console
@@ -94,6 +98,22 @@ async function rechunkDocuments(targetDocIds: number[]) {
 			// eslint-disable-next-line no-console
 			console.log(`Inserting ${embeddings.length} new chunks...`);
 			await dbService.logEmbeddings(embeddings, docForStorage);
+
+			// 6. Delete old chunks by ID
+			if (oldChunkIds.length > 0) {
+				// eslint-disable-next-line no-console
+				console.log(
+					`Deleting ${oldChunkIds.length} old chunks for document ${docId}...`,
+				);
+				const { error: deleteError } = await serviceRoleDbClient
+					.from("document_chunks")
+					.delete()
+					.in("id", oldChunkIds);
+
+				if (deleteError) {
+					console.error(`Failed to delete old chunks: ${deleteError.message}`);
+				}
+			}
 
 			// eslint-disable-next-line no-console
 			console.log(`Successfully re-chunked document ${docId}.`);

--- a/apps/backend/supabase/rechunk-documents.ts
+++ b/apps/backend/supabase/rechunk-documents.ts
@@ -1,0 +1,117 @@
+import { serviceRoleDbClient } from "../src/supabase";
+import { PrivilegedDbService } from "../src/services/db-service/privileged-db-service";
+import { EmbeddingService } from "../src/services/embedding-service";
+import { initQueues } from "../src/services/distributed-limiter";
+import type { Document } from "../src/types/common";
+
+const DEFAULT_DOC_IDS = [7256, 7262, 7263, 7380];
+
+/**
+ * Re-chunks and re-embeds documents that were previously ingested with oversized chunks.
+ * This script deletes the existing chunks for specific document IDs and runs the
+ * current chunking and embedding pipeline to create properly-sized chunks.
+ */
+async function rechunkDocuments(targetDocIds: number[]) {
+	// eslint-disable-next-line no-console
+	console.log(
+		`Starting re-chunking for documents: ${targetDocIds.join(", ")}...`,
+	);
+
+	const dbService = new PrivilegedDbService(serviceRoleDbClient);
+	const embeddingService = new EmbeddingService(dbService);
+
+	await initQueues();
+
+	for (const docId of targetDocIds) {
+		// eslint-disable-next-line no-console
+		console.log(`\n--- Processing Document ID: ${docId} ---`);
+
+		// 1. Fetch document metadata
+		const { data: document, error: fetchError } = await serviceRoleDbClient
+			.from("documents")
+			.select("*")
+			.eq("id", docId)
+			.single();
+
+		if (fetchError || !document) {
+			console.error(`Error fetching document ${docId}:`, fetchError);
+			continue;
+		}
+
+		const baseDoc: Document = {
+			id: document.id,
+			source_url: document.source_url,
+			source_type: document.source_type,
+			created_at: document.created_at ?? new Date().toISOString(),
+			owned_by_user_id: document.owned_by_user_id ?? undefined,
+			uploaded_by_user_id: document.uploaded_by_user_id ?? undefined,
+			access_group_id: document.access_group_id ?? undefined,
+			file_checksum: document.file_checksum ?? undefined,
+			file_size: document.file_size ?? undefined,
+			num_pages: document.num_pages ?? undefined,
+			folder_id: document.folder_id ?? undefined,
+			processing_finished_at: document.processing_finished_at ?? undefined,
+		};
+
+		// Used for embedding: user IDs are cleared so batchEmbed does not attempt to
+		// update per-user token counters via PrivilegedDbService (forbidden there).
+		const docForEmbed: Document = {
+			...baseDoc,
+			owned_by_user_id: undefined,
+			uploaded_by_user_id: undefined,
+		};
+
+		const docForStorage: Document = { ...baseDoc };
+
+		try {
+			// 2. Delete existing chunks
+			// eslint-disable-next-line no-console
+			console.log(`Deleting existing chunks for document ${docId}...`);
+			const { error: deleteError } = await serviceRoleDbClient
+				.from("document_chunks")
+				.delete()
+				.eq("document_id", docId);
+
+			if (deleteError) {
+				throw new Error(`Failed to delete chunks: ${deleteError.message}`);
+			}
+
+			// 3. Re-extract document content from storage
+			// eslint-disable-next-line no-console
+			console.log(`Extracting content for ${docForStorage.source_url}...`);
+			const extractionResult = await dbService.extractDocument(docForStorage);
+
+			// 4. Re-chunk and embed using current pipeline
+			// eslint-disable-next-line no-console
+			console.log(`Re-chunking and generating Mistral embeddings...`);
+			const embeddings = await embeddingService.batchEmbed(
+				extractionResult.parsedPages,
+				docForEmbed,
+				{ chunkingTechnique: "markdown" },
+			);
+
+			// 5. Log new chunks/embeddings with original ownership
+			// eslint-disable-next-line no-console
+			console.log(`Inserting ${embeddings.length} new chunks...`);
+			await dbService.logEmbeddings(embeddings, docForStorage);
+
+			// eslint-disable-next-line no-console
+			console.log(`Successfully re-chunked document ${docId}.`);
+		} catch (err) {
+			console.error(`Error processing document ${docId}:`, err);
+		}
+	}
+
+	// eslint-disable-next-line no-console
+	console.log("\n=== Re-chunking complete! ===");
+	process.exit(0);
+}
+
+// Allow passing IDs via CLI, otherwise use defaults
+const args = process.argv.slice(2);
+const docIdsToProcess = args.length > 0 ? args.map(Number) : DEFAULT_DOC_IDS;
+
+rechunkDocuments(docIdsToProcess).catch((err) => {
+	console.error("Unhandled error:", err);
+	process.exit(1);
+});

--- a/apps/backend/vitest.config.js
+++ b/apps/backend/vitest.config.js
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { config } from "dotenv";
 import { defineConfig } from "vitest/config";
 
@@ -9,7 +10,16 @@ import { defineConfig } from "vitest/config";
  */
 config({ override: true });
 
+// mistral-tokenizer-ts ESM build uses __dirname (undefined in ESM).
+// Alias to CJS build so it loads correctly in Vitest.
+const mistralCjs = createRequire(import.meta.url).resolve("mistral-tokenizer-ts");
+
 export default defineConfig({
+	resolve: {
+		alias: {
+			"mistral-tokenizer-ts": mistralCjs,
+		},
+	},
 	test: {
 		globalSetup: ["./src/integration/setup.ts"],
 		fileParallelism: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -325,6 +325,7 @@
         "ioredis": "5.8.2",
         "jsonwebtoken": "9.0.2",
         "mammoth": "1.11.0",
+        "mistral-tokenizer-ts": "2.2.1",
         "pdf-lib": "1.17.1",
         "throttled-queue": "3.0.0",
         "unpdf": "1.4.0",
@@ -13403,6 +13404,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/mistral-tokenizer-ts": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/mistral-tokenizer-ts/-/mistral-tokenizer-ts-2.2.1.tgz",
+      "integrity": "sha512-44IHOoNQY6bGR6rygDbdCA49pLcnAU2Rm6wcwCqA6e3QoSgtgrb4HKhHKoH7NYlhwbEtPJlCOa7DQB166rpttA==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=20",
+        "yarn": "please-use-npm-instead"
       }
     },
     "node_modules/module-details-from-path": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added runnable tools: backfill missing Mistral embeddings, scan/report oversized chunks, and re-chunk/re-embed documents; all exposed via project scripts.
  * Added runtime dependency for Mistral tokenization to support the new tooling.

* **Improvements**
  * Introduced Mistral tokenizer support and a new env-configurable total-token limit for embedding requests.
  * Improved embedding batching and token accounting; oversized chunks are now truncated to fit limits (with warnings) instead of being skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->