### PR TITLE
fix: proxy favicon requests to prevent exposing user IPs to Google

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -8,6 +8,7 @@ import documents from "./routes/documents";
 import llms from "./routes/llms";
 import { config, verifyConfig } from "./config";
 import admin from "./routes/admin";
+import favicon from "./routes/favicon";
 import { captureError } from "./monitoring/capture-error";
 import { initQueues } from "./services/distributed-limiter";
 import { logMemory } from "./monitoring/memory-logger";
@@ -37,6 +38,7 @@ app.use("*", sentryTracing);
 
 // Route modules
 app.route("/documents", documents);
+app.route("/favicon", favicon);
 app.route("/llm", llms);
 app.route("/admin", admin);
 

--- a/apps/backend/src/integration/db.integration.test.ts
+++ b/apps/backend/src/integration/db.integration.test.ts
@@ -150,9 +150,9 @@ describe("Integration tests for DB", async () => {
 						password: givenUserPassword,
 						email_confirm: true,
 					});
+				expect(signupError).toBeNull();
 				userId = data.user?.id ?? "";
 				expect(userId).not.toBe("");
-				expect(signupError).toBeNull();
 			});
 
 			it("should reject registration with invalid email domain", async () => {

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -1,13 +1,9 @@
 import { Hono } from "hono";
 import { PrivilegedDbService } from "../services/db-service/privileged-db-service";
-import { adminAuth } from "../middleware/admin-auth";
 import { captureError } from "../monitoring/capture-error";
-import basicAuth from "../middleware/basic-auth";
 import { serviceRoleDbClient } from "../supabase";
 
 const admin = new Hono();
-admin.use(basicAuth);
-admin.use(adminAuth);
 
 const serviceRoleAdminService = new PrivilegedDbService(serviceRoleDbClient);
 

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -2,8 +2,10 @@ import { Hono } from "hono";
 import { PrivilegedDbService } from "../services/db-service/privileged-db-service";
 import { captureError } from "../monitoring/capture-error";
 import { serviceRoleDbClient } from "../supabase";
+import { adminAuth } from "../middleware/admin-auth";
 
 const admin = new Hono();
+admin.use(adminAuth);
 
 const serviceRoleAdminService = new PrivilegedDbService(serviceRoleDbClient);
 

--- a/apps/backend/src/routes/favicon.ts
+++ b/apps/backend/src/routes/favicon.ts
@@ -1,0 +1,46 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { captureError } from "../monitoring/capture-error";
+
+const cache = new Map<string, { data: ArrayBuffer; contentType: string; expiresAt: number }>();
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+const favicon = new Hono();
+
+// route to fetch favicon for a given domain
+favicon.get("/", async (c: Context) => {
+  const domain = c.req.query("domain");
+
+  if (!domain) {
+    return c.json({ error: "Invalid domain" }, 400);
+  }
+
+  const now = Date.now();
+  const cached = cache.get(domain);
+
+  if (cached && cached.expiresAt > now) {
+    return c.body(cached.data, 200, { "Content-Type": cached.contentType });
+  }
+
+  try {
+    const response = await fetch(
+      `https://www.google.com/s2/favicons?domain=${domain}&sz=32`,
+    );
+
+    if (!response.ok) {
+      return c.json({ error: "Failed to fetch favicon" }, 502);
+    }
+
+    const contentType = response.headers.get("Content-Type") ?? "image/png";
+    const data = await response.arrayBuffer();
+
+    cache.set(domain, { data, contentType, expiresAt: now + TTL_MS });
+
+    return c.body(data, 200, { "Content-Type": contentType });
+  } catch (error) {
+    captureError(error);
+    return c.json({ error: "Failed to fetch favicon" }, 502);
+  }
+});
+
+export default favicon;

--- a/apps/backend/src/routes/favicon.ts
+++ b/apps/backend/src/routes/favicon.ts
@@ -2,24 +2,13 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { captureError } from "../monitoring/capture-error";
 
-const cache = new Map<string, { data: ArrayBuffer; contentType: string; expiresAt: number }>();
-const TTL_MS = 24 * 60 * 60 * 1000;
-
 const favicon = new Hono();
 
-// route to fetch favicon for a given domain
 favicon.get("/", async (c: Context) => {
   const domain = c.req.query("domain");
 
   if (!domain) {
     return c.json({ error: "Invalid domain" }, 400);
-  }
-
-  const now = Date.now();
-  const cached = cache.get(domain);
-
-  if (cached && cached.expiresAt > now) {
-    return c.body(cached.data, 200, { "Content-Type": cached.contentType });
   }
 
   try {
@@ -34,9 +23,10 @@ favicon.get("/", async (c: Context) => {
     const contentType = response.headers.get("Content-Type") ?? "image/png";
     const data = await response.arrayBuffer();
 
-    cache.set(domain, { data, contentType, expiresAt: now + TTL_MS });
-
-    return c.body(data, 200, { "Content-Type": contentType });
+    return c.body(data, 200, {
+      "Content-Type": contentType,
+      "Cache-Control": "max-age=86400",
+    });
   } catch (error) {
     captureError(error);
     return c.json({ error: "Failed to fetch favicon" }, 502);

--- a/apps/backend/src/routes/favicon.ts
+++ b/apps/backend/src/routes/favicon.ts
@@ -5,32 +5,32 @@ import { captureError } from "../monitoring/capture-error";
 const favicon = new Hono();
 
 favicon.get("/", async (c: Context) => {
-  const domain = c.req.query("domain");
+	const domain = c.req.query("domain");
 
-  if (!domain) {
-    return c.json({ error: "Invalid domain" }, 400);
-  }
+	if (!domain) {
+		return c.json({ error: "Invalid domain" }, 400);
+	}
 
-  try {
-    const response = await fetch(
-      `https://www.google.com/s2/favicons?domain=${domain}&sz=32`,
-    );
+	try {
+		const response = await fetch(
+			`https://www.google.com/s2/favicons?domain=${domain}&sz=32`,
+		);
 
-    if (!response.ok) {
-      return c.json({ error: "Failed to fetch favicon" }, 502);
-    }
+		if (!response.ok) {
+			return c.json({ error: "Failed to fetch favicon" }, 502);
+		}
 
-    const contentType = response.headers.get("Content-Type") ?? "image/png";
-    const data = await response.arrayBuffer();
+		const contentType = response.headers.get("Content-Type") ?? "image/png";
+		const data = await response.arrayBuffer();
 
-    return c.body(data, 200, {
-      "Content-Type": contentType,
-      "Cache-Control": "max-age=86400",
-    });
-  } catch (error) {
-    captureError(error);
-    return c.json({ error: "Failed to fetch favicon" }, 502);
-  }
+		return c.body(data, 200, {
+			"Content-Type": contentType,
+			"Cache-Control": "max-age=86400",
+		});
+	} catch (error) {
+		captureError(error);
+		return c.json({ error: "Failed to fetch favicon" }, 502);
+	}
 });
 
 export default favicon;

--- a/apps/backend/src/routes/favicon.ts
+++ b/apps/backend/src/routes/favicon.ts
@@ -7,13 +7,13 @@ const favicon = new Hono();
 favicon.get("/", async (c: Context) => {
 	const domain = c.req.query("domain");
 
-	if (!domain) {
+	if (!domain || domain.includes("://") || domain.includes("/")) {
 		return c.json({ error: "Invalid domain" }, 400);
 	}
 
 	try {
 		const response = await fetch(
-			`https://www.google.com/s2/favicons?domain=${domain}&sz=32`,
+			`https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=32`,
 		);
 
 		if (!response.ok) {

--- a/apps/backend/src/routes/favicon.ts
+++ b/apps/backend/src/routes/favicon.ts
@@ -17,6 +17,7 @@ favicon.get("/", async (c: Context) => {
 		);
 
 		if (!response.ok) {
+			captureError(new Error(`Failed to fetch favicon for domain: ${domain}`));
 			return c.json({ error: "Failed to fetch favicon" }, 502);
 		}
 

--- a/apps/frontend/src/api/chat/get-completion.ts
+++ b/apps/frontend/src/api/chat/get-completion.ts
@@ -180,7 +180,7 @@ export async function getCompletion(
 					web_citations: webSources.length ? webSources : null,
 				});
 				if (webSources.length) {
-					ensureFaviconsCached(webSources.map((s) => new URL(s.url).hostname));
+					ensureFaviconsCached(webSources.map(({ url }) => url));
 				}
 			},
 			onFinish: () => {

--- a/apps/frontend/src/api/chat/get-completion.ts
+++ b/apps/frontend/src/api/chat/get-completion.ts
@@ -7,6 +7,7 @@ import { useFolderStore } from "../../store/folder-store.ts";
 import { useUserStore } from "../../store/user-store.ts";
 import { useInferenceLoadingStatusStore } from "../../store/use-inference-loading-status-store.ts";
 import { useCitationsStore } from "../../store/use-citations-store.ts";
+import { useFaviconStore } from "../../store/favicon-store.ts";
 import { useChatStreamingStore } from "../../store/use-chat-streaming-store.ts";
 import type { Span } from "@sentry/react";
 
@@ -43,6 +44,7 @@ export async function getCompletion(
 	const { getSelectedChatFolderIds } = useFolderStore.getState();
 	const { setStatus } = useInferenceLoadingStatusStore.getState();
 	const { ensureCached } = useCitationsStore.getState();
+	const { ensureFaviconsCached } = useFaviconStore.getState();
 
 	const { session } = useAuthStore.getState();
 	const { user } = useUserStore.getState();
@@ -177,6 +179,9 @@ export async function getCompletion(
 					citations: citations.length ? citations : null,
 					web_citations: webSources.length ? webSources : null,
 				});
+				if (webSources.length) {
+					ensureFaviconsCached(webSources.map((s) => new URL(s.url).hostname));
+				}
 			},
 			onFinish: () => {
 				setStatus("idle");

--- a/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
+++ b/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
@@ -12,22 +12,24 @@ export function WebCitationItem({ source }: { source: WebCitationSource }) {
 
 	useEffect(() => {
 		const token = useAuthStore.getState().session?.access_token;
-		if (!token) return;
-
 		let objectUrl: string | null = null;
 
-		fetch(`${import.meta.env.VITE_API_URL}/favicon?domain=${encodeURIComponent(hostname)}`, {
-			headers: { Authorization: `Bearer ${token}` },
-		})
-			.then((res) => (res.ok ? res.blob() : Promise.reject()))
-			.then((blob) => {
-				objectUrl = URL.createObjectURL(blob);
-				setIconSrc(objectUrl);
+		if (token) {
+			fetch(`${import.meta.env.VITE_API_URL}/favicon?domain=${encodeURIComponent(hostname)}`, {
+				headers: { Authorization: `Bearer ${token}` },
 			})
-			.catch(() => setIconSrc(GLOBE_ICON_SRC));
+				.then((res) => (res.ok ? res.blob() : Promise.reject()))
+				.then((blob) => {
+					objectUrl = URL.createObjectURL(blob);
+					setIconSrc(objectUrl);
+				})
+				.catch(() => setIconSrc(GLOBE_ICON_SRC));
+		}
 
 		return () => {
-			if (objectUrl) URL.revokeObjectURL(objectUrl);
+			if (objectUrl) {
+				URL.revokeObjectURL(objectUrl);
+			}
 		};
 	}, [hostname]);
 

--- a/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
+++ b/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
@@ -15,9 +15,12 @@ export function WebCitationItem({ source }: { source: WebCitationSource }) {
 		let objectUrl: string | null = null;
 
 		if (token) {
-			fetch(`${import.meta.env.VITE_API_URL}/favicon?domain=${encodeURIComponent(hostname)}`, {
-				headers: { Authorization: `Bearer ${token}` },
-			})
+			fetch(
+				`${import.meta.env.VITE_API_URL}/favicon?domain=${encodeURIComponent(hostname)}`,
+				{
+					headers: { Authorization: `Bearer ${token}` },
+				},
+			)
 				.then((res) => (res.ok ? res.blob() : Promise.reject()))
 				.then((blob) => {
 					objectUrl = URL.createObjectURL(blob);

--- a/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
+++ b/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
@@ -1,40 +1,15 @@
-import { useState, useEffect } from "react";
 import removeMarkdown from "remove-markdown";
 import type { WebCitationSource } from "../../../../api/chat/get-completion.ts";
 import { TruncatedSnippet } from "./truncated-snippet.tsx";
-import { useAuthStore } from "../../../../store/auth-store.ts";
+import { useFaviconStore } from "../../../../store/favicon-store.ts";
 
 const GLOBE_ICON_SRC = "/icons/web-search-icon.svg";
 
 export function WebCitationItem({ source }: { source: WebCitationSource }) {
 	const hostname = new URL(source.url).hostname;
-	const [iconSrc, setIconSrc] = useState(GLOBE_ICON_SRC);
-
-	useEffect(() => {
-		const token = useAuthStore.getState().session?.access_token;
-		let objectUrl: string | null = null;
-
-		if (token) {
-			fetch(
-				`${import.meta.env.VITE_API_URL}/favicon?domain=${encodeURIComponent(hostname)}`,
-				{
-					headers: { Authorization: `Bearer ${token}` },
-				},
-			)
-				.then((res) => (res.ok ? res.blob() : Promise.reject()))
-				.then((blob) => {
-					objectUrl = URL.createObjectURL(blob);
-					setIconSrc(objectUrl);
-				})
-				.catch(() => setIconSrc(GLOBE_ICON_SRC));
-		}
-
-		return () => {
-			if (objectUrl) {
-				URL.revokeObjectURL(objectUrl);
-			}
-		};
-	}, [hostname]);
+	const iconSrc =
+		useFaviconStore((state) => state.faviconByHostname[hostname]) ??
+		GLOBE_ICON_SRC;
 
 	const handleClick = () => {
 		window.open(source.url, "_blank", "noopener,noreferrer");

--- a/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
+++ b/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
@@ -11,18 +11,15 @@ export function WebCitationItem({ source }: { source: WebCitationSource }) {
 		useFaviconStore((state) => state.faviconByHostname[hostname]) ??
 		GLOBE_ICON_SRC;
 
-	const handleClick = () => {
-		window.open(source.url, "_blank", "noopener,noreferrer");
-	};
-
 	const date = source.age?.[1] ? `${source.age?.[1]} –` : "";
 	const textWithDate = `${date} ${source.snippet}`;
 
 	return (
-		<button
-			type="button"
+		<a
+			href={source.url}
+			target="_blank"
+			rel="noopener noreferrer"
 			className="group flex flex-col items-start p-3.5 hover:bg-hellblau-30 text-dunkelblau-200 cursor-pointer gap-2.5"
-			onClick={handleClick}
 		>
 			<div className="flex items-center gap-1 text-xs">
 				<img
@@ -40,6 +37,6 @@ export function WebCitationItem({ source }: { source: WebCitationSource }) {
 			<div className="relative flex text-sm leading-5 group-hover:underline h-10">
 				<TruncatedSnippet text={removeMarkdown(textWithDate)} lines={2} />
 			</div>
-		</button>
+		</a>
 	);
 }

--- a/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
+++ b/apps/frontend/src/components/chat/chat-message/chat-citations/web-citation-item.tsx
@@ -1,17 +1,35 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import removeMarkdown from "remove-markdown";
 import type { WebCitationSource } from "../../../../api/chat/get-completion.ts";
 import { TruncatedSnippet } from "./truncated-snippet.tsx";
+import { useAuthStore } from "../../../../store/auth-store.ts";
 
 const GLOBE_ICON_SRC = "/icons/web-search-icon.svg";
 
-function faviconUrlForHostname(hostname: string) {
-	return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(hostname)}&sz=32`;
-}
-
 export function WebCitationItem({ source }: { source: WebCitationSource }) {
 	const hostname = new URL(source.url).hostname;
-	const [iconSrc, setIconSrc] = useState(() => faviconUrlForHostname(hostname));
+	const [iconSrc, setIconSrc] = useState(GLOBE_ICON_SRC);
+
+	useEffect(() => {
+		const token = useAuthStore.getState().session?.access_token;
+		if (!token) return;
+
+		let objectUrl: string | null = null;
+
+		fetch(`${import.meta.env.VITE_API_URL}/favicon?domain=${encodeURIComponent(hostname)}`, {
+			headers: { Authorization: `Bearer ${token}` },
+		})
+			.then((res) => (res.ok ? res.blob() : Promise.reject()))
+			.then((blob) => {
+				objectUrl = URL.createObjectURL(blob);
+				setIconSrc(objectUrl);
+			})
+			.catch(() => setIconSrc(GLOBE_ICON_SRC));
+
+		return () => {
+			if (objectUrl) URL.revokeObjectURL(objectUrl);
+		};
+	}, [hostname]);
 
 	const handleClick = () => {
 		window.open(source.url, "_blank", "noopener,noreferrer");
@@ -33,7 +51,6 @@ export function WebCitationItem({ source }: { source: WebCitationSource }) {
 					width={16}
 					height={16}
 					className="size-4 shrink-0"
-					onError={() => setIconSrc(GLOBE_ICON_SRC)}
 				/>
 				{hostname}
 			</div>

--- a/apps/frontend/src/store/current-chat-id-store.ts
+++ b/apps/frontend/src/store/current-chat-id-store.ts
@@ -3,7 +3,6 @@ import { useDocumentStore } from "./document-store.ts";
 import { useFolderStore } from "./folder-store.ts";
 import { useCitationsStore } from "./use-citations-store.ts";
 import { useFaviconStore } from "./favicon-store.ts";
-import { captureError } from "../monitoring/capture-error.ts";
 import { useChatsStore } from "./use-chats-store.ts";
 import { useInferenceLoadingStatusStore } from "./use-inference-loading-status-store.ts";
 import { useChatStreamingStore } from "./use-chat-streaming-store.ts";
@@ -48,7 +47,7 @@ const loadChatFavicons = (chatId: number) => {
 		.flatMap((message) => message.web_citations ?? [])
 		.map((wc) => new URL(wc.url).hostname);
 	if (hostnames.length > 0) {
-		ensureFaviconsCached(hostnames).catch(captureError);
+		void ensureFaviconsCached(hostnames);
 	}
 };
 

--- a/apps/frontend/src/store/current-chat-id-store.ts
+++ b/apps/frontend/src/store/current-chat-id-store.ts
@@ -43,11 +43,11 @@ const loadChatFavicons = (chatId: number) => {
 	if (!selectedChat) {
 		return;
 	}
-	const hostnames = selectedChat.messages
+	const webCitationUrls = selectedChat.messages
 		.flatMap((message) => message.web_citations ?? [])
-		.map((wc) => new URL(wc.url).hostname);
-	if (hostnames.length > 0) {
-		void ensureFaviconsCached(hostnames);
+		.map(({ url }) => url);
+	if (webCitationUrls.length > 0) {
+		void ensureFaviconsCached(webCitationUrls);
 	}
 };
 

--- a/apps/frontend/src/store/current-chat-id-store.ts
+++ b/apps/frontend/src/store/current-chat-id-store.ts
@@ -2,6 +2,8 @@ import { create } from "zustand";
 import { useDocumentStore } from "./document-store.ts";
 import { useFolderStore } from "./folder-store.ts";
 import { useCitationsStore } from "./use-citations-store.ts";
+import { useFaviconStore } from "./favicon-store.ts";
+import { captureError } from "../monitoring/capture-error.ts";
 import { useChatsStore } from "./use-chats-store.ts";
 import { useInferenceLoadingStatusStore } from "./use-inference-loading-status-store.ts";
 import { useChatStreamingStore } from "./use-chat-streaming-store.ts";
@@ -35,6 +37,21 @@ const loadChatCitations = (chatId: number) => {
 	}
 };
 
+const loadChatFavicons = (chatId: number) => {
+	const { ensureFaviconsCached } = useFaviconStore.getState();
+	const chats = useChatsStore.getState().chats;
+	const selectedChat = chats.find((chatItem) => chatItem.id === chatId);
+	if (!selectedChat) {
+		return;
+	}
+	const hostnames = selectedChat.messages
+		.flatMap((message) => message.web_citations ?? [])
+		.map((wc) => new URL(wc.url).hostname);
+	if (hostnames.length > 0) {
+		ensureFaviconsCached(hostnames).catch(captureError);
+	}
+};
+
 const clearPreviewDocument = () => {
 	const { unselectPreviewDocument } = useDocumentStore.getState();
 	unselectPreviewDocument();
@@ -62,6 +79,7 @@ export const useCurrentChatIdStore = create<CurrentChatIdStore>()(
 			}
 			if (chatId !== null) {
 				loadChatCitations(chatId);
+				loadChatFavicons(chatId);
 			}
 			clearPreviewDocument();
 			hideCompletionLoadingIndicator();

--- a/apps/frontend/src/store/favicon-store.ts
+++ b/apps/frontend/src/store/favicon-store.ts
@@ -1,24 +1,35 @@
 import { create } from "zustand";
 import { useAuthStore } from "./auth-store";
+import { captureError } from "../monitoring/capture-error";
 
 type FaviconStore = {
 	faviconByHostname: Record<string, string>;
-	ensureFaviconsCached: (hostnames: string[]) => Promise<void>;
+	ensureFaviconsCached: (urls: string[]) => Promise<void>;
 };
 
 export const useFaviconStore = create<FaviconStore>()((set, get) => ({
 	faviconByHostname: {},
 
-	async ensureFaviconsCached(hostnames) {
+	async ensureFaviconsCached(urls) {
 		const { faviconByHostname } = get();
 		const token = useAuthStore.getState().session?.access_token;
 		if (!token) {
 			return;
 		}
 
-		const missing = [...new Set(hostnames)].filter(
-			(h) => !faviconByHostname[h],
-		);
+		const missing = [
+			...new Set(
+				urls.flatMap((url) => {
+					try {
+						return [new URL(url).hostname];
+					} catch (error) {
+						captureError(error);
+						return [];
+					}
+				}),
+			),
+		].filter((h) => !faviconByHostname[h]);
+
 		if (missing.length === 0) {
 			return;
 		}

--- a/apps/frontend/src/store/favicon-store.ts
+++ b/apps/frontend/src/store/favicon-store.ts
@@ -1,0 +1,52 @@
+import { create } from "zustand";
+import { useAuthStore } from "./auth-store";
+
+type FaviconStore = {
+	faviconByHostname: Record<string, string>;
+	ensureFaviconsCached: (hostnames: string[]) => Promise<void>;
+};
+
+export const useFaviconStore = create<FaviconStore>()((set, get) => ({
+	faviconByHostname: {},
+
+	async ensureFaviconsCached(hostnames) {
+		const { faviconByHostname } = get();
+		const token = useAuthStore.getState().session?.access_token;
+		if (!token) {
+			return;
+		}
+
+		const missing = [...new Set(hostnames)].filter(
+			(h) => !faviconByHostname[h],
+		);
+		if (missing.length === 0) {
+			return;
+		}
+
+		const results = await Promise.all(
+			missing.map(async (hostname) => {
+				try {
+					const response = await fetch(
+						`${import.meta.env.VITE_API_URL}/favicon?domain=${encodeURIComponent(hostname)}`,
+						{ headers: { Authorization: `Bearer ${token}` } },
+					);
+					if (!response.ok) {
+						return null;
+					}
+					const blob = await response.blob();
+					return { hostname, url: URL.createObjectURL(blob) };
+				} catch {
+					return null;
+				}
+			}),
+		);
+
+		const merged = { ...faviconByHostname };
+		for (const result of results) {
+			if (result) {
+				merged[result.hostname] = result.url;
+			}
+		}
+		set({ faviconByHostname: merged });
+	},
+}));

--- a/apps/frontend/src/store/favicon-store.ts
+++ b/apps/frontend/src/store/favicon-store.ts
@@ -52,12 +52,14 @@ export const useFaviconStore = create<FaviconStore>()((set, get) => ({
 			}),
 		);
 
-		const merged = { ...faviconByHostname };
-		for (const result of results) {
-			if (result) {
-				merged[result.hostname] = result.url;
+		set((state) => {
+			const merged = { ...state.faviconByHostname };
+			for (const result of results) {
+				if (result) {
+					merged[result.hostname] = result.url;
+				}
 			}
-		}
-		set({ faviconByHostname: merged });
+			return { faviconByHostname: merged };
+		});
 	},
 }));


### PR DESCRIPTION
Previously favicons of cited URLs were loaded directly from Google's favicon service in the browser, exposing users' IP addresses and the domains they were viewing to Google.

A backend proxy endpoint (`GET /favicon`) now handles favicon fetching. The frontend calls our own backend, which forwards the request to Google, so Google only ever sees the server's IP. The endpoint is protected by JWT auth like all other backend routes. Since `<img>` tags cannot send custom headers, the frontend uses `fetch()` with the `Authorization` header instead, converts the response to a blob URL, and sets that as the image source. Browser-side caching via `Cache-Control: max-age=86400` prevents redundant requests for the same domain.

Additionally removed a redundant authorization check in the admin endpoint (already enforced by global middleware) and corrected assertion order in one test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend endpoint added to serve site favicons.
  * Frontend favicon cache/store added and used to display domain favicons for web citations.
  * Favicons are proactively cached when loading a chat and during live citation streaming.
  * Citation items now open external links in a new tab and show domain-specific icons.

* **Tests**
  * Reordered assertions in email-domain validation test for clearer verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/technologiestiftung/baergpt/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214495391882603