### PR TITLE
feat: add frontend logic for web citations

### DIFF
--- a/apps/frontend/src/components/chat/chat-form/chat-form.tsx
+++ b/apps/frontend/src/components/chat/chat-form/chat-form.tsx
@@ -121,7 +121,7 @@ export const ChatForm: React.FC = () => {
 		<form
 			onSubmit={handleSubmit}
 			className={`flex flex-col max-h-[290px] focus-visible:outline-2px hover:outline hover:outline-offset-[-2px] hover:outline-dunkelblau-100 border border-dunkelblau-100 rounded-[3px] 
-				${isWebSearchActive && "border-[2px] focus-visible:outline-3px hover:outline hover:outline-offset-[-1px]"}`}
+				${isWebSearchActive && "border-[2px] bg-hellblau-40 focus-visible:outline-3px hover:outline hover:outline-offset-[-1px]"}`}
 			id={chatFormId}
 		>
 			<SelectedChatItemsCollapsible />
@@ -142,7 +142,7 @@ export const ChatForm: React.FC = () => {
 								`}
 				>
 					<textarea
-						className={`w-full focus:outline-none min-h-6 max-h-44 resize-none overflow-y-auto text-base leading-6 text-dunkelblau-100 placeholder:text-dunkelblau-80`}
+						className={`w-full focus:outline-none min-h-6 max-h-44 resize-none overflow-y-auto text-base leading-6 text-dunkelblau-100 placeholder:text-dunkelblau-80 ${isWebSearchActive && "bg-hellblau-40"}`}
 						ref={textareaRef}
 						name="content"
 						rows={1}

--- a/apps/frontend/src/components/chat/chat-form/chat-form.tsx
+++ b/apps/frontend/src/components/chat/chat-form/chat-form.tsx
@@ -142,7 +142,7 @@ export const ChatForm: React.FC = () => {
 								`}
 				>
 					<textarea
-						className={`w-full focus:outline-none min-h-6 max-h-44 resize-none overflow-y-auto text-base leading-6 text-dunkelblau-100 placeholder:text-dunkelblau-80 ${isWebSearchActive && "bg-hellblau-40"}`}
+						className={`w-full focus:outline-none min-h-6 max-h-44 resize-none overflow-y-auto text-base leading-6 text-dunkelblau-100 placeholder:text-dunkelblau-80`}
 						ref={textareaRef}
 						name="content"
 						rows={1}

--- a/apps/frontend/src/components/chat/chat-message/assistant-message.tsx
+++ b/apps/frontend/src/components/chat/chat-message/assistant-message.tsx
@@ -18,7 +18,7 @@ export function AssistantMessage({
 }) {
 	const { status } = useInferenceLoadingStatusStore();
 	const { getCurrentChat } = useChatsStore();
-	const { content, citations } = message;
+	const { content, citations, web_citations } = message;
 	const { getUIError } = useErrorStore();
 
 	const exportErrorMessage = getUIError("chat-export");
@@ -52,6 +52,7 @@ export function AssistantMessage({
 						<CitationsButton
 							messageId={message.id}
 							citations={citations}
+							webCitations={web_citations}
 							isLastMessage={isLastMessage}
 						/>
 					</div>

--- a/apps/frontend/src/components/chat/chat-message/chat-citations/citations-dialog.tsx
+++ b/apps/frontend/src/components/chat/chat-message/chat-citations/citations-dialog.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import { Content } from "../../../../content";
 import { DefaultDialog } from "../../../primitives/dialogs/default-dialog.tsx";
+import type { WebCitationSource } from "../../../../api/chat/get-completion.ts";
 import { CitationItem } from "./citation-item.tsx";
+import { WebCitationItem } from "./web-citation-item.tsx";
 
 interface CitationsDialogProps {
 	messageId: number | null;
 	citations: number[] | null;
+	webCitations: WebCitationSource[] | null;
 }
 
 export const citationsDialogId = "citations-dialog";
@@ -31,8 +34,14 @@ export function closeCitationsDialog(messageId: number) {
 export const CitationsDialog: React.FC<CitationsDialogProps> = ({
 	messageId,
 	citations,
+	webCitations,
 }) => {
-	if (!messageId || !citations) {
+	const documentChunkIds = citations ?? [];
+	const webCitationSources = webCitations ?? [];
+	const hasDocumentCitations = documentChunkIds.length > 0;
+	const hasWebCitations = webCitationSources.length > 0;
+
+	if (!messageId || (!hasDocumentCitations && !hasWebCitations)) {
 		return null;
 	}
 
@@ -55,9 +64,14 @@ export const CitationsDialog: React.FC<CitationsDialogProps> = ({
 					</button>
 				</div>
 				<div className="flex flex-col px-4 pb-4 overflow-y-auto">
-					{citations.map((citationId, index) => (
-						<CitationItem citationId={citationId} key={index} />
-					))}
+					{hasDocumentCitations &&
+						documentChunkIds.map((chunkId) => (
+							<CitationItem citationId={chunkId} key={chunkId} />
+						))}
+					{hasWebCitations &&
+						webCitationSources.map((source, index) => (
+							<WebCitationItem source={source} key={`${source.url}-${index}`} />
+						))}
 				</div>
 			</div>
 		</DefaultDialog>

--- a/apps/frontend/src/components/chat/chat-message/chat-citations/citations-dialog.tsx
+++ b/apps/frontend/src/components/chat/chat-message/chat-citations/citations-dialog.tsx
@@ -6,7 +6,7 @@ import { CitationItem } from "./citation-item.tsx";
 import { WebCitationItem } from "./web-citation-item.tsx";
 
 interface CitationsDialogProps {
-	messageId: number | null;
+	messageId: number;
 	citations: number[] | null;
 	webCitations: WebCitationSource[] | null;
 }
@@ -38,12 +38,6 @@ export const CitationsDialog: React.FC<CitationsDialogProps> = ({
 }) => {
 	const documentChunkIds = citations ?? [];
 	const webCitationSources = webCitations ?? [];
-	const hasDocumentCitations = documentChunkIds.length > 0;
-	const hasWebCitations = webCitationSources.length > 0;
-
-	if (!messageId || (!hasDocumentCitations && !hasWebCitations)) {
-		return null;
-	}
 
 	return (
 		<DefaultDialog id={`${citationsDialogId}-${messageId}`}>
@@ -64,11 +58,11 @@ export const CitationsDialog: React.FC<CitationsDialogProps> = ({
 					</button>
 				</div>
 				<div className="flex flex-col px-4 pb-4 overflow-y-auto">
-					{hasDocumentCitations &&
+					{documentChunkIds.length > 0 &&
 						documentChunkIds.map((chunkId) => (
 							<CitationItem citationId={chunkId} key={chunkId} />
 						))}
-					{hasWebCitations &&
+					{webCitationSources.length > 0 &&
 						webCitationSources.map((source, index) => (
 							<WebCitationItem source={source} key={`${source.url}-${index}`} />
 						))}

--- a/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
+++ b/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
@@ -1,27 +1,47 @@
+import { useState } from "react";
 import removeMarkdown from "remove-markdown";
 import type { WebCitationSource } from "../../../../api/chat/get-completion.ts";
 import { TruncatedSnippet } from "./truncated-snippet.tsx";
 
+const GLOBE_ICON_SRC = "/icons/web-search-icon.svg";
+
+function faviconUrlForHostname(hostname: string) {
+	return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(hostname)}&sz=32`;
+}
+
 export function WebCitationItem({ source }: { source: WebCitationSource }) {
+	const hostname = new URL(source.url).hostname;
+	const [iconSrc, setIconSrc] = useState(() => faviconUrlForHostname(hostname));
+
 	const handleClick = () => {
 		window.open(source.url, "_blank", "noopener,noreferrer");
 	};
 
-	const date = source.age?.[1] ?? "";
-
-	const text = `${date} ${source.snippet}`;
+	const date = source.age?.[1] ? `${source.age?.[1]} –` : "";
+	const textWithDate = `${date} ${source.snippet}`;
 
 	return (
 		<button
 			type="button"
-			className="group flex flex-col p-3.5 hover:bg-hellblau-30 cursor-pointer gap-1"
+			className="group flex flex-col items-start p-3.5 hover:bg-hellblau-30 text-dunkelblau-200 cursor-pointer gap-2.5"
 			onClick={handleClick}
 		>
+			<div className="flex items-center gap-1 text-xs">
+				<img
+					src={iconSrc}
+					alt=""
+					width={16}
+					height={16}
+					className="size-4 shrink-0"
+					onError={() => setIconSrc(GLOBE_ICON_SRC)}
+				/>
+				{hostname}
+			</div>
 			<div className="flex min-w-0 text-sm font-bold truncate group-hover:underline">
 				{source.title}
 			</div>
-			<div className="relative flex text-sm leading-5 group-hover:underline text-dunkelblau-200 h-10">
-				<TruncatedSnippet text={removeMarkdown(text)} lines={2} />
+			<div className="relative flex text-sm leading-5 group-hover:underline h-10">
+				<TruncatedSnippet text={removeMarkdown(textWithDate)} lines={2} />
 			</div>
 		</button>
 	);

--- a/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
+++ b/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
@@ -1,0 +1,28 @@
+import removeMarkdown from "remove-markdown";
+import type { WebCitationSource } from "../../../../api/chat/get-completion.ts";
+import { TruncatedSnippet } from "./truncated-snippet.tsx";
+
+export function WebCitationItem({ source }: { source: WebCitationSource }) {
+	const handleClick = () => {
+		window.open(source.url, "_blank", "noopener,noreferrer");
+	};
+
+	const date = source.age?.[1] ?? "";
+
+	const text = `${date} ${source.snippet}`;
+
+	return (
+		<button
+			type="button"
+			className="group flex flex-col p-3.5 hover:bg-hellblau-30 cursor-pointer gap-1"
+			onClick={handleClick}
+		>
+			<div className="flex min-w-0 text-sm font-bold truncate group-hover:underline">
+				{source.title}
+			</div>
+			<div className="relative flex text-sm leading-5 group-hover:underline text-dunkelblau-200 h-10">
+				<TruncatedSnippet text={removeMarkdown(text)} lines={2} />
+			</div>
+		</button>
+	);
+}

--- a/apps/frontend/src/components/chat/chat-message/citations-button.tsx
+++ b/apps/frontend/src/components/chat/chat-message/citations-button.tsx
@@ -9,16 +9,19 @@ import { useInferenceLoadingStatusStore } from "../../../store/use-inference-loa
 import { LoadingSpinnerIcon } from "../../primitives/icons/loading-spinner-icon.tsx";
 import { useCitationsStore } from "../../../store/use-citations-store.ts";
 import type { CitationWithDetails } from "../../../common.ts";
+import type { WebCitationSource } from "../../../api/chat/get-completion.ts";
 
 interface CitationsButtonProps {
 	messageId: number;
 	citations: number[] | null;
+	webCitations: WebCitationSource[] | null;
 	isLastMessage: boolean;
 }
 
 export const CitationsButton: React.FC<CitationsButtonProps> = ({
 	messageId,
 	citations,
+	webCitations,
 	isLastMessage,
 }) => {
 	const { status } = useInferenceLoadingStatusStore();
@@ -26,12 +29,14 @@ export const CitationsButton: React.FC<CitationsButtonProps> = ({
 	const isLoadingLastCitations = isLastMessage && isLoadingCitations;
 
 	const { getCitation } = useCitationsStore();
-	const hasCitations =
+	const hasWebCitations = Boolean(webCitations && webCitations.length > 0);
+	const hasChunkCitations =
 		citations &&
 		citations.length > 0 &&
 		checkCitationsExists(citations, getCitation);
 
-	const isCitationsButtonVisible = hasCitations || isLoadingLastCitations;
+	const isCitationsButtonVisible =
+		hasChunkCitations || hasWebCitations || isLoadingLastCitations;
 
 	if (!isCitationsButtonVisible) {
 		return null;
@@ -69,7 +74,11 @@ export const CitationsButton: React.FC<CitationsButtonProps> = ({
 					</>
 				)}
 			</ChatButton>
-			<CitationsDialog messageId={messageId} citations={citations} />
+			<CitationsDialog
+				messageId={messageId}
+				citations={citations}
+				webCitations={webCitations}
+			/>
 		</>
 	);
 };

--- a/apps/frontend/src/components/chat/chat-message/citations-button.tsx
+++ b/apps/frontend/src/components/chat/chat-message/citations-button.tsx
@@ -28,15 +28,15 @@ export const CitationsButton: React.FC<CitationsButtonProps> = ({
 	const isLoadingCitations = status === "loading-citations";
 	const isLoadingLastCitations = isLastMessage && isLoadingCitations;
 
-	const { getCitation } = useCitationsStore();
 	const hasWebCitations = Boolean(webCitations && webCitations.length > 0);
-	const hasChunkCitations =
+	const { getCitation } = useCitationsStore();
+	const hasDocumentCitations =
 		citations &&
 		citations.length > 0 &&
 		checkCitationsExists(citations, getCitation);
 
 	const isCitationsButtonVisible =
-		hasChunkCitations || hasWebCitations || isLoadingLastCitations;
+		hasDocumentCitations || hasWebCitations || isLoadingLastCitations;
 
 	if (!isCitationsButtonVisible) {
 		return null;
@@ -74,11 +74,13 @@ export const CitationsButton: React.FC<CitationsButtonProps> = ({
 					</>
 				)}
 			</ChatButton>
-			<CitationsDialog
-				messageId={messageId}
-				citations={citations}
-				webCitations={webCitations}
-			/>
+			{(hasDocumentCitations || hasWebCitations) && (
+				<CitationsDialog
+					messageId={messageId}
+					citations={citations}
+					webCitations={webCitations}
+				/>
+			)}
 		</>
 	);
 };

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -31,7 +31,6 @@ export default {
 				"hellblau-60": "#D1DFF0",
 				"hellblau-50": "#E1EAF5",
 				"hellblau-55": "#D9E4F2",
-				"hellblau-40": "#EBF1F9",
 				"hellblau-30": "#F5F8FC",
 				"aktiv-blau-100": "#0D5DBF",
 			},

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -31,6 +31,7 @@ export default {
 				"hellblau-60": "#D1DFF0",
 				"hellblau-50": "#E1EAF5",
 				"hellblau-55": "#D9E4F2",
+				"hellblau-40": "#EBF1F9",
 				"hellblau-30": "#F5F8FC",
 				"aktiv-blau-100": "#0D5DBF",
 			},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web citations are now shown alongside document citations in chat: favicons, site, title and snippet with one-click open in a new tab.

* **Improvements**
  * Citations control now appears only when document or web citations exist; dialog lists sections only when content is present. Favicons gracefully fall back if unavailable.

* **Tests**
  * E2E test updated to wait for the chat response endpoint before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214415609362335