### PR TITLE
Fix user deletion with high document count

### DIFF
--- a/apps/backend/supabase/migrations/20260325120000_fix_delete_user_statement_timeout.sql
+++ b/apps/backend/supabase/migrations/20260325120000_fix_delete_user_statement_timeout.sql
@@ -1,0 +1,14 @@
+-- Fix 57014 timeout in delete_user(): add GIN index on
+-- chat_messages.allowed_document_ids so the per-document trigger update
+-- uses an index scan instead of a full sequential scan.
+-- Also raises delete_user() timeout to 60s as defense in depth.
+CREATE INDEX idx_chat_messages_allowed_document_ids_gin ON public.chat_messages USING gin (allowed_document_ids);
+
+-- The function-level SET overrides PostgREST's session-level 8s timeout.
+CREATE OR REPLACE FUNCTION public.delete_user () RETURNS void LANGUAGE sql SECURITY DEFINER
+SET
+    search_path = ''
+SET
+    statement_timeout TO '60000' AS $$
+    DELETE FROM auth.users WHERE id = auth.uid();
+$$;

--- a/apps/frontend/src/api/auth/delete-user.ts
+++ b/apps/frontend/src/api/auth/delete-user.ts
@@ -5,5 +5,9 @@ export async function deleteUser(): Promise<{ error: Error | null }> {
 	if (!error) {
 		return { error: null };
 	}
-	return { error: new Error("account_deletion_failed") };
+	return {
+		error: new Error("account_deletion_failed", {
+			cause: error,
+		} as ErrorOptions),
+	};
 }

--- a/apps/frontend/src/api/auth/delete-user.ts
+++ b/apps/frontend/src/api/auth/delete-user.ts
@@ -2,5 +2,8 @@ import { supabase } from "../../../supabase-client";
 
 export async function deleteUser(): Promise<{ error: Error | null }> {
 	const { error } = await supabase.rpc("delete_user");
-	return { error };
+	if (!error) {
+		return { error: null };
+	}
+	return { error: new Error("account_deletion_failed") };
 }

--- a/apps/frontend/src/components/profile/delete-account/delete-account-dialog.tsx
+++ b/apps/frontend/src/components/profile/delete-account/delete-account-dialog.tsx
@@ -46,7 +46,10 @@ export const DeleteAccountDialog = () => {
 			return;
 		}
 
-		await deleteAccount();
+		const { error } = await deleteAccount();
+		if (error) {
+			return;
+		}
 
 		navigate("/account-deleted/", { replace: true });
 	};

--- a/apps/frontend/src/store/error-store.ts
+++ b/apps/frontend/src/store/error-store.ts
@@ -47,6 +47,8 @@ const errorMessages: { [key: string]: string } = {
 	no_healthy_llm_available:
 		"Temporär keine Modelle verfügbar. Bitte versuchen Sie es später erneut.",
 	"Token has expired or is invalid": "Code ist abgelaufen oder ungültig.",
+	account_deletion_failed:
+		"Ihr Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut.",
 	document_not_found: "Dokument konnte nicht gelöscht werden.",
 	document_download_failed:
 		Content["documentsPreviewSection.download.failed.error"],

--- a/apps/frontend/src/store/user-store.ts
+++ b/apps/frontend/src/store/user-store.ts
@@ -17,7 +17,7 @@ interface UserStore {
 		academic_title: string;
 		personal_title: string;
 	}) => Promise<void>;
-	deleteAccount: () => Promise<void>;
+	deleteAccount: () => Promise<{ error: Error | null }>;
 	updateAddressedFormal: (isAddressedFormal: boolean) => Promise<void>;
 }
 
@@ -76,19 +76,19 @@ export const useUserStore = create<UserStore>((set, get) => ({
 	deleteAccount: async () => {
 		const session = useAuthStore.getState().session;
 		if (!session) {
-			useErrorStore
-				.getState()
-				.handleError(new Error("No active session found"));
-			return;
+			const error = new Error("account_deletion_failed");
+			useErrorStore.getState().handleError(error);
+			return { error };
 		}
 		const { error } = await deleteUser();
 		if (error) {
 			useErrorStore.getState().handleError(error);
-			return;
+			return { error };
 		}
 		// Clear user data
 		set({ user: null });
 		// Clear session
 		await useAuthStore.getState().logout();
+		return { error: null };
 	},
 }));

--- a/apps/frontend/tests/e2e/user.spec.ts
+++ b/apps/frontend/tests/e2e/user.spec.ts
@@ -2,8 +2,17 @@ import { defaultUserFirstName, defaultUserLastName } from "../constants";
 import { testWithLoggedInUser } from "../fixtures/test-with-logged-in-user";
 import { expect } from "@playwright/test";
 import Content from "../../src/content";
+import { supabaseAdminClient } from "../supabase.ts";
 
 testWithLoggedInUser.describe("User Profile", () => {
+	testWithLoggedInUser.beforeEach(async () => {
+		await supabaseAdminClient
+			.from("maintenance_mode")
+			.upsert(
+				{ onerow_id: true, is_enabled: false },
+				{ onConflict: "onerow_id" },
+			);
+	});
 	testWithLoggedInUser.describe("greeting messages", () => {
 		const testGreeting = (hour: number, expectedContent: string) =>
 			testWithLoggedInUser(
@@ -116,6 +125,44 @@ testWithLoggedInUser.describe("User Profile", () => {
 					name: `Willkommen bei BärGPT, ${defaultUserFirstName} ${defaultUserLastName}`,
 				}),
 			).toBeVisible();
+		},
+	);
+
+	testWithLoggedInUser(
+		"should stay on profile page when account deletion fails",
+		async ({ page, account }) => {
+			await page.goto("/profile/");
+			await page.getByTestId("delete-account-button").click();
+
+			const dialog = page.locator("#delete-account-dialog");
+			await expect(dialog).toBeVisible();
+
+			await page.fill("#currentPasswordValidation", account.password);
+
+			// Set up route interceptor just before submitting — delete_user is
+			// only called on confirm, so setting it up here avoids interfering
+			// with session refresh requests made during page load.
+			await page.route("**/rest/v1/rpc/delete_user", (route) =>
+				route.fulfill({
+					status: 500,
+					contentType: "application/json",
+					body: JSON.stringify({
+						code: "57014",
+						message: "canceling statement due to statement timeout",
+						details: null,
+						hint: null,
+					}),
+				}),
+			);
+
+			// Wait for the delete_user RPC to complete before asserting URL,
+			// otherwise the assertion races with the async navigation.
+			await Promise.all([
+				page.waitForResponse("**/rest/v1/rpc/delete_user"),
+				page.getByTestId("confirm-delete-account-button").click(),
+			]);
+
+			await expect(page).toHaveURL("/profile/");
 		},
 	);
 

--- a/apps/frontend/tests/e2e/user.spec.ts
+++ b/apps/frontend/tests/e2e/user.spec.ts
@@ -2,17 +2,7 @@ import { defaultUserFirstName, defaultUserLastName } from "../constants";
 import { testWithLoggedInUser } from "../fixtures/test-with-logged-in-user";
 import { expect } from "@playwright/test";
 import Content from "../../src/content";
-import { supabaseAdminClient } from "../supabase.ts";
-
 testWithLoggedInUser.describe("User Profile", () => {
-	testWithLoggedInUser.beforeEach(async () => {
-		await supabaseAdminClient
-			.from("maintenance_mode")
-			.upsert(
-				{ onerow_id: true, is_enabled: false },
-				{ onConflict: "onerow_id" },
-			);
-	});
 	testWithLoggedInUser.describe("greeting messages", () => {
 		const testGreeting = (hour: number, expectedContent: string) =>
 			testWithLoggedInUser(

--- a/libs/typescript-config/tsconfig.app.json
+++ b/libs/typescript-config/tsconfig.app.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2022",
 		"useDefineForClassFields": true,
-		"lib": ["ES2021", "DOM", "DOM.Iterable"],
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
 		"module": "ESNext",
 		"types": ["vite/client"],
 		"skipLibCheck": true,


### PR DESCRIPTION
Sentry issue: https://technologiestiftung-berlin.sentry.io/issues/106401994/?environment=production&project=4509684009009232&query=is%3Aunresolved%20delete&referrer=issue-stream

This PR fixes 2 bugs: 
1. Database Timeout: 
`trg_maintain_chat_messages_document_references` fires for each row when a document is deleted and runs:

```
  UPDATE chat_messages
  SET allowed_document_ids = array_remove(allowed_document_ids, OLD.id)
  WHERE allowed_document_ids @> ARRAY[OLD.id]
```
@> requires a full sequential scan of all chat_messages of all users. A user with 100 documents triggers 100 such scans. At 280k+ rows that's 28M row reads total. 

A GIN index should make this much faster. I measured on my local machine with 280k messages, deletion of 100 messages takes 1648ms. With GIN index it takes 122ms. So we are gaining 13x performance. I also tried to find out why its much slower (8+ seconds) on prod and I guess its because of slower storage speed and perhaps because locally its on RAM but measuring these turned out to be a bit of a rabbit hole. I've benchmarked staging to be about 15x slower than my laptop on NVMe writes but prod has a higher performance class so I dont know.

To be safe, I've also included the timeout here to 60 seconds. 

2. When User deletion failed, the frontend would flicker to the `account-deleted` path and then back to the chat window. 

  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account deletion now surfaces a clear error on failure and prevents redirect — users remain on the profile page.
  * Added localized message for account-deletion failures.
  * Improved backend handling to make account-deletion operations more reliable under load.

* **Tests**
  * Added end-to-end test ensuring the app stays on the profile page when account deletion fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213778649793328