### PR TITLE
feat: add web search prompt if web search is active

### DIFF
--- a/apps/backend/src/routes/llms.ts
+++ b/apps/backend/src/routes/llms.ts
@@ -77,7 +77,11 @@ llms.post("/just-chatting", async (c: Context) => {
 		const activeTools: ActiveTools[] = rawActiveTools;
 
 		const { messages: promptMessages, promptClient: langfusePrompt } =
-			await generationService.createPrompt(messages, isAddressedFormal);
+			await generationService.createPrompt(
+				messages,
+				isAddressedFormal,
+				activeTools,
+			);
 		const response = await generationService.generateTextStreamResponse(
 			llmHandler,
 			promptMessages,

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -789,36 +789,28 @@ export class GenerationService {
 
 		const addressForm = isAddressedFormal ? "Sieze" : "Duze";
 		let freeChatPromptClient: TextPromptClient;
-async createPrompt(
-  previousMessages: ModelMessage[],
-  isAddressedFormal: boolean,
-  activeTools: ActiveTools[],
-): Promise<{
-  messages: ModelMessage[];
-  promptClient: TextPromptClient;
-}> {
-  const addressForm = isAddressedFormal ? "Sieze" : "Duze";
-  let freeChatPromptClient: TextPromptClient;
-  const effectiveActiveTools = [...activeTools];
-  if (
-    config.featureFlagWebSearchAllowed &&
-    !effectiveActiveTools.includes("webSearchTool")
-  ) {
-    effectiveActiveTools.push("webSearchTool");
-  }
 
-  if (effectiveActiveTools.includes("webSearchTool")) {
-    try {
-      freeChatPromptClient = await langfuse.prompt.get(
-        "free-chat-with-web-search-enabled",
-        { label: config.nodeEnv === "test" ? "development" : config.nodeEnv },
-      );
-    } catch (error) {
-      captureError(error);
-      throw error;
-    }
-  } else {
-    try {
+		const effectiveActiveTools = [...activeTools];
+		// TODO: Remove the check for feature flag once frontend functionality to add web search tool in chat is implemented
+		if (
+			config.featureFlagWebSearchAllowed &&
+			!effectiveActiveTools.includes("webSearchTool")
+		) {
+			effectiveActiveTools.push("webSearchTool");
+		}
+
+		if (effectiveActiveTools.includes("webSearchTool")) {
+			try {
+				freeChatPromptClient = await langfuse.prompt.get(
+					"free-chat-with-web-search-enabled",
+					{ label: config.nodeEnv === "test" ? "development" : config.nodeEnv },
+				);
+			} catch (error) {
+				captureError(error);
+				throw error;
+			}
+		} else {
+			try {
 				freeChatPromptClient = await langfuse.prompt.get(
 					"free-chat",
 					{ label: config.nodeEnv === "test" ? "development" : config.nodeEnv }, // Fallback to development prompt version during tests

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -789,18 +789,36 @@ export class GenerationService {
 
 		const addressForm = isAddressedFormal ? "Sieze" : "Duze";
 		let freeChatPromptClient: TextPromptClient;
-		if (activeTools.includes("webSearchTool")) {
-			try {
-				freeChatPromptClient = await langfuse.prompt.get(
-					"free-chat-with-web-search-enabled",
-					{ label: config.nodeEnv === "test" ? "development" : config.nodeEnv },
-				);
-			} catch (error) {
-				captureError(error);
-				throw error;
-			}
-		} else {
-			try {
+async createPrompt(
+  previousMessages: ModelMessage[],
+  isAddressedFormal: boolean,
+  activeTools: ActiveTools[],
+): Promise<{
+  messages: ModelMessage[];
+  promptClient: TextPromptClient;
+}> {
+  const addressForm = isAddressedFormal ? "Sieze" : "Duze";
+  let freeChatPromptClient: TextPromptClient;
+  const effectiveActiveTools = [...activeTools];
+  if (
+    config.featureFlagWebSearchAllowed &&
+    !effectiveActiveTools.includes("webSearchTool")
+  ) {
+    effectiveActiveTools.push("webSearchTool");
+  }
+
+  if (effectiveActiveTools.includes("webSearchTool")) {
+    try {
+      freeChatPromptClient = await langfuse.prompt.get(
+        "free-chat-with-web-search-enabled",
+        { label: config.nodeEnv === "test" ? "development" : config.nodeEnv },
+      );
+    } catch (error) {
+      captureError(error);
+      throw error;
+    }
+  } else {
+    try {
 				freeChatPromptClient = await langfuse.prompt.get(
 					"free-chat",
 					{ label: config.nodeEnv === "test" ? "development" : config.nodeEnv }, // Fallback to development prompt version during tests

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -776,6 +776,7 @@ export class GenerationService {
 	async createPrompt(
 		previousMessages: ModelMessage[],
 		isAddressedFormal: boolean,
+		activeTools: ActiveTools[],
 	): Promise<{
 		messages: ModelMessage[];
 		promptClient: TextPromptClient;
@@ -787,16 +788,27 @@ export class GenerationService {
 		});
 
 		const addressForm = isAddressedFormal ? "Sieze" : "Duze";
-		// Always use free-chat prompt
 		let freeChatPromptClient: TextPromptClient;
-		try {
-			freeChatPromptClient = await langfuse.prompt.get(
-				"free-chat",
-				{ label: config.nodeEnv === "test" ? "development" : config.nodeEnv }, // Fallback to development prompt version during tests
-			);
-		} catch (error) {
-			captureError(error);
-			throw error;
+		if (activeTools.includes("webSearchTool")) {
+			try {
+				freeChatPromptClient = await langfuse.prompt.get(
+					"free-chat-with-web-search-enabled",
+					{ label: config.nodeEnv === "test" ? "development" : config.nodeEnv },
+				);
+			} catch (error) {
+				captureError(error);
+				throw error;
+			}
+		} else {
+			try {
+				freeChatPromptClient = await langfuse.prompt.get(
+					"free-chat",
+					{ label: config.nodeEnv === "test" ? "development" : config.nodeEnv }, // Fallback to development prompt version during tests
+				);
+			} catch (error) {
+				captureError(error);
+				throw error;
+			}
 		}
 		const compiledFreeChatPrompt = freeChatPromptClient.compile({
 			currentDate: currentDate,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic, tool-aware prompt generation: prompts now reflect which tools are active at runtime and include that state in streaming responses.
  * Web-search handling: when web search is permitted by settings but not active, it’s implicitly considered; prompts switch to a web-search-aware variant when web search is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->