### PR TITLE
Feat: stop text generation

### DIFF
--- a/apps/frontend/public/icons/chat-stop-generating-icon.svg
+++ b/apps/frontend/public/icons/chat-stop-generating-icon.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="9" y="8" width="4.5" height="16" rx="1" fill="#0C2753"/>
+  <rect x="18.5" y="8" width="4.5" height="16" rx="1" fill="#0C2753"/>
+</svg>

--- a/apps/frontend/src/api/chat/get-completion.ts
+++ b/apps/frontend/src/api/chat/get-completion.ts
@@ -184,10 +184,15 @@ export async function getCompletion(
 			},
 		});
 	} catch (error) {
-		setStatus("error");
 		// Only handle error if it's not an abort error
-		if (error instanceof Error && error.name !== "AbortError") {
-			handleError(error, span);
+		const isUserAbort = error instanceof Error && error.name === "AbortError";
+		if (isUserAbort) {
+			setStatus("idle");
+		} else {
+			setStatus("error");
+			if (error instanceof Error) {
+				handleError(error, span);
+			}
 		}
 		setStreamingAbortController(null);
 	}

--- a/apps/frontend/src/components/chat/chat-form/chat-form.tsx
+++ b/apps/frontend/src/components/chat/chat-form/chat-form.tsx
@@ -153,7 +153,7 @@ export const ChatForm: React.FC = () => {
 								type="button"
 								aria-label={Content["chat.stopGeneratingButton.ariaLabel"]}
 								onClick={() => abortStreaming()}
-								className="rounded-3px size-8 bg-hellblau-50 flex items-center justify-center shrink-0 hover:bg-hellblau-60 focus-visible:outline-2px"
+								className="rounded-3px size-8 bg-hellblau-50 flex items-center justify-center shrink-0 hover:bg-hellblau-110 focus-visible:outline-2px"
 							>
 								<ChatStopGeneratingIcon />
 							</button>

--- a/apps/frontend/src/components/chat/chat-form/chat-form.tsx
+++ b/apps/frontend/src/components/chat/chat-form/chat-form.tsx
@@ -8,6 +8,8 @@ import { useChatScrollingStore } from "../../../store/use-chat-scrolling-store.t
 import { useInferenceLoadingStatusStore } from "../../../store/use-inference-loading-status-store.ts";
 import { SelectedChatItemsCollapsible } from "../selected-chat-items/selected-chat-items-collapsible.tsx";
 import { ArrowWhiteRightIcon } from "../../primitives/icons/arrow-white-right-icon.tsx";
+import { ChatStopGeneratingIcon } from "../../primitives/icons/chat-stop-generating-icon.tsx";
+import { useChatStreamingStore } from "../../../store/use-chat-streaming-store.ts";
 import { useFolderStore } from "../../../store/folder-store.ts";
 import { useDocumentStore } from "../../../store/document-store.ts";
 import Content from "../../../content.ts";
@@ -27,6 +29,7 @@ export const ChatForm: React.FC = () => {
 	const { selectedChatDocuments } = useDocumentStore();
 	const { getCurrentOrCreateChat, selectedChatOptions, toggleChatOption } =
 		useChatsStore();
+	const { abortStreaming } = useChatStreamingStore.getState();
 
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const [textareaContent, setTextareaContent] = useState("");
@@ -76,6 +79,7 @@ export const ChatForm: React.FC = () => {
 			role: "user",
 			content: messageText,
 			citations: null,
+			web_citations: null,
 			allowed_document_ids: selectedChatDocuments.map((doc) => doc.id),
 			allowed_folder_ids: selectedChatFolders.map((folder) => folder.id),
 		};
@@ -144,15 +148,25 @@ export const ChatForm: React.FC = () => {
 					</div>
 					<div className="flex items-center gap-3">
 						<LlmModelToggleButton />
-						<button
-							type="submit"
-							disabled={
-								(isInferenceLoading && !hasError) || !textareaContent.trim()
-							}
-							className={`rounded-3px size-8 bg-dunkelblau-100 disabled:bg-dunkelblau-30 p-1.5 hover:bg-dunkelblau-90 focus-visible:outline-2px`}
-						>
-							<ArrowWhiteRightIcon />
-						</button>
+						{isInferenceLoading && !hasError ? (
+							<button
+								type="button"
+								aria-label={Content["chat.stopGeneratingButton.ariaLabel"]}
+								onClick={() => abortStreaming()}
+								className="rounded-3px size-8 bg-hellblau-50 flex items-center justify-center shrink-0 hover:bg-hellblau-60 focus-visible:outline-2px"
+							>
+								<ChatStopGeneratingIcon />
+							</button>
+						) : (
+							<button
+								type="submit"
+								disabled={!textareaContent.trim()}
+								aria-label={Content["chat.sendButton.ariaLabel"]}
+								className={`rounded-3px size-8 bg-dunkelblau-100 disabled:bg-dunkelblau-30 p-1.5 hover:bg-dunkelblau-90 focus-visible:outline-2px`}
+							>
+								<ArrowWhiteRightIcon />
+							</button>
+						)}
 					</div>
 				</div>
 			</div>

--- a/apps/frontend/src/components/primitives/icons/chat-stop-generating-icon.tsx
+++ b/apps/frontend/src/components/primitives/icons/chat-stop-generating-icon.tsx
@@ -1,0 +1,12 @@
+import Content from "../../../content.ts";
+
+export function ChatStopGeneratingIcon() {
+	return (
+		<img
+			src="/icons/chat-stop-generating-icon.svg"
+			width={32}
+			height={32}
+			alt={Content["chatStopGeneratingIcon.imgAlt"]}
+		/>
+	);
+}

--- a/apps/frontend/src/content.ts
+++ b/apps/frontend/src/content.ts
@@ -874,6 +874,9 @@ export const Content = {
 	"chat.errorIcon.imgAlt": "Ein rotes Ausrufezeichen-Icon",
 
 	"chat.textarea.placeholder": "Stellen Sie eine Frage",
+	"chat.sendButton.ariaLabel": "Nachricht senden",
+	"chat.stopGeneratingButton.ariaLabel": "Textgenerierung stoppen",
+	"chatStopGeneratingIcon.imgAlt": "Generierung stoppen (Pause-Symbol)",
 	"chat.selectedChatItems.document": "Datei in diesem Chat",
 	"chat.selectedChatItems.folder": "Ordner in diesem Chat",
 	"chat.selectedChatItems.items": "Elemente in diesem Chat",

--- a/apps/frontend/tests/e2e/chat.spec.ts
+++ b/apps/frontend/tests/e2e/chat.spec.ts
@@ -1,3 +1,4 @@
+import { Readable } from "node:stream";
 import {
 	mockDocumentUpload,
 	uploadFileViaDragAndDrop,
@@ -49,6 +50,54 @@ test.describe("Chat", () => {
 				navigator.clipboard.readText(),
 			);
 			expect(clipboardText).toBeDefined();
+		},
+	);
+
+	testWithLoggedInUser(
+		"Stop generating aborts stream without error banner",
+		async ({ page }) => {
+			await page.goto("/");
+
+			// Mock the LLM API to return a partial response
+			await page.route("**/llm/just-chatting", async (route) => {
+				const hangingStream = new Readable({
+					read() {},
+				});
+				hangingStream.push(
+					`data: ${JSON.stringify({
+						type: "text-delta",
+						id: "1",
+						delta: "Partial ",
+					})}\n\n`,
+				);
+
+				await route.fulfill({
+					status: 200,
+					headers: {
+						"Content-Type": "text/event-stream; charset=utf-8",
+					},
+					// @ts-expect-error Playwright Node accepts Readable for streaming bodies; public types omit it.
+					body: hangingStream,
+				});
+			});
+
+			await page.getByPlaceholder("Stellen Sie eine Frage").fill("hallo");
+			await page.getByRole("button", { name: "Nachricht senden" }).click();
+
+			const stopButton = page.getByRole("button", {
+				name: "Textgenerierung stoppen",
+			});
+			await expect(stopButton).toBeVisible();
+
+			await stopButton.click();
+
+			await expect(
+				page.getByText("Ihre Anfrage konnte gerade nicht bearbeitet werden."),
+			).not.toBeVisible();
+
+			await expect(
+				page.getByRole("button", { name: "Nachricht senden" }),
+			).toBeVisible();
 		},
 	);
 

--- a/apps/frontend/tests/e2e/chat.spec.ts
+++ b/apps/frontend/tests/e2e/chat.spec.ts
@@ -26,9 +26,7 @@ test.describe("Chat", () => {
 			await page.getByPlaceholder("Stellen Sie eine Frage").fill("hallo");
 
 			// Click the send button
-			await page
-				.getByRole("button", { name: "Ein weißer Pfeil nach rechts" })
-				.click();
+			await page.getByRole("button", { name: "Nachricht senden" }).click();
 
 			// Wait for the AI response with a longer timeout since it involves backend API calls
 			await page.waitForLoadState("networkidle");

--- a/apps/frontend/tests/e2e/chat.spec.ts
+++ b/apps/frontend/tests/e2e/chat.spec.ts
@@ -108,9 +108,7 @@ test.describe("Chat", () => {
 			await page.getByPlaceholder("Stellen Sie eine Frage").fill("**hallo**");
 
 			// Click the send button
-			await page
-				.getByRole("button", { name: "Ein weißer Pfeil nach rechts" })
-				.click();
+			await page.getByRole("button", { name: "Nachricht senden" }).click();
 
 			if (browserName === "webkit") {
 				return;
@@ -165,9 +163,7 @@ test.describe("Chat", () => {
 			.fill("Worum geht es?");
 
 		// Click the send button
-		await page
-			.getByRole("button", { name: "Ein weißer Pfeil nach rechts" })
-			.click();
+		await page.getByRole("button", { name: "Nachricht senden" }).click();
 
 		const question = page.getByTestId("user-message-markdown-container");
 		await expect(question).toBeVisible();
@@ -336,9 +332,7 @@ test.describe("Chat", () => {
 				.fill("Worum geht es?");
 
 			// Click the send button
-			await page
-				.getByRole("button", { name: "Ein weißer Pfeil nach rechts" })
-				.click();
+			await page.getByRole("button", { name: "Nachricht senden" }).click();
 
 			// Wait for the citations button to appear (after stream finishes and citations are loaded)
 			const allCitationsButton = page.getByRole("button", { name: "Quellen" });
@@ -473,9 +467,7 @@ test.describe("Chat", () => {
 				.fill("Worum geht es?");
 
 			// Click the send button
-			await page
-				.getByRole("button", { name: "Ein weißer Pfeil nach rechts" })
-				.click();
+			await page.getByRole("button", { name: "Nachricht senden" }).click();
 
 			// Wait for the citations button to appear (after stream finishes and citations are loaded)
 			const allCitationsButton = page.getByRole("button", { name: "Quellen" });
@@ -523,9 +515,7 @@ test.describe("Chat", () => {
 			await page.getByPlaceholder("Stellen Sie eine Frage").fill("hallo");
 
 			// Click the send button
-			await page
-				.getByRole("button", { name: "Ein weißer Pfeil nach rechts" })
-				.click();
+			await page.getByRole("button", { name: "Nachricht senden" }).click();
 
 			const question = page.getByTestId("user-message-markdown-container");
 			await expect(question).toBeVisible();
@@ -677,9 +667,7 @@ test.describe("Chat", () => {
 			await page.getByPlaceholder("Stellen Sie eine Frage").fill("hallo");
 
 			// Click the send button
-			await page
-				.getByRole("button", { name: "Ein weißer Pfeil nach rechts" })
-				.click();
+			await page.getByRole("button", { name: "Nachricht senden" }).click();
 
 			const question1 = page
 				.getByTestId("user-message-markdown-container")
@@ -706,9 +694,7 @@ test.describe("Chat", () => {
 			await page.getByPlaceholder("Stellen Sie eine Frage").fill("hallo");
 
 			// Click the send button
-			await page
-				.getByRole("button", { name: "Ein weißer Pfeil nach rechts" })
-				.click();
+			await page.getByRole("button", { name: "Nachricht senden" }).click();
 
 			// Wait for the AI response with a longer timeout since it involves backend API calls
 			await page.waitForLoadState("networkidle");
@@ -884,7 +870,7 @@ test.describe("Chat", () => {
 			await chatInput.fill("hallo");
 
 			const sendButton = page.getByRole("button", {
-				name: "Ein weißer Pfeil nach rechts",
+				name: "Nachricht senden",
 			});
 			await sendButton.click();
 
@@ -921,9 +907,7 @@ test.describe("Chat", () => {
 			await page.getByPlaceholder("Stellen Sie eine Frage").fill("hallo");
 
 			// Click the send button
-			await page
-				.getByRole("button", { name: "Ein weißer Pfeil nach rechts" })
-				.click();
+			await page.getByRole("button", { name: "Nachricht senden" }).click();
 
 			await page.waitForLoadState("networkidle");
 

--- a/apps/frontend/tests/e2e/chat.spec.ts
+++ b/apps/frontend/tests/e2e/chat.spec.ts
@@ -55,10 +55,11 @@ test.describe("Chat", () => {
 		"Stop generating aborts stream without error banner",
 		async ({ page }) => {
 			await page.goto("/");
+			let hangingStream: Readable | undefined;
 
 			// Mock the LLM API to return a partial response
 			await page.route("**/llm/just-chatting", async (route) => {
-				const hangingStream = new Readable({
+				hangingStream = new Readable({
 					read() {},
 				});
 				hangingStream.push(
@@ -79,23 +80,28 @@ test.describe("Chat", () => {
 				});
 			});
 
-			await page.getByPlaceholder("Stellen Sie eine Frage").fill("hallo");
-			await page.getByRole("button", { name: "Nachricht senden" }).click();
+			try {
+				await page.getByPlaceholder("Stellen Sie eine Frage").fill("hallo");
+				await page.getByRole("button", { name: "Nachricht senden" }).click();
 
-			const stopButton = page.getByRole("button", {
-				name: "Textgenerierung stoppen",
-			});
-			await expect(stopButton).toBeVisible();
+				const stopButton = page.getByRole("button", {
+					name: "Textgenerierung stoppen",
+				});
+				await expect(stopButton).toBeVisible();
 
-			await stopButton.click();
+				await stopButton.click();
 
-			await expect(
-				page.getByText("Ihre Anfrage konnte gerade nicht bearbeitet werden."),
-			).not.toBeVisible();
+				await expect(
+					page.getByText("Ihre Anfrage konnte gerade nicht bearbeitet werden."),
+				).not.toBeVisible();
 
-			await expect(
-				page.getByRole("button", { name: "Nachricht senden" }),
-			).toBeVisible();
+				await expect(
+					page.getByRole("button", { name: "Nachricht senden" }),
+				).toBeVisible();
+			} finally {
+				await page.unroute("**/llm/just-chatting");
+				hangingStream?.destroy();
+			}
 		},
 	);
 


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211992915035417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "stop generating" control and icon so users can halt active text generation; send control returns afterward.

* **Bug Fixes**
  * Improved error handling so intentional stop actions do not show error banners.

* **Accessibility**
  * Added/updated accessibility labels and icon alt text for chat controls.

* **Tests**
  * Added an end-to-end test verifying stop behavior hides error banners and restores the send control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->