### PR TITLE
fix: remove embedding tracing from test & production

### DIFF
--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -33,6 +33,7 @@ export interface Config {
 	braveSearchMaxRPS?: number;
 	featureFlagWebSearchAllowed: boolean;
 	featureFlagMemoryLog: boolean;
+	isTracingEnabled: boolean;
 }
 
 /* eslint-disable-next-line complexity */
@@ -175,4 +176,8 @@ export const config: Config = {
 	featureFlagWebSearchAllowed:
 		process.env.FEATURE_FLAG_WEB_SEARCH_ALLOWED === "true",
 	featureFlagMemoryLog: process.env.FEATURE_FLAG_MEMORY_LOG === "true",
+	isTracingEnabled:
+		process.env.NODE_ENV !== undefined &&
+		process.env.NODE_ENV !== "production" &&
+		process.env.NODE_ENV !== "test",
 };

--- a/apps/backend/src/services/embedding-service.ts
+++ b/apps/backend/src/services/embedding-service.ts
@@ -32,6 +32,9 @@ export class EmbeddingService {
 				return await embed({
 					model: mistral.embeddingModel(config.mistralEmbeddingModel),
 					value: input,
+					experimental_telemetry: {
+						isEnabled: config.isTracingEnabled,
+					},
 				});
 			},
 			{ queueType: "embeddings" },

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -309,8 +309,7 @@ export class GenerationService {
 						},
 					},
 					experimental_telemetry: {
-						isEnabled:
-							config.nodeEnv !== "test" && config.nodeEnv !== "production", // Disable telemetry in CI and production
+						isEnabled: config.isTracingEnabled,
 						functionId: "text-toolCall-generation",
 						metadata: {
 							sessionId: sessionId ? sessionId : "unknown",
@@ -445,9 +444,7 @@ export class GenerationService {
 														schema: citationAnswerSchema,
 													}),
 													experimental_telemetry: {
-														isEnabled:
-															config.nodeEnv !== "test" &&
-															config.nodeEnv !== "production", // Disable telemetry in CI and production
+														isEnabled: config.isTracingEnabled,
 														functionId: "citation-extraction",
 														metadata: {
 															sessionId: sessionId ? sessionId : "unknown",
@@ -515,9 +512,7 @@ export class GenerationService {
 															schema: webCitationAnswerSchema,
 														}),
 														experimental_telemetry: {
-															isEnabled:
-																config.nodeEnv !== "test" &&
-																config.nodeEnv !== "production",
+															isEnabled: config.isTracingEnabled,
 															functionId: "web-citation-extraction",
 															metadata: {
 																sessionId: sessionId ? sessionId : "unknown",
@@ -584,8 +579,8 @@ export class GenerationService {
 								}
 							},
 							experimental_telemetry: {
-								isEnabled:
-									config.nodeEnv !== "test" && config.nodeEnv !== "production", // Disable telemetry in CI and production
+								isEnabled: config.isTracingEnabled,
+								functionId: "streamed-text-generation",
 								metadata: {
 									sessionId: sessionId ? sessionId : "unknown",
 									langfusePrompt: langfusePrompt
@@ -626,8 +621,7 @@ export class GenerationService {
 						},
 					},
 					experimental_telemetry: {
-						isEnabled:
-							config.nodeEnv !== "test" && config.nodeEnv !== "production", // Disable telemetry in CI and production
+						isEnabled: config.isTracingEnabled,
 						metadata: {
 							sessionId: "unknown",
 							langfusePrompt: langfusePrompt.toJSON(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a configurable telemetry/tracing toggle in backend services; telemetry is now enabled automatically in non-production/test environments to improve diagnostics and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->