### PR TITLE
fix: set maxOutputTokens to 8192 for generation

### DIFF
--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -296,6 +296,7 @@ export class GenerationService {
 				generateText({
 					model: llmHandler.languageModel,
 					messages: messages,
+					maxOutputTokens: 8192,
 					temperature: LLM_PARAMETERS.temperature,
 					tools,
 					toolChoice,
@@ -380,6 +381,7 @@ export class GenerationService {
 						streamText({
 							model: llmHandler.languageModel,
 							messages: messages,
+							maxOutputTokens: 8192,
 							temperature: LLM_PARAMETERS.temperature,
 							providerOptions: {
 								mistral: {


### PR DESCRIPTION
Looking at the logs, the issue seemed that the bug occured when Mistral came back with an endless response loop. It seems that AI SDK has a quadratic growth memory leak on larger responses. I was able to confirm this behavior/fix with this script:
[verify-oom-fix.ts](https://github.com/user-attachments/files/26741031/verify-oom-fix.ts)

Output: 
```
[HEAP] 21MB (+0MB) | start
[HEAP] 21MB (+0MB) | 21s | ~500 output tokens | 4KB text
[HEAP] 30MB (+9MB) | 43s | ~1000 output tokens | 8KB text
[HEAP] 38MB (+18MB) | 64s | ~1500 output tokens | 12KB text
[HEAP] 50MB (+30MB) | 85s | ~2000 output tokens | 16KB text
[HEAP] 70MB (+49MB) | 105s | ~2500 output tokens | 20KB text
[HEAP] 96MB (+76MB) | 127s | ~3000 output tokens | 25KB text
[HEAP] 117MB (+96MB) | 149s | ~3500 output tokens | 29KB text
[HEAP] 120MB (+100MB) | done 152s | ~3558 output tokens | 30KB text
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the maximum length of generated text responses to support longer outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->