### PR TITLE
Add CVE-2026-31431 workaround and kernel patch

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -131,6 +131,39 @@ For debugging, add verbosity flags:
 op run --env-file .op.env.supabase-staging -- ansible-playbook -i inventory/supabase-staging.yml supabase.yml -vv
 ```
 
+### Kernel hardening (tag: `kernel-hardening`)
+
+Hardening tasks in the `common` role (e.g. blacklisting unused kernel modules like `algif_aead`) are tagged `kernel-hardening`. Use this to apply only those tasks without running the rest of the playbook — useful when a host's full state is not yet reconciled with Ansible.
+
+```bash
+# Staging — dry run, then apply
+op run --env-file .op.env.supabase-staging -- ansible-playbook -i inventory/supabase-staging.yml supabase.yml --tags kernel-hardening --check --diff
+op run --env-file .op.env.supabase-staging -- ansible-playbook -i inventory/supabase-staging.yml supabase.yml --tags kernel-hardening
+
+# Production — dry run, then apply
+op run --env-file .op.env.supabase-production -- ansible-playbook -i inventory/supabase-production.yml supabase.yml --tags kernel-hardening --check --diff
+op run --env-file .op.env.supabase-production -- ansible-playbook -i inventory/supabase-production.yml supabase.yml --tags kernel-hardening
+```
+
+### Kernel patches and reboots
+
+The standalone `kernel-patch.yml` playbook upgrades the cloud-VM kernel meta-packages (`linux-image-virtual`, `linux-headers-virtual`) to the latest available version and reboots the host if `/var/run/reboot-required` exists after the upgrade. Hosts are patched one at a time (`serial: 1`). If you ever migrate to bare-metal hosts, the package list will need `linux-image-generic` / `linux-headers-generic` added.
+
+Caveats:
+
+- The reboot fires whenever `/var/run/reboot-required` is present — including from earlier package activity that predates this run.
+- Expect a few minutes of service downtime per host during the reboot. Take a backup before running on production.
+
+```bash
+# Staging — dry run, then apply
+op run --env-file .op.env.supabase-staging -- ansible-playbook -i inventory/supabase-staging.yml kernel-patch.yml --check --diff
+op run --env-file .op.env.supabase-staging -- ansible-playbook -i inventory/supabase-staging.yml kernel-patch.yml
+
+# Production — dry run, then apply
+op run --env-file .op.env.supabase-production -- ansible-playbook -i inventory/supabase-production.yml kernel-patch.yml --check --diff
+op run --env-file .op.env.supabase-production -- ansible-playbook -i inventory/supabase-production.yml kernel-patch.yml
+```
+
 ## Supabase Stack
 
 The project uses a customized `docker-compose.yml` located at `supabase/docker-compose.yml`, which overrides the default Supabase configuration. It is deployed to `/opt/supabase-baergpt/` on the server.

--- a/infra/ansible/kernel-patch.yml
+++ b/infra/ansible/kernel-patch.yml
@@ -1,0 +1,23 @@
+- name: Apply pending kernel upgrades and reboot if required
+  hosts: supabase
+  become: true
+  serial: 1
+  gather_facts: true
+  tasks:
+    - name: Upgrade kernel packages
+      ansible.builtin.apt:
+        name:
+          - linux-image-virtual
+          - linux-headers-virtual
+        state: latest
+        update_cache: true
+
+    - name: Check whether the system flagged a reboot as required
+      ansible.builtin.stat:
+        path: /var/run/reboot-required
+      register: reboot_required
+
+    - name: Reboot if /var/run/reboot-required exists
+      ansible.builtin.reboot:
+        reboot_timeout: 600
+      when: reboot_required.stat.exists

--- a/infra/ansible/roles/common/tasks/disable-algif-aead.yml
+++ b/infra/ansible/roles/common/tasks/disable-algif-aead.yml
@@ -1,0 +1,21 @@
+- name: Block algif_aead module from loading
+  ansible.builtin.copy:
+    dest: /etc/modprobe.d/disable-algif.conf
+    content: |
+      # Disable algif_aead — unused by this stack and reduces attack surface.
+      # Originally added in response to CVE-2026-31431 (AF_ALG/splice container escape).
+      # Safe to remove only if a future workload genuinely needs AF_ALG AEAD sockets
+      install algif_aead /bin/false
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Check whether algif_aead is currently loaded
+  ansible.builtin.command: lsmod
+  register: cve_2026_31431_lsmod
+  changed_when: false
+  check_mode: false
+
+- name: Unload algif_aead if loaded
+  ansible.builtin.command: rmmod algif_aead
+  when: "'algif_aead' in cve_2026_31431_lsmod.stdout"

--- a/infra/ansible/roles/common/tasks/main.yml
+++ b/infra/ansible/roles/common/tasks/main.yml
@@ -19,3 +19,6 @@
     state: present
     update_cache: true
     force_apt_get: true
+
+- ansible.builtin.import_tasks: disable-algif-aead.yml
+  tags: [kernel-hardening]


### PR DESCRIPTION
I've added two things:
1. Quick fix as outlined in: https://copy.fail/#mitigation can be run via: 
```
 op run --env-file .op.env.supabase-staging -- \
    ansible-playbook -i inventory/supabase-staging.yml supabase.yml \
    --tags kernel-hardening
```
2. Another standalone playbook for kernel patches. These require a server reboot. 
```
 op run --env-file .op.env.supabase-staging -- \
    ansible-playbook -i inventory/supabase-staging.yml kernel-patch.yml
```

Both of these are tested and live on staging. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated kernel upgrades with conditional reboot when required.
  * Implemented kernel module hardening to block a specific module from loading and remove it if currently active.
* **Documentation**
  * Added deployment instructions and examples for running kernel-hardening tasks and the standalone kernel patch workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->