### PR TITLE
fix: make public_document storage upload idempotent in test fixture, …

### DIFF
--- a/apps/frontend/tests/fixtures/test-with-documents.ts
+++ b/apps/frontend/tests/fixtures/test-with-documents.ts
@@ -209,7 +209,9 @@ export async function mockDocumentUpload({
 			});
 
 	const uploadOptions =
-		sourceType === "default_document" ? { upsert: true } : undefined;
+		sourceType === "default_document" || sourceType === "public_document"
+			? { upsert: true }
+			: undefined;
 
 	const { error: uploadError } = await storageClient.storage
 		.from(bucketName)


### PR DESCRIPTION
…otherwise test failes

Public documents are shared seed data and should be treated the same as default documents.