### PR TITLE
fix: stop forwarding empty assistant messages

### DIFF
--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -291,11 +291,15 @@ export class GenerationService {
 		const prepareStep = this.getPrepareStep(useBaseKnowledgeAfterFirstStep);
 
 		updateActiveTrace({ input: messages[messages.length - 1].content });
+
+		const nonEmptyAssistantMessage = (message: ModelMessage) =>
+			!(message.role === "assistant" && message.content === "");
+
 		const generationResult = await resilientCall(
 			() =>
 				generateText({
 					model: llmHandler.languageModel,
-					messages: messages,
+					messages: messages.filter(nonEmptyAssistantMessage),
 					maxOutputTokens: 8192,
 					temperature: LLM_PARAMETERS.temperature,
 					tools,
@@ -386,7 +390,7 @@ export class GenerationService {
 					async () =>
 						streamText({
 							model: llmHandler.languageModel,
-							messages: messages,
+							messages: messages.filter(nonEmptyAssistantMessage),
 							maxOutputTokens: 8192,
 							temperature: LLM_PARAMETERS.temperature,
 							providerOptions: {

--- a/apps/frontend/tests/e2e/chat.spec.ts
+++ b/apps/frontend/tests/e2e/chat.spec.ts
@@ -19,6 +19,7 @@ import {
 import { testDesktopOnly } from "../fixtures/test-desktop-only.ts";
 import { supabaseAdminClient, supabaseAnonClient } from "../supabase.ts";
 import { testDesktopOnlyWithManyChats } from "../fixtures/test-desktop-only-with-many-chats.ts";
+import { testWithLoggedInUser } from "../fixtures/test-with-logged-in-user.ts";
 
 test.describe("Chat", () => {
 	testWithMockedLlm(

--- a/apps/frontend/tests/e2e/document.spec.ts
+++ b/apps/frontend/tests/e2e/document.spec.ts
@@ -911,17 +911,16 @@ test.describe("Documents", () => {
 			await expect(uploadButton).toBeEnabled();
 
 			// Upload the 100th visible file using setInputFiles to simulate user file selection
-			const fileInput = page.locator('input[type="file"]').first();
-			await fileInput.setInputFiles(secondaryDocumentPath);
-
-			await page.waitForResponse(
-				(res) =>
-					res.url().includes("/documents/process") &&
-					res.request().method() === "POST",
-				{ timeout: 60_000 },
-			);
-
-			await page.waitForLoadState("networkidle");
+			await mockDocumentUpload({
+				userId: account.id,
+				accessToken: session.access_token,
+				accessGroupId: null,
+				fileName: secondaryDocumentName,
+				filePath: secondaryDocumentPath,
+				sourceType: "personal_document",
+				bucketName: defaultBucketName,
+			});
+			await page.goto("/");
 
 			// Now at 100 visible → limit reached again
 			await expect(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filtered out empty assistant messages before sending conversation history to the AI for both initial and streaming responses, reducing blank replies and improving stability.

* **Tests**
  * Chat e2e test now runs under an authenticated user context to ensure Enter during streaming doesn't duplicate messages.
  * Document e2e test switched to a mocked document upload to reliably assert upload limits and UI state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/technologiestiftung/baergpt/pull/292)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214290156293226