### PR TITLE
fix: prevent double submission of messages while waiting for a response

### DIFF
--- a/apps/frontend/src/components/chat/chat-form/chat-form.tsx
+++ b/apps/frontend/src/components/chat/chat-form/chat-form.tsx
@@ -26,7 +26,7 @@ const { setHasUserScrolledUp } = useChatScrollingStore.getState();
 export const chatFormId = "chat-form";
 
 export const ChatForm: React.FC = () => {
-	const { status, clearError } = useInferenceLoadingStatusStore();
+	const { status, clearError, isLoading } = useInferenceLoadingStatusStore();
 	const { selectedChatFolders } = useFolderStore();
 	const { selectedChatDocuments } = useDocumentStore();
 	const { getCurrentOrCreateChat, selectedChatOptions, toggleChatOption } =
@@ -48,9 +48,14 @@ export const ChatForm: React.FC = () => {
 	// Handle Enter key to submit the form
 	// and create a new line with Shift + Enter
 	const handleTextAreaKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-		const isSubmit = event.key === "Enter" && !event.shiftKey;
-		if (isSubmit) {
+		const isEnterWithoutShiftPressed = event.key === "Enter" && !event.shiftKey;
+		if (isEnterWithoutShiftPressed) {
 			event.preventDefault();
+		}
+
+		const isSubmitEnabled =
+			!isLoading() && event.currentTarget.value.trim().length > 0;
+		if (isEnterWithoutShiftPressed && isSubmitEnabled) {
 			event.currentTarget.form?.requestSubmit();
 		}
 	};
@@ -99,12 +104,6 @@ export const ChatForm: React.FC = () => {
 			},
 		);
 	};
-
-	const isInferenceLoading = [
-		"waiting-for-response",
-		"loading-text",
-		"loading-citations",
-	].includes(status);
 
 	const hasError = status === "error";
 
@@ -156,7 +155,7 @@ export const ChatForm: React.FC = () => {
 					</div>
 					<div className="flex items-center gap-3">
 						<LlmModelToggleButton />
-						{isInferenceLoading && !hasError ? (
+						{isLoading() && !hasError ? (
 							<button
 								type="button"
 								aria-label={Content["chat.stopGeneratingButton.ariaLabel"]}

--- a/apps/frontend/src/components/chat/chat-form/chat-form.tsx
+++ b/apps/frontend/src/components/chat/chat-form/chat-form.tsx
@@ -1,6 +1,7 @@
 import React, {
 	type FormEvent,
 	type KeyboardEvent,
+	type MouseEvent,
 	useRef,
 	useState,
 } from "react";
@@ -105,6 +106,11 @@ export const ChatForm: React.FC = () => {
 		);
 	};
 
+	const handleStop = (event: MouseEvent<HTMLButtonElement>) => {
+		event.preventDefault();
+		abortStreaming();
+	};
+
 	const hasError = status === "error";
 
 	return (
@@ -159,7 +165,7 @@ export const ChatForm: React.FC = () => {
 							<button
 								type="button"
 								aria-label={Content["chat.stopGeneratingButton.ariaLabel"]}
-								onClick={() => abortStreaming()}
+								onClick={handleStop}
 								className="rounded-3px size-8 bg-hellblau-50 flex items-center justify-center shrink-0 hover:bg-hellblau-110 focus-visible:outline-2px"
 							>
 								<ChatStopGeneratingIcon />

--- a/apps/frontend/src/store/use-inference-loading-status-store.ts
+++ b/apps/frontend/src/store/use-inference-loading-status-store.ts
@@ -13,13 +13,23 @@ interface InferenceLoadingStatusStore {
 	setStatus: (status: InferenceLoadingStatus) => void;
 	setError: (error: string) => void;
 	clearError: () => void;
+	isLoading: () => boolean;
 }
 
 export const useInferenceLoadingStatusStore =
-	create<InferenceLoadingStatusStore>()((set) => ({
+	create<InferenceLoadingStatusStore>()((set, get) => ({
 		status: "idle",
 		error: undefined,
 		setStatus: (status: InferenceLoadingStatus) => set({ status }),
 		setError: (error: string) => set({ status: "error", error }),
 		clearError: () => set({ status: "idle", error: undefined }),
+		isLoading: () => {
+			const { status } = get();
+
+			return [
+				"waiting-for-response",
+				"loading-text",
+				"loading-citations",
+			].includes(status);
+		},
 	}));

--- a/apps/frontend/tests/e2e/chat.spec.ts
+++ b/apps/frontend/tests/e2e/chat.spec.ts
@@ -898,6 +898,70 @@ test.describe("Chat", () => {
 			await expect(baseKnowledgePill).not.toBeVisible();
 		},
 	);
+
+	testWithLoggedInUser(
+		"Should not be able to send another message with enter while waiting for a response",
+		async ({ page }) => {
+			await page.goto("/");
+			let hangingStream: Readable | undefined;
+
+			// Mock the LLM API to return a partial response
+			await page.route("**/llm/just-chatting", async (route) => {
+				hangingStream = new Readable({
+					read() {},
+				});
+				hangingStream.push(
+					`data: ${JSON.stringify({
+						type: "text-delta",
+						id: "1",
+						delta: "Partial ",
+					})}\n\n`,
+				);
+
+				await route.fulfill({
+					status: 200,
+					headers: {
+						"Content-Type": "text/event-stream; charset=utf-8",
+					},
+					// @ts-expect-error Playwright Node accepts Readable for streaming bodies; public types omit it.
+					body: hangingStream,
+				});
+			});
+
+			try {
+				const chatInput = page.getByPlaceholder("Stellen Sie eine Frage");
+				await chatInput.fill("hallo123");
+
+				const submitButton = page.getByRole("button", {
+					name: "Nachricht senden",
+				});
+				await submitButton.click();
+
+				const question = page.getByTestId("user-message-markdown-container");
+				await expect(question).toBeVisible();
+
+				const stopButton = page.getByRole("button", {
+					name: "Textgenerierung stoppen",
+				});
+				await expect(stopButton).toBeVisible();
+
+				const userMessages = page.getByTestId(
+					"user-message-markdown-container",
+				);
+				const userMessageCountBefore = await userMessages.count();
+
+				await chatInput.fill("hallo456");
+				await chatInput.focus();
+
+				await page.keyboard.press("Enter");
+
+				await expect(userMessages).toHaveCount(userMessageCountBefore);
+			} finally {
+				await page.unroute("**/llm/just-chatting");
+				hangingStream?.destroy();
+			}
+		},
+	);
 });
 
 async function sendAndWaitForLLMResponse(page: Page) {


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214032916442645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved chat submission so pressing Enter won’t submit while a response is actively generating; Enter+Shift still inserts a newline.
  * Stop-generation control now reliably reflects the live loading state.

* **Tests**
  * Added end-to-end test verifying chat behavior when a response stream is active to prevent duplicate submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->