### PR TITLE
feat: render-monitoring stack

### DIFF
--- a/infra/render-log-shipper/Dockerfile
+++ b/infra/render-log-shipper/Dockerfile
@@ -1,8 +1,9 @@
 FROM --platform=linux/amd64 node:22-alpine
 
 WORKDIR /app
-COPY package.json index.js ./
+COPY package.json index.ts ./
+RUN npm install --omit=dev --ignore-scripts
 
 USER node
 
-CMD ["node", "index.js"]
+CMD ["npx", "tsx", "index.ts"]

--- a/infra/render-log-shipper/Dockerfile
+++ b/infra/render-log-shipper/Dockerfile
@@ -1,0 +1,8 @@
+FROM --platform=linux/amd64 node:22-alpine
+
+WORKDIR /app
+COPY package.json index.js ./
+
+USER node
+
+CMD ["node", "index.js"]

--- a/infra/render-log-shipper/Dockerfile
+++ b/infra/render-log-shipper/Dockerfile
@@ -1,8 +1,9 @@
 FROM --platform=linux/amd64 node:22-alpine
 
 WORKDIR /app
-COPY package.json index.ts ./
-RUN npm install --omit=dev --ignore-scripts
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
+COPY index.ts ./
 
 USER node
 

--- a/infra/render-log-shipper/README.md
+++ b/infra/render-log-shipper/README.md
@@ -1,0 +1,42 @@
+# Render Log Shipper
+
+Polls Render's REST API for logs from specified services and pushes them to STACKIT Observability's Loki endpoint.
+
+## Deploy on Render
+
+1. Create a new **Background Worker** on Render (not a web service — this has no inbound traffic).
+2. Point it at this repo, set the root directory to `infra/render-log-shipper`.
+3. Set the following environment variables:
+
+| Variable | Value | Notes |
+|----------|-------|-------|
+| `RENDER_API_KEY` | Render API key | Create at Account Settings → API Keys |
+| `RENDER_OWNER_ID` | Your workspace/owner ID | Found in workspace settings URL |
+| `RENDER_RESOURCE_IDS` | Comma-separated service IDs | e.g. `srv-abc123,srv-def456` |
+| `LOKI_PUSH_URL` | STACKIT Loki Ingest URL | The "Ingest" endpoint from your Observability instance |
+| `LOKI_USERNAME` | STACKIT Observability username | From Observability credentials |
+| `LOKI_PASSWORD` | STACKIT Observability password | From Observability credentials |
+| `POLL_INTERVAL_SECONDS` | `60` | How often to poll (default: 60) |
+
+4. Deploy.
+
+## Finding service IDs
+
+Service IDs look like `srv-xxxxxxxxxxxxxxxx`. You can find them in the Render dashboard URL when viewing a service, or via the Render API:
+
+```bash
+curl -H "Authorization: Bearer $RENDER_API_KEY" https://api.render.com/v1/services?ownerId=$RENDER_OWNER_ID
+```
+
+## Verify
+
+Check the worker's logs in the Render dashboard — you should see "Pushed N log entries to Loki" messages.
+
+In STACKIT Grafana → Explore → Loki data source → search for `{source="render"}`.
+
+## Security
+
+- **No inbound attack surface** — background workers accept no incoming traffic
+- **Credentials** — stored as Render env vars, never in code
+- **Scope** — only fetches logs for the explicitly listed service IDs
+- **Render API key** — has workspace-wide read access; store securely

--- a/infra/render-log-shipper/README.md
+++ b/infra/render-log-shipper/README.md
@@ -8,15 +8,15 @@ Polls Render's REST API for logs from specified services and pushes them to STAC
 2. Point it at this repo, set the root directory to `infra/render-log-shipper`.
 3. Set the following environment variables:
 
-| Variable | Value | Notes |
-|----------|-------|-------|
-| `RENDER_API_KEY` | Render API key | Create at Account Settings → API Keys |
-| `RENDER_OWNER_ID` | Your workspace/owner ID | Found in workspace settings URL |
-| `RENDER_RESOURCE_IDS` | Comma-separated service IDs | e.g. `srv-abc123,srv-def456` |
-| `LOKI_PUSH_URL` | STACKIT Loki Ingest URL | The "Ingest" endpoint from your Observability instance |
-| `LOKI_USERNAME` | STACKIT Observability username | From Observability credentials |
-| `LOKI_PASSWORD` | STACKIT Observability password | From Observability credentials |
-| `POLL_INTERVAL_SECONDS` | `60` | How often to poll (default: 60) |
+| Variable                | Value                          | Notes                                                  |
+| ----------------------- | ------------------------------ | ------------------------------------------------------ |
+| `RENDER_API_KEY`        | Render API key                 | Create at Account Settings → API Keys                  |
+| `RENDER_OWNER_ID`       | Your workspace/owner ID        | Found in workspace settings URL                        |
+| `RENDER_RESOURCE_IDS`   | Comma-separated service IDs    | e.g. `srv-abc123,srv-def456`                           |
+| `LOKI_PUSH_URL`         | STACKIT Loki Ingest URL        | The "Ingest" endpoint from your Observability instance |
+| `LOKI_USERNAME`         | STACKIT Observability username | From Observability credentials                         |
+| `LOKI_PASSWORD`         | STACKIT Observability password | From Observability credentials                         |
+| `POLL_INTERVAL_SECONDS` | `60`                           | How often to poll (default: 60)                        |
 
 4. Deploy.
 

--- a/infra/render-log-shipper/index.js
+++ b/infra/render-log-shipper/index.js
@@ -34,14 +34,12 @@ for (const key of requiredEnv) {
 
 const RENDER_API_KEY = process.env.RENDER_API_KEY;
 const RENDER_OWNER_ID = process.env.RENDER_OWNER_ID;
-const RESOURCE_IDS = process.env.RENDER_RESOURCE_IDS.split(",").map((s) =>
-	s.trim(),
-);
+const RESOURCE_IDS = process.env.RENDER_RESOURCE_IDS.split(",")
+	.map((s) => s.trim())
+	.filter(Boolean);
 const LOKI_PUSH_URL = process.env.LOKI_PUSH_URL;
-if (
-	!LOKI_PUSH_URL.startsWith("https://") ||
-	!LOKI_PUSH_URL.includes("stackit.cloud")
-) {
+const lokiHost = new URL(LOKI_PUSH_URL).hostname;
+if (!lokiHost.endsWith(".stackit.cloud")) {
 	console.error(
 		"LOKI_PUSH_URL must be an HTTPS endpoint on stackit.cloud",
 	);
@@ -86,7 +84,6 @@ async function fetchLogs() {
 	const data = await response.json();
 	const logs = data.logs || [];
 
-	// Paginate if there are more results
 	let allLogs = [...logs];
 	let hasMore = data.hasMore;
 	let nextStart = data.nextStartTime;
@@ -113,13 +110,22 @@ async function fetchLogs() {
 			},
 		);
 
-		if (!pageResponse.ok) break;
+		if (!pageResponse.ok) {
+			console.warn(
+				`Pagination request failed: ${pageResponse.status}, stopping pagination`,
+			);
+			break;
+		}
 
 		const pageData = await pageResponse.json();
 		allLogs = allLogs.concat(pageData.logs || []);
 		hasMore = pageData.hasMore;
 		nextStart = pageData.nextStartTime;
 		nextEnd = pageData.nextEndTime;
+	}
+
+	if (hasMore) {
+		console.warn(`Hit MAX_PAGES (${MAX_PAGES}), some logs may be deferred to next cycle`);
 	}
 
 	return allLogs;
@@ -134,7 +140,6 @@ function labelsFromLog(log) {
 }
 
 function toLokiPayload(logs) {
-	// Group logs by their label set (Loki requires one stream per unique label combo)
 	const streams = new Map();
 
 	for (const log of logs) {
@@ -145,8 +150,8 @@ function toLokiPayload(logs) {
 			streams.set(key, { stream: labels, values: [] });
 		}
 
-		// Loki expects [timestamp_ns_string, log_line]
-		const tsNanos = String(new Date(log.timestamp).getTime() * 1_000_000);
+		// String concatenation avoids Number overflow (ms * 1e6 > MAX_SAFE_INTEGER)
+		const tsNanos = String(new Date(log.timestamp).getTime()) + "000000";
 		streams.get(key).values.push([tsNanos, log.message]);
 	}
 
@@ -172,31 +177,36 @@ async function pushToLoki(logs) {
 
 	if (!response.ok) {
 		const body = await response.text();
-		console.error(`Loki push failed: ${response.status} ${body}`);
-	} else {
-		console.log(`Pushed ${logs.length} log entries to Loki`);
+		throw new Error(`Loki push failed: ${response.status} ${body}`);
 	}
+
+	console.log(`Pushed ${logs.length} log entries to Loki`);
 }
 
 async function poll() {
 	try {
 		const logs = await fetchLogs();
+		if (logs.length === 0) return;
+
 		await pushToLoki(logs);
 
-		if (logs.length > 0) {
-			// Advance the cursor to the latest log timestamp + 1ms to avoid duplicates
-			const latestTs = logs[logs.length - 1].timestamp;
-			lastPollTime = new Date(
-				new Date(latestTs).getTime() + 1,
-			).toISOString();
-		}
+		// Only advance cursor after successful push
+		const latestTs = logs.reduce(
+			(max, log) => Math.max(max, new Date(log.timestamp).getTime()),
+			0,
+		);
+		lastPollTime = new Date(latestTs + 1).toISOString();
 	} catch (err) {
 		console.error("Poll cycle failed:", err.message);
 	}
 }
 
+async function loop() {
+	await poll();
+	setTimeout(loop, POLL_INTERVAL_MS);
+}
+
 console.log(
 	`Starting log shipper: polling every ${POLL_INTERVAL_MS / 1000}s for ${RESOURCE_IDS.length} services`,
 );
-poll();
-setInterval(poll, POLL_INTERVAL_MS);
+loop();

--- a/infra/render-log-shipper/index.js
+++ b/infra/render-log-shipper/index.js
@@ -1,0 +1,190 @@
+/**
+ * Render Log Shipper
+ *
+ * Polls Render's REST API for logs from specified services
+ * and pushes them to STACKIT Observability's Loki endpoint.
+ *
+ * Environment variables:
+ *   RENDER_API_KEY          - Render API key (Bearer token)
+ *   RENDER_OWNER_ID         - Render workspace/owner ID
+ *   RENDER_RESOURCE_IDS     - Comma-separated list of Render service IDs to collect logs from
+ *   LOKI_PUSH_URL           - STACKIT Loki push endpoint (e.g. https://logs.stackitXX.argus.eu01.stackit.cloud/instances/.../loki/api/v1/push)
+ *   LOKI_USERNAME           - STACKIT Observability username
+ *   LOKI_PASSWORD           - STACKIT Observability password
+ *   POLL_INTERVAL_SECONDS   - How often to poll (default: 60)
+ */
+
+const RENDER_API_BASE = "https://api.render.com/v1";
+
+const requiredEnv = [
+	"RENDER_API_KEY",
+	"RENDER_OWNER_ID",
+	"RENDER_RESOURCE_IDS",
+	"LOKI_PUSH_URL",
+	"LOKI_USERNAME",
+	"LOKI_PASSWORD",
+];
+
+for (const key of requiredEnv) {
+	if (!process.env[key]) {
+		console.error(`Missing required environment variable: ${key}`);
+		process.exit(1);
+	}
+}
+
+const RENDER_API_KEY = process.env.RENDER_API_KEY;
+const RENDER_OWNER_ID = process.env.RENDER_OWNER_ID;
+const RESOURCE_IDS = process.env.RENDER_RESOURCE_IDS.split(",").map((s) =>
+	s.trim(),
+);
+const LOKI_PUSH_URL = process.env.LOKI_PUSH_URL;
+const LOKI_USERNAME = process.env.LOKI_USERNAME;
+const LOKI_PASSWORD = process.env.LOKI_PASSWORD;
+const POLL_INTERVAL_MS =
+	(parseInt(process.env.POLL_INTERVAL_SECONDS, 10) || 60) * 1000;
+
+let lastPollTime = new Date(Date.now() - POLL_INTERVAL_MS).toISOString();
+
+async function fetchLogs() {
+	const params = new URLSearchParams();
+	params.set("ownerId", RENDER_OWNER_ID);
+	params.set("startTime", lastPollTime);
+	params.set("endTime", new Date().toISOString());
+	params.set("direction", "forward");
+	params.set("limit", "100");
+
+	for (const id of RESOURCE_IDS) {
+		params.append("resource", id);
+	}
+
+	const url = `${RENDER_API_BASE}/logs?${params}`;
+	const response = await fetch(url, {
+		headers: { Authorization: `Bearer ${RENDER_API_KEY}` },
+	});
+
+	if (response.status === 429) {
+		console.warn("Rate limited by Render API, will retry next cycle");
+		return [];
+	}
+
+	if (!response.ok) {
+		console.error(
+			`Render API error: ${response.status} ${response.statusText}`,
+		);
+		return [];
+	}
+
+	const data = await response.json();
+	const logs = data.logs || [];
+
+	// Paginate if there are more results
+	let allLogs = [...logs];
+	let hasMore = data.hasMore;
+	let nextStart = data.nextStartTime;
+	let nextEnd = data.nextEndTime;
+
+	while (hasMore) {
+		const pageParams = new URLSearchParams();
+		pageParams.set("ownerId", RENDER_OWNER_ID);
+		pageParams.set("startTime", nextStart);
+		pageParams.set("endTime", nextEnd);
+		pageParams.set("direction", "forward");
+		pageParams.set("limit", "100");
+		for (const id of RESOURCE_IDS) {
+			pageParams.append("resource", id);
+		}
+
+		const pageResponse = await fetch(
+			`${RENDER_API_BASE}/logs?${pageParams}`,
+			{
+				headers: { Authorization: `Bearer ${RENDER_API_KEY}` },
+			},
+		);
+
+		if (!pageResponse.ok) break;
+
+		const pageData = await pageResponse.json();
+		allLogs = allLogs.concat(pageData.logs || []);
+		hasMore = pageData.hasMore;
+		nextStart = pageData.nextStartTime;
+		nextEnd = pageData.nextEndTime;
+	}
+
+	return allLogs;
+}
+
+function labelsFromLog(log) {
+	const labels = { source: "render" };
+	for (const label of log.labels || []) {
+		labels[label.name] = label.value;
+	}
+	return labels;
+}
+
+function toLokiPayload(logs) {
+	// Group logs by their label set (Loki requires one stream per unique label combo)
+	const streams = new Map();
+
+	for (const log of logs) {
+		const labels = labelsFromLog(log);
+		const key = JSON.stringify(labels, Object.keys(labels).sort());
+
+		if (!streams.has(key)) {
+			streams.set(key, { stream: labels, values: [] });
+		}
+
+		// Loki expects [timestamp_ns_string, log_line]
+		const tsNanos = String(new Date(log.timestamp).getTime() * 1_000_000);
+		streams.get(key).values.push([tsNanos, log.message]);
+	}
+
+	return { streams: Array.from(streams.values()) };
+}
+
+async function pushToLoki(logs) {
+	if (logs.length === 0) return;
+
+	const payload = toLokiPayload(logs);
+	const auth = Buffer.from(`${LOKI_USERNAME}:${LOKI_PASSWORD}`).toString(
+		"base64",
+	);
+
+	const response = await fetch(LOKI_PUSH_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Basic ${auth}`,
+		},
+		body: JSON.stringify(payload),
+	});
+
+	if (!response.ok) {
+		const body = await response.text();
+		console.error(`Loki push failed: ${response.status} ${body}`);
+	} else {
+		console.log(`Pushed ${logs.length} log entries to Loki`);
+	}
+}
+
+async function poll() {
+	try {
+		const logs = await fetchLogs();
+		await pushToLoki(logs);
+
+		if (logs.length > 0) {
+			// Advance the cursor to the latest log timestamp + 1ms to avoid duplicates
+			const latestTs = logs[logs.length - 1].timestamp;
+			lastPollTime = new Date(
+				new Date(latestTs).getTime() + 1,
+			).toISOString();
+		}
+	} catch (err) {
+		console.error("Poll cycle failed:", err.message);
+	}
+}
+
+console.log(
+	`Starting log shipper: polling every ${POLL_INTERVAL_MS / 1000}s for ${RESOURCE_IDS.length} services`,
+);
+poll();
+setInterval(poll, POLL_INTERVAL_MS);

--- a/infra/render-log-shipper/index.js
+++ b/infra/render-log-shipper/index.js
@@ -4,19 +4,17 @@
  * Polls Render's REST API for logs from specified services
  * and pushes them to STACKIT Observability's Loki endpoint.
  *
- * Environment variables:
- *   RENDER_API_KEY          - Render API key (Bearer token)
- *   RENDER_OWNER_ID         - Render workspace/owner ID
- *   RENDER_RESOURCE_IDS     - Comma-separated list of Render service IDs to collect logs from
- *   LOKI_PUSH_URL           - STACKIT Loki push endpoint (e.g. https://logs.stackitXX.argus.eu01.stackit.cloud/instances/.../loki/api/v1/push)
- *   LOKI_USERNAME           - STACKIT Observability username
- *   LOKI_PASSWORD           - STACKIT Observability password
- *   POLL_INTERVAL_SECONDS   - How often to poll (default: 60)
+ * Env vars: RENDER_API_KEY, RENDER_OWNER_ID, RENDER_RESOURCE_IDS,
+ *           LOKI_PUSH_URL, LOKI_USERNAME, LOKI_PASSWORD, POLL_INTERVAL_SECONDS
  */
 
-const RENDER_API_BASE = "https://api.render.com/v1";
+const RENDER_LOGS_URL = "https://api.render.com/v1/logs";
+const MAX_PAGES = 10;
+const LOGS_PER_PAGE = "100";
+const NANOSECOND_SUFFIX = "000000";
+const CURSOR_ADVANCE_MS = 1;
 
-const requiredEnv = [
+const REQUIRED_ENV = [
 	"RENDER_API_KEY",
 	"RENDER_OWNER_ID",
 	"RENDER_RESOURCE_IDS",
@@ -25,154 +23,132 @@ const requiredEnv = [
 	"LOKI_PASSWORD",
 ];
 
-for (const key of requiredEnv) {
+for (const key of REQUIRED_ENV) {
 	if (!process.env[key]) {
-		console.error(`Missing required environment variable: ${key}`);
+		console.error(`Missing required env var: ${key}`);
 		process.exit(1);
 	}
 }
 
-const RENDER_API_KEY = process.env.RENDER_API_KEY;
-const RENDER_OWNER_ID = process.env.RENDER_OWNER_ID;
-const RESOURCE_IDS = process.env.RENDER_RESOURCE_IDS.split(",")
-	.map((s) => s.trim())
-	.filter(Boolean);
-const LOKI_PUSH_URL = process.env.LOKI_PUSH_URL;
-const lokiHost = new URL(LOKI_PUSH_URL).hostname;
-if (!lokiHost.endsWith(".stackit.cloud")) {
-	console.error(
-		"LOKI_PUSH_URL must be an HTTPS endpoint on stackit.cloud",
-	);
+const {
+	RENDER_API_KEY,
+	RENDER_OWNER_ID,
+	RENDER_RESOURCE_IDS,
+	LOKI_PUSH_URL,
+	LOKI_USERNAME,
+	LOKI_PASSWORD,
+} = process.env;
+
+if (!new URL(LOKI_PUSH_URL).hostname.endsWith(".stackit.cloud")) {
+	console.error("LOKI_PUSH_URL must be an HTTPS endpoint on stackit.cloud");
 	process.exit(1);
 }
-const LOKI_USERNAME = process.env.LOKI_USERNAME;
-const LOKI_PASSWORD = process.env.LOKI_PASSWORD;
-const POLL_INTERVAL_MS =
+
+const resourceIds = RENDER_RESOURCE_IDS.split(",")
+	.map((id) => id.trim())
+	.filter(Boolean); // remove empty strings
+
+const pollIntervalMs =
 	(parseInt(process.env.POLL_INTERVAL_SECONDS, 10) || 60) * 1000;
 
-let lastPollTime = new Date(Date.now() - POLL_INTERVAL_MS).toISOString();
+const lokiAuth =
+	"Basic " +
+	Buffer.from(`${LOKI_USERNAME}:${LOKI_PASSWORD}`).toString("base64");
 
-async function fetchLogs() {
-	const params = new URLSearchParams();
-	params.set("ownerId", RENDER_OWNER_ID);
-	params.set("startTime", lastPollTime);
-	params.set("endTime", new Date().toISOString());
-	params.set("direction", "forward");
-	params.set("limit", "100");
+let lastPollTime = new Date(Date.now() - pollIntervalMs).toISOString();
 
-	for (const id of RESOURCE_IDS) {
+function buildLogParams(startTime, endTime) {
+	const params = new URLSearchParams({
+		ownerId: RENDER_OWNER_ID,
+		startTime,
+		endTime,
+		direction: "forward",
+		limit: LOGS_PER_PAGE,
+	});
+	for (const id of resourceIds) {
 		params.append("resource", id);
 	}
+	return params;
+}
 
-	const url = `${RENDER_API_BASE}/logs?${params}`;
-	const response = await fetch(url, {
-		headers: { Authorization: `Bearer ${RENDER_API_KEY}` },
-	});
+async function fetchRenderLogs(startTime, endTime) {
+	const response = await fetch(
+		`${RENDER_LOGS_URL}?${buildLogParams(startTime, endTime)}`,
+		{ headers: { Authorization: `Bearer ${RENDER_API_KEY}` } },
+	);
 
 	if (response.status === 429) {
-		console.warn("Rate limited by Render API, will retry next cycle");
-		return [];
+		console.warn("Rate limited by Render API, retrying next cycle");
+		return { logs: [], hasMore: false };
 	}
 
 	if (!response.ok) {
 		console.error(
-			`Render API error: ${response.status} ${response.statusText}`,
+			`Render API error (${startTime}–${endTime}): ${response.status} ${response.statusText}`,
 		);
-		return [];
+		return { logs: [], hasMore: false };
 	}
 
-	const data = await response.json();
-	const logs = data.logs || [];
+	return await response.json();
+}
 
-	let allLogs = [...logs];
-	let hasMore = data.hasMore;
-	let nextStart = data.nextStartTime;
-	let nextEnd = data.nextEndTime;
+async function fetchAllLogs() {
+	const firstPage = await fetchRenderLogs(
+		lastPollTime,
+		new Date().toISOString(),
+	);
+	const allLogs = [...(firstPage.logs || [])];
 
-	const MAX_PAGES = 10;
-	let page = 0;
-	while (hasMore && page < MAX_PAGES) {
-		page++;
-		const pageParams = new URLSearchParams();
-		pageParams.set("ownerId", RENDER_OWNER_ID);
-		pageParams.set("startTime", nextStart);
-		pageParams.set("endTime", nextEnd);
-		pageParams.set("direction", "forward");
-		pageParams.set("limit", "100");
-		for (const id of RESOURCE_IDS) {
-			pageParams.append("resource", id);
-		}
+	let { hasMore, nextStartTime, nextEndTime } = firstPage;
 
-		const pageResponse = await fetch(
-			`${RENDER_API_BASE}/logs?${pageParams}`,
-			{
-				headers: { Authorization: `Bearer ${RENDER_API_KEY}` },
-			},
-		);
+	for (let page = 0; hasMore && page < MAX_PAGES; page++) {
+		const nextPage = await fetchRenderLogs(nextStartTime, nextEndTime);
 
-		if (!pageResponse.ok) {
-			console.warn(
-				`Pagination request failed: ${pageResponse.status}, stopping pagination`,
-			);
-			break;
-		}
-
-		const pageData = await pageResponse.json();
-		allLogs = allLogs.concat(pageData.logs || []);
-		hasMore = pageData.hasMore;
-		nextStart = pageData.nextStartTime;
-		nextEnd = pageData.nextEndTime;
+		allLogs.push(...(nextPage.logs || []));
+		hasMore = nextPage.hasMore;
+		nextStartTime = nextPage.nextStartTime;
+		nextEndTime = nextPage.nextEndTime;
 	}
 
 	if (hasMore) {
-		console.warn(`Hit MAX_PAGES (${MAX_PAGES}), some logs may be deferred to next cycle`);
+		console.warn(
+			`Hit MAX_PAGES (${MAX_PAGES}), remaining logs deferred to next cycle`,
+		);
 	}
 
 	return allLogs;
-}
-
-function labelsFromLog(log) {
-	const labels = { source: "render" };
-	for (const label of log.labels || []) {
-		labels[label.name] = label.value;
-	}
-	return labels;
 }
 
 function toLokiPayload(logs) {
 	const streams = new Map();
 
 	for (const log of logs) {
-		const labels = labelsFromLog(log);
-		const key = JSON.stringify(labels, Object.keys(labels).sort());
+		const labels = { source: "render" };
+		for (const label of log.labels || []) {
+			labels[label.name] = label.value;
+		}
 
+		const key = JSON.stringify(labels, Object.keys(labels).sort());
 		if (!streams.has(key)) {
 			streams.set(key, { stream: labels, values: [] });
 		}
 
-		// String concatenation avoids Number overflow (ms * 1e6 > MAX_SAFE_INTEGER)
-		const tsNanos = String(new Date(log.timestamp).getTime()) + "000000";
-		streams.get(key).values.push([tsNanos, log.message]);
+		const timestampNanos =
+			String(new Date(log.timestamp).getTime()) + NANOSECOND_SUFFIX;
+		streams.get(key).values.push([timestampNanos, log.message]);
 	}
 
 	return { streams: Array.from(streams.values()) };
 }
 
 async function pushToLoki(logs) {
-	if (logs.length === 0) return;
-
-	const payload = toLokiPayload(logs);
-	const auth = Buffer.from(`${LOKI_USERNAME}:${LOKI_PASSWORD}`).toString(
-		"base64",
-	);
-
 	const response = await fetch(LOKI_PUSH_URL, {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
-			Authorization: `Basic ${auth}`,
+			Authorization: lokiAuth,
 		},
-		body: JSON.stringify(payload),
+		body: JSON.stringify(toLokiPayload(logs)),
 	});
 
 	if (!response.ok) {
@@ -183,30 +159,34 @@ async function pushToLoki(logs) {
 	console.log(`Pushed ${logs.length} log entries to Loki`);
 }
 
+function getLatestTimestamp(logs) {
+	return logs.reduce(
+		(max, log) => Math.max(max, new Date(log.timestamp).getTime()),
+		0,
+	);
+}
+
 async function poll() {
 	try {
-		const logs = await fetchLogs();
+		const logs = await fetchAllLogs();
 		if (logs.length === 0) return;
 
 		await pushToLoki(logs);
 
-		// Only advance cursor after successful push
-		const latestTs = logs.reduce(
-			(max, log) => Math.max(max, new Date(log.timestamp).getTime()),
-			0,
-		);
-		lastPollTime = new Date(latestTs + 1).toISOString();
-	} catch (err) {
-		console.error("Poll cycle failed:", err.message);
+		lastPollTime = new Date(
+			getLatestTimestamp(logs) + CURSOR_ADVANCE_MS,
+		).toISOString();
+	} catch (error) {
+		console.error("Poll cycle failed:", error.message);
 	}
 }
 
-async function loop() {
+async function startPolling() {
 	await poll();
-	setTimeout(loop, POLL_INTERVAL_MS);
+	setTimeout(startPolling, pollIntervalMs);
 }
 
 console.log(
-	`Starting log shipper: polling every ${POLL_INTERVAL_MS / 1000}s for ${RESOURCE_IDS.length} services`,
+	`Log shipper: polling every ${pollIntervalMs / 1000}s for ${resourceIds.length} services`,
 );
-loop();
+startPolling();

--- a/infra/render-log-shipper/index.js
+++ b/infra/render-log-shipper/index.js
@@ -13,6 +13,7 @@ const MAX_PAGES = 10;
 const LOGS_PER_PAGE = "100";
 const NANOSECOND_SUFFIX = "000000";
 const CURSOR_ADVANCE_MS = 1;
+const REQUEST_TIMEOUT_MS = 30_000;
 
 const REQUIRED_ENV = [
 	"RENDER_API_KEY",
@@ -39,7 +40,18 @@ const {
 	LOKI_PASSWORD,
 } = process.env;
 
-if (!new URL(LOKI_PUSH_URL).hostname.endsWith(".stackit.cloud")) {
+let lokiUrl;
+try {
+	lokiUrl = new URL(LOKI_PUSH_URL);
+} catch {
+	console.error("LOKI_PUSH_URL must be a valid URL");
+	process.exit(1);
+}
+
+if (
+	lokiUrl.protocol !== "https:" ||
+	!lokiUrl.hostname.endsWith(".stackit.cloud")
+) {
 	console.error("LOKI_PUSH_URL must be an HTTPS endpoint on stackit.cloud");
 	process.exit(1);
 }
@@ -47,6 +59,13 @@ if (!new URL(LOKI_PUSH_URL).hostname.endsWith(".stackit.cloud")) {
 const resourceIds = RENDER_RESOURCE_IDS.split(",")
 	.map((id) => id.trim())
 	.filter(Boolean); // remove empty strings
+
+if (resourceIds.length === 0) {
+	console.error(
+		"RENDER_RESOURCE_IDS must contain at least one non-empty service ID",
+	);
+	process.exit(1);
+}
 
 const pollIntervalMs =
 	(parseInt(process.env.POLL_INTERVAL_SECONDS, 10) || 60) * 1000;
@@ -74,7 +93,10 @@ function buildLogParams(startTime, endTime) {
 async function fetchRenderLogs(startTime, endTime) {
 	const response = await fetch(
 		`${RENDER_LOGS_URL}?${buildLogParams(startTime, endTime)}`,
-		{ headers: { Authorization: `Bearer ${RENDER_API_KEY}` } },
+		{
+			headers: { Authorization: `Bearer ${RENDER_API_KEY}` },
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+		},
 	);
 
 	if (response.status === 429) {
@@ -149,6 +171,7 @@ async function pushToLoki(logs) {
 			Authorization: lokiAuth,
 		},
 		body: JSON.stringify(toLokiPayload(logs)),
+		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 	});
 
 	if (!response.ok) {

--- a/infra/render-log-shipper/index.js
+++ b/infra/render-log-shipper/index.js
@@ -38,6 +38,15 @@ const RESOURCE_IDS = process.env.RENDER_RESOURCE_IDS.split(",").map((s) =>
 	s.trim(),
 );
 const LOKI_PUSH_URL = process.env.LOKI_PUSH_URL;
+if (
+	!LOKI_PUSH_URL.startsWith("https://") ||
+	!LOKI_PUSH_URL.includes("stackit.cloud")
+) {
+	console.error(
+		"LOKI_PUSH_URL must be an HTTPS endpoint on stackit.cloud",
+	);
+	process.exit(1);
+}
 const LOKI_USERNAME = process.env.LOKI_USERNAME;
 const LOKI_PASSWORD = process.env.LOKI_PASSWORD;
 const POLL_INTERVAL_MS =
@@ -83,7 +92,10 @@ async function fetchLogs() {
 	let nextStart = data.nextStartTime;
 	let nextEnd = data.nextEndTime;
 
-	while (hasMore) {
+	const MAX_PAGES = 10;
+	let page = 0;
+	while (hasMore && page < MAX_PAGES) {
+		page++;
 		const pageParams = new URLSearchParams();
 		pageParams.set("ownerId", RENDER_OWNER_ID);
 		pageParams.set("startTime", nextStart);

--- a/infra/render-log-shipper/index.ts
+++ b/infra/render-log-shipper/index.ts
@@ -15,32 +15,52 @@ const NANOSECOND_SUFFIX = "000000";
 const CURSOR_ADVANCE_MS = 1;
 const REQUEST_TIMEOUT_MS = 30_000;
 
-const REQUIRED_ENV = [
-	"RENDER_API_KEY",
-	"RENDER_OWNER_ID",
-	"RENDER_RESOURCE_IDS",
-	"LOKI_PUSH_URL",
-	"LOKI_USERNAME",
-	"LOKI_PASSWORD",
-];
+interface RenderLogLabel {
+	name: string;
+	value: string;
+}
 
-for (const key of REQUIRED_ENV) {
-	if (!process.env[key]) {
+interface RenderLogEntry {
+	timestamp: string;
+	message: string;
+	labels?: RenderLogLabel[];
+}
+
+interface RenderLogsResponse {
+	logs?: RenderLogEntry[];
+	hasMore?: boolean;
+	nextStartTime?: string;
+	nextEndTime?: string;
+}
+
+type LokiLabels = Record<string, string>;
+
+interface LokiStream {
+	stream: LokiLabels;
+	values: [string, string][];
+}
+
+interface LokiPayload {
+	streams: LokiStream[];
+}
+
+function requireEnv(key: string): string {
+	const value = process.env[key];
+	if (!value) {
 		console.error(`Missing required env var: ${key}`);
 		process.exit(1);
 	}
+	return value;
 }
 
-const {
-	RENDER_API_KEY,
-	RENDER_OWNER_ID,
-	RENDER_RESOURCE_IDS,
-	LOKI_PUSH_URL,
-	LOKI_USERNAME,
-	LOKI_PASSWORD,
-} = process.env;
+const RENDER_API_KEY = requireEnv("RENDER_API_KEY");
+const RENDER_OWNER_ID = requireEnv("RENDER_OWNER_ID");
+const RENDER_RESOURCE_IDS = requireEnv("RENDER_RESOURCE_IDS");
+const LOKI_PUSH_URL = requireEnv("LOKI_PUSH_URL");
+const LOKI_USERNAME = requireEnv("LOKI_USERNAME");
+const LOKI_PASSWORD = requireEnv("LOKI_PASSWORD");
 
-let lokiUrl;
+let lokiUrl: URL;
 try {
 	lokiUrl = new URL(LOKI_PUSH_URL);
 } catch {
@@ -58,7 +78,7 @@ if (
 
 const resourceIds = RENDER_RESOURCE_IDS.split(",")
 	.map((id) => id.trim())
-	.filter(Boolean); // remove empty strings
+	.filter(Boolean);
 
 if (resourceIds.length === 0) {
 	console.error(
@@ -68,7 +88,7 @@ if (resourceIds.length === 0) {
 }
 
 const pollIntervalMs =
-	(parseInt(process.env.POLL_INTERVAL_SECONDS, 10) || 60) * 1000;
+	(parseInt(process.env.POLL_INTERVAL_SECONDS ?? "", 10) || 60) * 1000;
 
 const lokiAuth =
 	"Basic " +
@@ -76,7 +96,7 @@ const lokiAuth =
 
 let lastPollTime = new Date(Date.now() - pollIntervalMs).toISOString();
 
-function buildLogParams(startTime, endTime) {
+function buildLogParams(startTime: string, endTime: string): URLSearchParams {
 	const params = new URLSearchParams({
 		ownerId: RENDER_OWNER_ID,
 		startTime,
@@ -90,7 +110,10 @@ function buildLogParams(startTime, endTime) {
 	return params;
 }
 
-async function fetchRenderLogs(startTime, endTime) {
+async function fetchRenderLogs(
+	startTime: string,
+	endTime: string,
+): Promise<RenderLogsResponse> {
 	const response = await fetch(
 		`${RENDER_LOGS_URL}?${buildLogParams(startTime, endTime)}`,
 		{
@@ -111,22 +134,22 @@ async function fetchRenderLogs(startTime, endTime) {
 		return { logs: [], hasMore: false };
 	}
 
-	return await response.json();
+	return (await response.json()) as RenderLogsResponse;
 }
 
-async function fetchAllLogs() {
+async function fetchAllLogs(): Promise<RenderLogEntry[]> {
 	const firstPage = await fetchRenderLogs(
 		lastPollTime,
 		new Date().toISOString(),
 	);
-	const allLogs = [...(firstPage.logs || [])];
+	const allLogs: RenderLogEntry[] = [...(firstPage.logs ?? [])];
 
 	let { hasMore, nextStartTime, nextEndTime } = firstPage;
 
-	for (let page = 0; hasMore && page < MAX_PAGES; page++) {
+	for (let page = 0; hasMore && nextStartTime && nextEndTime && page < MAX_PAGES; page++) {
 		const nextPage = await fetchRenderLogs(nextStartTime, nextEndTime);
 
-		allLogs.push(...(nextPage.logs || []));
+		allLogs.push(...(nextPage.logs ?? []));
 		hasMore = nextPage.hasMore;
 		nextStartTime = nextPage.nextStartTime;
 		nextEndTime = nextPage.nextEndTime;
@@ -141,29 +164,31 @@ async function fetchAllLogs() {
 	return allLogs;
 }
 
-function toLokiPayload(logs) {
-	const streams = new Map();
+function toLokiPayload(logs: RenderLogEntry[]): LokiPayload {
+	const streams = new Map<string, LokiStream>();
 
 	for (const log of logs) {
-		const labels = { source: "render" };
-		for (const label of log.labels || []) {
+		const labels: LokiLabels = { source: "render" };
+		for (const label of log.labels ?? []) {
 			labels[label.name] = label.value;
 		}
 
 		const key = JSON.stringify(labels, Object.keys(labels).sort());
-		if (!streams.has(key)) {
-			streams.set(key, { stream: labels, values: [] });
+		let stream = streams.get(key);
+		if (!stream) {
+			stream = { stream: labels, values: [] };
+			streams.set(key, stream);
 		}
 
 		const timestampNanos =
 			String(new Date(log.timestamp).getTime()) + NANOSECOND_SUFFIX;
-		streams.get(key).values.push([timestampNanos, log.message]);
+		stream.values.push([timestampNanos, log.message]);
 	}
 
 	return { streams: Array.from(streams.values()) };
 }
 
-async function pushToLoki(logs) {
+async function pushToLoki(logs: RenderLogEntry[]): Promise<void> {
 	const response = await fetch(LOKI_PUSH_URL, {
 		method: "POST",
 		headers: {
@@ -182,14 +207,14 @@ async function pushToLoki(logs) {
 	console.log(`Pushed ${logs.length} log entries to Loki`);
 }
 
-function getLatestTimestamp(logs) {
+function getLatestTimestamp(logs: RenderLogEntry[]): number {
 	return logs.reduce(
 		(max, log) => Math.max(max, new Date(log.timestamp).getTime()),
 		0,
 	);
 }
 
-async function poll() {
+async function poll(): Promise<void> {
 	try {
 		const logs = await fetchAllLogs();
 		if (logs.length === 0) return;
@@ -200,11 +225,12 @@ async function poll() {
 			getLatestTimestamp(logs) + CURSOR_ADVANCE_MS,
 		).toISOString();
 	} catch (error) {
-		console.error("Poll cycle failed:", error.message);
+		const message = error instanceof Error ? error.message : String(error);
+		console.error("Poll cycle failed:", message);
 	}
 }
 
-async function startPolling() {
+async function startPolling(): Promise<void> {
 	await poll();
 	setTimeout(startPolling, pollIntervalMs);
 }

--- a/infra/render-log-shipper/index.ts
+++ b/infra/render-log-shipper/index.ts
@@ -14,6 +14,7 @@ const LOGS_PER_PAGE = "100";
 const NANOSECOND_SUFFIX = "000000";
 const CURSOR_ADVANCE_MS = 1;
 const REQUEST_TIMEOUT_MS = 30_000;
+const INDEXING_LAG_BUFFER_MS = 5_000;
 
 interface RenderLogLabel {
 	name: string;
@@ -123,25 +124,20 @@ async function fetchRenderLogs(
 	);
 
 	if (response.status === 429) {
-		console.warn("Rate limited by Render API, retrying next cycle");
-		return { logs: [], hasMore: false };
+		throw new Error("Rate limited by Render API");
 	}
 
 	if (!response.ok) {
-		console.error(
+		throw new Error(
 			`Render API error (${startTime}–${endTime}): ${response.status} ${response.statusText}`,
 		);
-		return { logs: [], hasMore: false };
 	}
 
 	return (await response.json()) as RenderLogsResponse;
 }
 
-async function fetchAllLogs(): Promise<RenderLogEntry[]> {
-	const firstPage = await fetchRenderLogs(
-		lastPollTime,
-		new Date().toISOString(),
-	);
+async function fetchAllLogs(endTime: string): Promise<RenderLogEntry[]> {
+	const firstPage = await fetchRenderLogs(lastPollTime, endTime);
 	const allLogs: RenderLogEntry[] = [...(firstPage.logs ?? [])];
 
 	let { hasMore, nextStartTime, nextEndTime } = firstPage;
@@ -218,16 +214,27 @@ function getLatestTimestamp(logs: RenderLogEntry[]): number {
 	);
 }
 
+function advanceCursor(targetMs: number): void {
+	if (targetMs > Date.parse(lastPollTime)) {
+		lastPollTime = new Date(targetMs).toISOString();
+	}
+}
+
 async function poll(): Promise<void> {
 	try {
-		const logs = await fetchAllLogs();
-		if (logs.length === 0) return;
+		const endTime = new Date().toISOString();
+		const logs = await fetchAllLogs(endTime);
+		const safeCeilingMs = Date.parse(endTime) - INDEXING_LAG_BUFFER_MS;
+
+		if (logs.length === 0) {
+			advanceCursor(safeCeilingMs);
+			return;
+		}
 
 		await pushToLoki(logs);
 
-		lastPollTime = new Date(
-			getLatestTimestamp(logs) + CURSOR_ADVANCE_MS,
-		).toISOString();
+		const latestPlusOneMs = getLatestTimestamp(logs) + CURSOR_ADVANCE_MS;
+		advanceCursor(latestPlusOneMs);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		console.error("Poll cycle failed:", message);

--- a/infra/render-log-shipper/index.ts
+++ b/infra/render-log-shipper/index.ts
@@ -146,7 +146,11 @@ async function fetchAllLogs(): Promise<RenderLogEntry[]> {
 
 	let { hasMore, nextStartTime, nextEndTime } = firstPage;
 
-	for (let page = 0; hasMore && nextStartTime && nextEndTime && page < MAX_PAGES; page++) {
+	for (
+		let page = 0;
+		hasMore && nextStartTime && nextEndTime && page < MAX_PAGES;
+		page++
+	) {
 		const nextPage = await fetchRenderLogs(nextStartTime, nextEndTime);
 
 		allLogs.push(...(nextPage.logs ?? []));

--- a/infra/render-log-shipper/index.ts
+++ b/infra/render-log-shipper/index.ts
@@ -7,6 +7,7 @@
  * Env vars: RENDER_API_KEY, RENDER_OWNER_ID, RENDER_RESOURCE_IDS,
  *           LOKI_PUSH_URL, LOKI_USERNAME, LOKI_PASSWORD, POLL_INTERVAL_SECONDS
  */
+/* eslint-disable no-console */
 
 const RENDER_LOGS_URL = "https://api.render.com/v1/logs";
 const MAX_PAGES = 10;
@@ -91,9 +92,7 @@ if (resourceIds.length === 0) {
 const pollIntervalMs =
 	(parseInt(process.env.POLL_INTERVAL_SECONDS ?? "", 10) || 60) * 1000;
 
-const lokiAuth =
-	"Basic " +
-	Buffer.from(`${LOKI_USERNAME}:${LOKI_PASSWORD}`).toString("base64");
+const lokiAuth = `Basic ${Buffer.from(`${LOKI_USERNAME}:${LOKI_PASSWORD}`).toString("base64")}`;
 
 let lastPollTime = new Date(Date.now() - pollIntervalMs).toISOString();
 

--- a/infra/render-log-shipper/package-lock.json
+++ b/infra/render-log-shipper/package-lock.json
@@ -1,0 +1,561 @@
+{
+  "name": "render-log-shipper",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "render-log-shipper",
+      "version": "1.0.0",
+      "dependencies": {
+        "tsx": "4.19.3"
+      },
+      "devDependencies": {
+        "@types/node": "22.5.0",
+        "typescript": "5.8.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
+      "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
+      "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/infra/render-log-shipper/package.json
+++ b/infra/render-log-shipper/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "render-log-shipper",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  }
+}

--- a/infra/render-log-shipper/package.json
+++ b/infra/render-log-shipper/package.json
@@ -4,6 +4,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node index.js"
+    "start": "tsx index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "tsx": "4.19.3"
+  },
+  "devDependencies": {
+    "@types/node": "22.5.0",
+    "typescript": "5.8.3"
   }
 }

--- a/infra/render-log-shipper/tsconfig.json
+++ b/infra/render-log-shipper/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"target": "ES2023",
+		"lib": ["ES2023"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"isolatedModules": true,
+		"moduleDetection": "force",
+		"noEmit": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"erasableSyntaxOnly": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": true
+	},
+	"include": ["index.ts"]
+}

--- a/infra/render-otel-collector/Dockerfile
+++ b/infra/render-otel-collector/Dockerfile
@@ -1,0 +1,10 @@
+FROM --platform=linux/amd64 otel/opentelemetry-collector-contrib:0.120.0
+
+COPY otel-config.yml /etc/otelcol-contrib/config.yml
+
+# Render assigns PORT dynamically (usually 10000).
+# The OTLP receiver binds to it.
+# Syslog listens on 5514 (private network only).
+EXPOSE ${PORT} 5514
+
+CMD ["--config", "/etc/otelcol-contrib/config.yml"]

--- a/infra/render-otel-collector/Dockerfile
+++ b/infra/render-otel-collector/Dockerfile
@@ -2,9 +2,6 @@ FROM --platform=linux/amd64 otel/opentelemetry-collector-contrib:0.120.0
 
 COPY otel-config.yml /etc/otelcol-contrib/config.yml
 
-# Render assigns PORT dynamically (usually 10000).
-# The OTLP receiver binds to it.
-# Syslog listens on 5514 (private network only).
-EXPOSE ${PORT} 5514
+EXPOSE ${PORT}
 
 CMD ["--config", "/etc/otelcol-contrib/config.yml"]

--- a/infra/render-otel-collector/README.md
+++ b/infra/render-otel-collector/README.md
@@ -8,18 +8,19 @@ Bridges Render's metrics stream to STACKIT Observability. **Metrics only** — l
 2. Point it at this repo, set the root directory to `infra/render-otel-collector`.
 3. Set the following environment variables:
 
-| Variable | Value |
-|----------|-------|
-| `STACKIT_OBSERVABILITY_METRICS_PUSH_URL` | STACKIT Observability → Remote Write URL |
-| `STACKIT_OBSERVABILITY_USERNAME` | From STACKIT Observability credentials |
-| `STACKIT_OBSERVABILITY_PASSWORD` | From STACKIT Observability credentials |
-| `RENDER_OTEL_BEARER_TOKEN` | A random secret you generate (e.g. `openssl rand -hex 32`). Use the same value in Render's metrics stream API Key field. |
+| Variable                                 | Value                                                                                                                    |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `STACKIT_OBSERVABILITY_METRICS_PUSH_URL` | STACKIT Observability → Remote Write URL                                                                                 |
+| `STACKIT_OBSERVABILITY_USERNAME`         | From STACKIT Observability credentials                                                                                   |
+| `STACKIT_OBSERVABILITY_PASSWORD`         | From STACKIT Observability credentials                                                                                   |
+| `RENDER_OTEL_BEARER_TOKEN`               | A random secret you generate (e.g. `openssl rand -hex 32`). Use the same value in Render's metrics stream API Key field. |
 
 4. Deploy. Note the public URL (e.g. `https://otel-collector-xxx.onrender.com`).
 
 ## Wire up Render Observability
 
 Dashboard > Integrations > Observability > Metrics Stream > + Add destination:
+
 - Provider: **Custom**
 - Endpoint: `https://otel-collector-xxx.onrender.com/v1/metrics`
 - API Key: the same value as `RENDER_OTEL_BEARER_TOKEN`
@@ -27,4 +28,5 @@ Dashboard > Integrations > Observability > Metrics Stream > + Add destination:
 ## Verify
 
 Open STACKIT Observability Grafana:
+
 1. Go to **Explore** > select **Thanos** data source > look for `render_service_*` metrics

--- a/infra/render-otel-collector/README.md
+++ b/infra/render-otel-collector/README.md
@@ -1,9 +1,6 @@
 # Render OTel Collector
 
-Bridges Render's observability streams to STACKIT Observability.
-
-- **Metrics**: Receives OTLP HTTP from Render metrics stream, forwards to STACKIT via Prometheus Remote Write with Basic Auth.
-- **Logs**: Receives syslog from Render log stream, forwards to STACKIT via Loki Push API with Basic Auth.
+Bridges Render's metrics stream to STACKIT Observability. **Metrics only** — logs are handled by the separate [render-log-shipper](../render-log-shipper/).
 
 ## Deploy on Render
 
@@ -13,33 +10,21 @@ Bridges Render's observability streams to STACKIT Observability.
 
 | Variable | Value |
 |----------|-------|
-| `STACKIT_OBSERVABILITY_METRICS_PUSH_URL` | From STACKIT Observability instance (Prometheus remote write URL) |
-| `STACKIT_OBSERVABILITY_LOGS_PUSH_URL` | From STACKIT Observability instance (Loki push URL) |
+| `STACKIT_OBSERVABILITY_METRICS_PUSH_URL` | STACKIT Observability → Remote Write URL |
 | `STACKIT_OBSERVABILITY_USERNAME` | From STACKIT Observability credentials |
 | `STACKIT_OBSERVABILITY_PASSWORD` | From STACKIT Observability credentials |
 | `RENDER_OTEL_BEARER_TOKEN` | A random secret you generate (e.g. `openssl rand -hex 32`). Use the same value in Render's metrics stream API Key field. |
 
-4. Deploy. Note the public URL (e.g. `https://otel-collector-xxx.onrender.com`) and internal address (e.g. `otel-collector-xxx:5514`).
+4. Deploy. Note the public URL (e.g. `https://otel-collector-xxx.onrender.com`).
 
 ## Wire up Render Observability
-
-### Metrics Stream
 
 Dashboard > Integrations > Observability > Metrics Stream > + Add destination:
 - Provider: **Custom**
 - Endpoint: `https://otel-collector-xxx.onrender.com/v1/metrics`
-- API Key: the same value as `RENDER_OTEL_BEARER_TOKEN` (collector validates this token on every request)
-
-### Log Stream
-
-Dashboard > Integrations > Observability > Log Stream > + Set default:
-- Log Endpoint: `otel-collector-xxx:5514` (internal address — may or may not work; see notes)
-- Token: leave empty
-
-**Note on logs**: Render log streams require a TLS-enabled syslog endpoint. The internal address may not work if Render's platform streams from outside the private network. If logs don't appear in Grafana but metrics do, this is why. In that case, we'll need to expose the syslog port externally.
+- API Key: the same value as `RENDER_OTEL_BEARER_TOKEN`
 
 ## Verify
 
 Open STACKIT Observability Grafana:
-1. Go to **Explore** > select **Thanos** data source > look for metrics with `source="render"` label
-2. Go to **Explore** > select **Loki** data source > look for logs with `source="render"` label
+1. Go to **Explore** > select **Thanos** data source > look for `render_service_*` metrics

--- a/infra/render-otel-collector/README.md
+++ b/infra/render-otel-collector/README.md
@@ -1,0 +1,45 @@
+# Render OTel Collector
+
+Bridges Render's observability streams to STACKIT Observability.
+
+- **Metrics**: Receives OTLP HTTP from Render metrics stream, forwards to STACKIT via Prometheus Remote Write with Basic Auth.
+- **Logs**: Receives syslog from Render log stream, forwards to STACKIT via Loki Push API with Basic Auth.
+
+## Deploy on Render
+
+1. Create a new **Web Service** on Render.
+2. Point it at this repo, set the root directory to `infra/render-otel-collector`.
+3. Set the following environment variables:
+
+| Variable | Value |
+|----------|-------|
+| `STACKIT_OBSERVABILITY_METRICS_PUSH_URL` | From STACKIT Observability instance (Prometheus remote write URL) |
+| `STACKIT_OBSERVABILITY_LOGS_PUSH_URL` | From STACKIT Observability instance (Loki push URL) |
+| `STACKIT_OBSERVABILITY_USERNAME` | From STACKIT Observability credentials |
+| `STACKIT_OBSERVABILITY_PASSWORD` | From STACKIT Observability credentials |
+| `RENDER_OTEL_BEARER_TOKEN` | A random secret you generate (e.g. `openssl rand -hex 32`). Use the same value in Render's metrics stream API Key field. |
+
+4. Deploy. Note the public URL (e.g. `https://otel-collector-xxx.onrender.com`) and internal address (e.g. `otel-collector-xxx:5514`).
+
+## Wire up Render Observability
+
+### Metrics Stream
+
+Dashboard > Integrations > Observability > Metrics Stream > + Add destination:
+- Provider: **Custom**
+- Endpoint: `https://otel-collector-xxx.onrender.com/v1/metrics`
+- API Key: the same value as `RENDER_OTEL_BEARER_TOKEN` (collector validates this token on every request)
+
+### Log Stream
+
+Dashboard > Integrations > Observability > Log Stream > + Set default:
+- Log Endpoint: `otel-collector-xxx:5514` (internal address — may or may not work; see notes)
+- Token: leave empty
+
+**Note on logs**: Render log streams require a TLS-enabled syslog endpoint. The internal address may not work if Render's platform streams from outside the private network. If logs don't appear in Grafana but metrics do, this is why. In that case, we'll need to expose the syslog port externally.
+
+## Verify
+
+Open STACKIT Observability Grafana:
+1. Go to **Explore** > select **Thanos** data source > look for metrics with `source="render"` label
+2. Go to **Explore** > select **Loki** data source > look for logs with `source="render"` label

--- a/infra/render-otel-collector/otel-config.yml
+++ b/infra/render-otel-collector/otel-config.yml
@@ -19,6 +19,14 @@ extensions:
     endpoint: 0.0.0.0:13133
 
 processors:
+  filter/baergpt:
+    metrics:
+      include:
+        match_type: regexp
+        resource_attributes:
+          - key: job
+            value: "baergpt.*|bottleneck.*|gotenberg"
+
   batch:
     timeout: 10s
     send_batch_size: 1024
@@ -40,5 +48,5 @@ service:
   pipelines:
     metrics:
       receivers: [otlp]
-      processors: [batch, attributes/render]
+      processors: [filter/baergpt, batch, attributes/render]
       exporters: [prometheusremotewrite/stackit]

--- a/infra/render-otel-collector/otel-config.yml
+++ b/infra/render-otel-collector/otel-config.yml
@@ -24,7 +24,7 @@ processors:
       include:
         match_type: regexp
         resource_attributes:
-          - key: job
+          - key: service.name
             value: "baergpt.*|bottleneck.*|gotenberg"
 
   batch:

--- a/infra/render-otel-collector/otel-config.yml
+++ b/infra/render-otel-collector/otel-config.yml
@@ -42,6 +42,15 @@ exporters:
     endpoint: ${STACKIT_OBSERVABILITY_METRICS_PUSH_URL}
     auth:
       authenticator: basicauth/stackit
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+    sending_queue:
+      enabled: true
+      num_consumers: 2
+      queue_size: 1000
 
 service:
   extensions: [bearertokenauth/render, basicauth/stackit, health_check]

--- a/infra/render-otel-collector/otel-config.yml
+++ b/infra/render-otel-collector/otel-config.yml
@@ -58,6 +58,9 @@ exporters:
       authenticator: basicauth/stackit
 
 service:
+  telemetry:
+    logs:
+      level: debug
   extensions: [bearertokenauth/render, basicauth/stackit, health_check]
   pipelines:
     metrics:

--- a/infra/render-otel-collector/otel-config.yml
+++ b/infra/render-otel-collector/otel-config.yml
@@ -1,7 +1,4 @@
 receivers:
-  # Render metrics stream sends OTLP HTTP with Bearer token.
-  # This listens on the Render web service PORT (public URL).
-  # Bearer token is validated via the bearertokenauth extension.
   otlp:
     protocols:
       http:
@@ -9,18 +6,7 @@ receivers:
         auth:
           authenticator: bearertokenauth/render
 
-  # Render log stream sends syslog over TCP/TLS (RFC5424).
-  # This listens on port 5514, reachable via Render private network.
-  # If Render's platform log streaming can't reach internal addresses,
-  # this receiver will simply sit idle.
-  syslog:
-    protocol: rfc5424
-    tcp:
-      listen_address: 0.0.0.0:5514
-
 extensions:
-  # Validates the Bearer token Render sends with each OTLP request.
-  # Use the same token value when configuring the Render metrics stream.
   bearertokenauth/render:
     token: ${RENDER_OTEL_BEARER_TOKEN}
 
@@ -42,9 +28,6 @@ processors:
       - key: source
         value: render
         action: upsert
-      - key: environment
-        value: production
-        action: upsert
 
 exporters:
   prometheusremotewrite/stackit:
@@ -52,26 +35,10 @@ exporters:
     auth:
       authenticator: basicauth/stackit
 
-  loki/stackit:
-    endpoint: ${STACKIT_OBSERVABILITY_LOGS_PUSH_URL}
-    auth:
-      authenticator: basicauth/stackit
-
-  telemetry:
-    logs:
-      level: debug
-
 service:
-  telemetry:
-    logs:
-      level: debug
   extensions: [bearertokenauth/render, basicauth/stackit, health_check]
   pipelines:
     metrics:
       receivers: [otlp]
       processors: [batch, attributes/render]
       exporters: [prometheusremotewrite/stackit]
-    logs:
-      receivers: [syslog]
-      processors: [batch, attributes/render]
-      exporters: [loki/stackit]

--- a/infra/render-otel-collector/otel-config.yml
+++ b/infra/render-otel-collector/otel-config.yml
@@ -1,0 +1,70 @@
+receivers:
+  # Render metrics stream sends OTLP HTTP with Bearer token.
+  # This listens on the Render web service PORT (public URL).
+  # Bearer token is validated via the bearertokenauth extension.
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:${PORT}
+        auth:
+          authenticator: bearertokenauth/render
+
+  # Render log stream sends syslog over TCP/TLS (RFC5424).
+  # This listens on port 5514, reachable via Render private network.
+  # If Render's platform log streaming can't reach internal addresses,
+  # this receiver will simply sit idle.
+  syslog:
+    protocol: rfc5424
+    tcp:
+      listen_address: 0.0.0.0:5514
+
+extensions:
+  # Validates the Bearer token Render sends with each OTLP request.
+  # Use the same token value when configuring the Render metrics stream.
+  bearertokenauth/render:
+    token: ${RENDER_OTEL_BEARER_TOKEN}
+
+  basicauth/stackit:
+    client_auth:
+      username: ${STACKIT_OBSERVABILITY_USERNAME}
+      password: ${STACKIT_OBSERVABILITY_PASSWORD}
+
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+
+  attributes/render:
+    actions:
+      - key: source
+        value: render
+        action: upsert
+      - key: environment
+        value: production
+        action: upsert
+
+exporters:
+  prometheusremotewrite/stackit:
+    endpoint: ${STACKIT_OBSERVABILITY_METRICS_PUSH_URL}
+    auth:
+      authenticator: basicauth/stackit
+
+  loki/stackit:
+    endpoint: ${STACKIT_OBSERVABILITY_LOGS_PUSH_URL}
+    auth:
+      authenticator: basicauth/stackit
+
+service:
+  extensions: [bearertokenauth/render, basicauth/stackit, health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch, attributes/render]
+      exporters: [prometheusremotewrite/stackit]
+    logs:
+      receivers: [syslog]
+      processors: [batch, attributes/render]
+      exporters: [loki/stackit]

--- a/infra/render-otel-collector/otel-config.yml
+++ b/infra/render-otel-collector/otel-config.yml
@@ -57,6 +57,10 @@ exporters:
     auth:
       authenticator: basicauth/stackit
 
+  telemetry:
+    logs:
+      level: debug
+
 service:
   telemetry:
     logs:

--- a/infra/render-otel-collector/otel-config.yml
+++ b/infra/render-otel-collector/otel-config.yml
@@ -47,7 +47,7 @@ exporters:
       initial_interval: 5s
       max_interval: 30s
       max_elapsed_time: 300s
-    sending_queue:
+    remote_write_queue:
       enabled: true
       num_consumers: 2
       queue_size: 1000


### PR DESCRIPTION
First step towards consolidating our metrics and logs in StackITs Observability Dashboard. To test it out, login to
[stackit](https://stackit.com/de). Then go to Observability Dashboard -> Grafana -> Grafana Dashboard and login via Stackit SSO.

baergpt-render-log-shipper in render as of now is only shipping logs from staging. I will update the environment vars to also ship prod logs once the PR is through. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a background worker that polls Render for configured service logs and forwards them to the observability logs ingest (Loki).
  * Added an OpenTelemetry Collector service to receive Render metrics and forward them to the observability metrics backend (metrics-only).
  * Provided containerized startup and runtime configuration for both services.

* **Documentation**
  * Added deployment, configuration, verification, and security guidance for both services, including required credentials and tuning options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->