### PR TITLE
Feat/extract preview document in own store

### DIFF
--- a/apps/backend/src/services/db-service/base-db-service.ts
+++ b/apps/backend/src/services/db-service/base-db-service.ts
@@ -54,7 +54,7 @@ export abstract class BaseContentDbService {
 		);
 
 		if (summariesError) {
-			throw new Error("Failed to find summaries");
+			throw summariesError;
 		}
 
 		return summaries;

--- a/apps/frontend/src/components/documents/document-list/list-item/document-item.tsx
+++ b/apps/frontend/src/components/documents/document-list/list-item/document-item.tsx
@@ -7,6 +7,7 @@ import { DraggableDocumentName } from "./draggable-document-name.tsx";
 import Content from "../../../../content.ts";
 import { ToggleChatItemButton } from "./toggle-chat-item-button.tsx";
 import { ItemDropdownButton } from "./dropdown/item-dropdown-button.tsx";
+import { usePreviewDocumentStore } from "../../../../store/use-preview-document-store.ts";
 
 interface DocumentItemProps {
 	item: Document;
@@ -19,8 +20,8 @@ const DocumentItem: React.FC<DocumentItemProps> = ({ item }) => {
 		selectedDocumentsForAction,
 		selectedChatDocuments,
 		toggleChatDocument,
-		selectedPreviewDocument,
 	} = useDocumentStore();
+	const { selectedPreviewDocument } = usePreviewDocumentStore();
 	const { isMultiSelectForActionVisible } = useDocumentsListStore();
 
 	const isSelectedForAction = selectedDocumentsForAction.some(

--- a/apps/frontend/src/components/documents/document-list/list-item/draggable-document-name.tsx
+++ b/apps/frontend/src/components/documents/document-list/list-item/draggable-document-name.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { useDocumentStore } from "../../../../store/document-store.ts";
+import { usePreviewDocumentStore } from "../../../../store/use-preview-document-store.ts";
 import { useDrag } from "react-dnd";
 import type { Document } from "../../../../common.ts";
 import { DocumentIcon } from "../../../primitives/icons/document-icon.tsx";
@@ -14,7 +14,8 @@ type DragableProps = {
 const TOOLTIP_DELAY = 600;
 
 export function DraggableDocumentName({ item }: DragableProps) {
-	const { selectPreviewDocument, selectedPreviewDocument } = useDocumentStore();
+	const { selectPreviewDocument, selectedPreviewDocument } =
+		usePreviewDocumentStore();
 	const { showTooltip, hideTooltip } = useTooltipStore();
 	const tooltipTimeoutRef = useRef<number | null>(null);
 	const spanRef = useRef<HTMLSpanElement>(null);

--- a/apps/frontend/src/components/documents/document-list/list-item/dropdown/item-dropdown.tsx
+++ b/apps/frontend/src/components/documents/document-list/list-item/dropdown/item-dropdown.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useDropdownKeyboard } from "../../../../../hooks/use-dropdown-keyboard";
-import { useDocumentStore } from "../../../../../store/document-store";
+import { usePreviewDocumentStore } from "../../../../../store/use-preview-document-store.ts";
 import type { Document, DocumentFolder } from "../../../../../common";
 import Content from "../../../../../content";
 import { isDocument } from "../utils/is-document";
@@ -24,7 +24,7 @@ export const ItemDropdown: React.FC<ItemDropdownProps> = ({
 	onClose,
 	triggerRef,
 }) => {
-	const { selectPreviewDocument } = useDocumentStore();
+	const { selectPreviewDocument } = usePreviewDocumentStore();
 	const { setSingleItemSelectedForAction } = useDocumentsListStore();
 	const [position, setPosition] = useState<{
 		top: number;

--- a/apps/frontend/src/components/documents/document-preview-section.tsx
+++ b/apps/frontend/src/components/documents/document-preview-section.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useDocumentStore } from "../../store/document-store";
+import { usePreviewDocumentStore } from "../../store/use-preview-document-store.ts";
 import { useErrorStore } from "../../store/error-store";
 import { CloseIcon } from "../primitives/icons/close-icon";
 import Content from "../../content";
@@ -10,7 +10,7 @@ export const DocumentPreviewSection: React.FC = () => {
 		selectedPreviewDocumentPreviewUrl,
 		selectedPreviewDocumentDownloadUrl,
 		unselectPreviewDocument,
-	} = useDocumentStore();
+	} = usePreviewDocumentStore();
 
 	const { getUIError } = useErrorStore();
 	const errorMessage = getUIError("document-download");

--- a/apps/frontend/src/store/current-chat-id-store.ts
+++ b/apps/frontend/src/store/current-chat-id-store.ts
@@ -6,6 +6,7 @@ import { useFaviconStore } from "./favicon-store.ts";
 import { useChatsStore } from "./use-chats-store.ts";
 import { useInferenceLoadingStatusStore } from "./use-inference-loading-status-store.ts";
 import { useChatStreamingStore } from "./use-chat-streaming-store.ts";
+import { usePreviewDocumentStore } from "./use-preview-document-store.ts";
 
 interface CurrentChatIdStore {
 	currentChatId: number | null;
@@ -52,7 +53,7 @@ const loadChatFavicons = (chatId: number) => {
 };
 
 const clearPreviewDocument = () => {
-	const { unselectPreviewDocument } = useDocumentStore.getState();
+	const { unselectPreviewDocument } = usePreviewDocumentStore.getState();
 	unselectPreviewDocument();
 };
 

--- a/apps/frontend/src/store/document-store.ts
+++ b/apps/frontend/src/store/document-store.ts
@@ -5,8 +5,6 @@ import { getPublicDocuments } from "../api/documents/get-public-documents";
 import { deleteDocument } from "../api/documents/delete-document";
 import { updateDocumentFolder } from "../api/documents/update-document-folder";
 import { getDocumentObjectUrl } from "../api/documents/get-document-object-url.ts";
-import { downloadDocument } from "../api/documents/download-document.ts";
-import { useErrorStore } from "./error-store";
 import { hideDefaultDocument } from "../api/documents/hide-default-document";
 import { getHiddenDefaultDocumentIds } from "../api/documents/get-hidden-default-document-ids";
 import { useChatsStore } from "./use-chats-store.ts";
@@ -24,12 +22,6 @@ interface DocumentStore {
 	deleteDocument: (documentId: number) => Promise<Error | null>;
 	removeItemFromFolder: (documentId: number) => Promise<void>;
 	moveItemToFolder: (documentId: number, folderId: number) => Promise<void>;
-
-	selectedPreviewDocument: Document | null;
-	selectedPreviewDocumentPreviewUrl: string | null;
-	selectedPreviewDocumentDownloadUrl: string | null;
-	selectPreviewDocument: (document: Document | null) => void;
-	unselectPreviewDocument: () => void;
 
 	selectedChatDocuments: Document[];
 	selectChatDocument: (document: Document) => void;
@@ -156,45 +148,6 @@ export const useDocumentStore = create<DocumentStore>((set, get) => ({
 				doc.id === documentId ? { ...doc, folder_id: folderId } : doc,
 			),
 		}));
-	},
-
-	selectedPreviewDocument: null,
-	selectedPreviewDocumentPreviewUrl: null,
-	selectedPreviewDocumentDownloadUrl: null,
-	selectPreviewDocument: async (document: Document | null) => {
-		set({ selectedPreviewDocument: document });
-
-		if (!document) {
-			return;
-		}
-
-		const previewUrl = await getDocumentObjectUrl({
-			sourceUrl: document.source_url,
-			sourceType: document.source_type,
-		});
-
-		set({ selectedPreviewDocumentPreviewUrl: previewUrl });
-
-		const blob = await downloadDocument({
-			sourceUrl: document.source_url,
-			sourceType: document.source_type,
-		});
-
-		if (!blob) {
-			return;
-		}
-
-		const downloadUrl = URL.createObjectURL(blob);
-
-		set({ selectedPreviewDocumentDownloadUrl: downloadUrl });
-	},
-	unselectPreviewDocument: () => {
-		useErrorStore.getState().clearUIError("document-download");
-		set({
-			selectedPreviewDocument: null,
-			selectedPreviewDocumentPreviewUrl: null,
-			selectedPreviewDocumentDownloadUrl: null,
-		});
 	},
 
 	selectedChatDocuments: [],

--- a/apps/frontend/src/store/use-preview-document-store.ts
+++ b/apps/frontend/src/store/use-preview-document-store.ts
@@ -1,0 +1,55 @@
+import { create } from "zustand";
+import { getDocumentObjectUrl } from "../api/documents/get-document-object-url.ts";
+import { downloadDocument } from "../api/documents/download-document.ts";
+import { useErrorStore } from "./error-store.ts";
+import { type Document } from "../common.ts";
+
+interface PreviewDocumentStore {
+	selectedPreviewDocument: Document | null;
+	selectedPreviewDocumentPreviewUrl: string | null;
+	selectedPreviewDocumentDownloadUrl: string | null;
+	selectPreviewDocument: (document: Document | null) => void;
+	unselectPreviewDocument: () => void;
+}
+
+export const usePreviewDocumentStore = create<PreviewDocumentStore>((set) => ({
+	selectedPreviewDocument: null,
+	selectedPreviewDocumentPreviewUrl: null,
+	selectedPreviewDocumentDownloadUrl: null,
+
+	selectPreviewDocument: async (document: Document | null) => {
+		set({ selectedPreviewDocument: document });
+
+		if (!document) {
+			return;
+		}
+
+		const previewUrl = await getDocumentObjectUrl({
+			sourceUrl: document.source_url,
+			sourceType: document.source_type,
+		});
+
+		set({ selectedPreviewDocumentPreviewUrl: previewUrl });
+
+		const blob = await downloadDocument({
+			sourceUrl: document.source_url,
+			sourceType: document.source_type,
+		});
+
+		if (!blob) {
+			return;
+		}
+
+		const downloadUrl = URL.createObjectURL(blob);
+
+		set({ selectedPreviewDocumentDownloadUrl: downloadUrl });
+	},
+	unselectPreviewDocument: () => {
+		useErrorStore.getState().clearUIError("document-download");
+		set({
+			selectedPreviewDocument: null,
+			selectedPreviewDocumentPreviewUrl: null,
+			selectedPreviewDocumentDownloadUrl: null,
+		});
+	},
+}));

--- a/apps/frontend/src/store/use-preview-document-store.ts
+++ b/apps/frontend/src/store/use-preview-document-store.ts
@@ -18,7 +18,22 @@ export const usePreviewDocumentStore = create<PreviewDocumentStore>((set) => ({
 	selectedPreviewDocumentDownloadUrl: null,
 
 	selectPreviewDocument: async (document: Document | null) => {
-		set({ selectedPreviewDocument: document });
+		const {
+			selectedPreviewDocumentDownloadUrl,
+			selectedPreviewDocumentPreviewUrl,
+		} = usePreviewDocumentStore.getState();
+		if (selectedPreviewDocumentDownloadUrl) {
+			URL.revokeObjectURL(selectedPreviewDocumentDownloadUrl);
+		}
+		if (selectedPreviewDocumentPreviewUrl) {
+			URL.revokeObjectURL(selectedPreviewDocumentPreviewUrl);
+		}
+
+		set({
+			selectedPreviewDocument: document,
+			selectedPreviewDocumentPreviewUrl: null,
+			selectedPreviewDocumentDownloadUrl: null,
+		});
 
 		if (!document) {
 			return;


### PR DESCRIPTION
This is a preparation PR for the upcoming read-only Verwaltungswissen folder, to split all required changes into smaller PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messaging when document summaries fail to retrieve, displaying specific error details instead of generic messages

* **Refactor**
  * Reorganized document preview state management into a dedicated store for better code organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/technologiestiftung/baergpt/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->