### PR TITLE
Feat/supabase vm monitoring

### DIFF
--- a/infra/ansible/inventory/supabase-production.yml
+++ b/infra/ansible/inventory/supabase-production.yml
@@ -7,3 +7,4 @@ all:
           ansible_user: "{{ lookup('env', 'ANSIBLE_USER') }}"
           ansible_port: "{{ lookup('env', 'ANSIBLE_PORT') }}"
           ansible_ssh_private_key_file: "{{ lookup('env', 'ANSIBLE_SSH_KEY') }}"
+          baergpt_env: production

--- a/infra/ansible/inventory/supabase-staging.yml
+++ b/infra/ansible/inventory/supabase-staging.yml
@@ -7,3 +7,4 @@ all:
           ansible_user: "{{ lookup('env', 'ANSIBLE_USER') }}"
           ansible_port: "{{ lookup('env', 'ANSIBLE_PORT') }}"
           ansible_ssh_private_key_file: "{{ lookup('env', 'ANSIBLE_SSH_KEY') }}"
+          baergpt_env: staging

--- a/infra/ansible/roles/supabase/handlers/main.yml
+++ b/infra/ansible/roles/supabase/handlers/main.yml
@@ -1,0 +1,7 @@
+# force-recreate: the config is a bind-mounted single file, so a plain `up -d`
+# keeps the old inode after the file is replaced. Recreating reloads it.
+- name: Recreate otel-collector
+  ansible.builtin.command:
+    cmd: "docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d --force-recreate otel-collector"
+  args:
+    chdir: "{{ supabase_dir }}"

--- a/infra/ansible/roles/supabase/tasks/main.yml
+++ b/infra/ansible/roles/supabase/tasks/main.yml
@@ -49,14 +49,37 @@
       delegate_to: localhost
       become: false
 
+- name: Upload otel-collector config
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../supabase/otel-config.yml"
+    dest: "{{ supabase_dir }}/otel-config.yml"
+    mode: "0644"
+    force: true
+  notify: Recreate otel-collector
+
+- name: Upload monitoring compose overlay
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../supabase/docker-compose.monitoring.yml"
+    dest: "{{ supabase_dir }}/docker-compose.monitoring.yml"
+    mode: "0644"
+    force: true
+  notify: Recreate otel-collector
+
+- name: Render monitoring.env from inventory
+  ansible.builtin.template:
+    src: monitoring.env.j2
+    dest: "{{ supabase_dir }}/monitoring.env"
+    mode: "0640"
+  notify: Recreate otel-collector
+
 - name: Pull images
   ansible.builtin.command:
-    cmd: "docker compose pull"
+    cmd: "docker compose -f docker-compose.yml -f docker-compose.monitoring.yml pull"
   args:
     chdir: "{{ supabase_dir }}"
 
-- name: Start Supabase stack
+- name: Start Supabase + monitoring stack
   ansible.builtin.command:
-    cmd: "docker compose up -d"
+    cmd: "docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d"
   args:
     chdir: "{{ supabase_dir }}"

--- a/infra/ansible/roles/supabase/templates/monitoring.env.j2
+++ b/infra/ansible/roles/supabase/templates/monitoring.env.j2
@@ -1,0 +1,4 @@
+# Rendered by Ansible. Secrets (STACKIT_OBSERVABILITY_*) come from the Supabase .env.
+# Not named HOSTNAME: Docker auto-sets that per container and would shadow it.
+BAERGPT_ENV={{ baergpt_env }}
+BAERGPT_HOSTNAME={{ inventory_hostname }}

--- a/infra/supabase/MONITORING.md
+++ b/infra/supabase/MONITORING.md
@@ -1,0 +1,24 @@
+# Supabase VM monitoring
+
+An OpenTelemetry Collector runs on each Supabase VM (Compose overlay) and ships to
+STACKIT Observability: **metrics** via Prometheus remote-write, **logs** via OTLP/HTTP.
+
+- Collector config: [`otel-config.yml`](./otel-config.yml)
+- Overlay: [`docker-compose.monitoring.yml`](./docker-compose.monitoring.yml)
+- Provisioned by the Ansible `supabase` role; STACKIT creds come from the Supabase `.env`
+  (1Password), per-env metadata from `monitoring.env` (rendered from the inventory).
+- Grafana dashboard: [`grafana/supabase-vm-dashboard.json`](./grafana/supabase-vm-dashboard.json)
+  (import it; pick the Thanos + Loki datasources, switch `$source` for staging/prod).
+
+All telemetry is tagged `source=supabase-<env>` and `host=<hostname>`.
+
+## Metrics
+
+- **Host** (`hostmetrics`): cpu, memory, load, disk, filesystem, network, paging.
+- **Per-container** (`docker_stats`): cpu/memory/network/io per service (`container_name` label).
+
+## Logs
+
+Only the **Kong gateway** access logs + error/crit/alert/emerg lines, shipped under the Loki
+stream label `service_name=supabase-<env>` (filter by `container.id` in structured metadata).
+Everything else on container stdout is dropped (see `filter/gateway-only`).

--- a/infra/supabase/docker-compose.monitoring.yml
+++ b/infra/supabase/docker-compose.monitoring.yml
@@ -1,0 +1,31 @@
+# Overlay merged onto docker-compose.yml:
+#   docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+
+name: supabase
+
+services:
+  otel-collector:
+    container_name: supabase-otel-collector
+    image: otel/opentelemetry-collector-contrib:0.119.0
+    restart: unless-stopped
+    user: "0:0"  # root needed for /proc, /sys, docker.sock, /var/lib/docker/containers
+    command: ["--config=/etc/otel/config.yml"]
+    env_file:
+      - ./monitoring.env
+    environment:
+      STACKIT_OBSERVABILITY_USERNAME: ${STACKIT_OBSERVABILITY_USERNAME}
+      STACKIT_OBSERVABILITY_PASSWORD: ${STACKIT_OBSERVABILITY_PASSWORD}
+      STACKIT_OBSERVABILITY_METRICS_PUSH_URL: ${STACKIT_OBSERVABILITY_METRICS_PUSH_URL}
+      STACKIT_OBSERVABILITY_LOGS_OTLP_URL: ${STACKIT_OBSERVABILITY_LOGS_OTLP_URL}
+    volumes:
+      - ./otel-config.yml:/etc/otel/config.yml:ro
+      - /proc:/hostfs/proc:ro
+      - /sys:/hostfs/sys:ro
+      - /:/hostfs:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    deploy:
+      resources:
+        limits:
+          memory: 384M  # above otel-config memory_limiter (256MiB) so the limiter sheds load before the kernel OOM-kills
+          cpus: "0.5"

--- a/infra/supabase/grafana/supabase-vm-dashboard.json
+++ b/infra/supabase/grafana/supabase-vm-dashboard.json
@@ -1,0 +1,176 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "title": "Supabase VM — Health",
+  "uid": null,
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-6h", "to": "now" },
+  "tags": ["supabase", "otel", "stackit"],
+  "templating": {
+    "list": [
+      {
+        "name": "ds_metrics",
+        "label": "Metrics datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Thanos", "value": "Thanos" },
+        "hide": 0
+      },
+      {
+        "name": "ds_logs",
+        "label": "Logs datasource",
+        "type": "datasource",
+        "query": "loki",
+        "current": { "text": "Loki", "value": "Loki" },
+        "hide": 0
+      },
+      {
+        "name": "source",
+        "label": "Source",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+        "query": "label_values(source)",
+        "regex": "/supabase-.*/",
+        "current": { "text": "supabase-staging", "value": "supabase-staging" },
+        "refresh": 2,
+        "sort": 1,
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "gauge",
+      "title": "CPU used %",
+      "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent", "min": 0, "max": 100,
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 70 },
+            { "color": "red", "value": 90 }
+          ] }
+        }
+      },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+          "expr": "100 * (1 - (sum(rate(system_cpu_time_seconds_total{source=\"$source\", state=\"idle\"}[5m])) / sum(rate(system_cpu_time_seconds_total{source=\"$source\"}[5m]))))" }
+      ]
+    },
+    {
+      "type": "gauge",
+      "title": "RAM used %",
+      "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent", "min": 0, "max": 100,
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 75 },
+            { "color": "red", "value": 90 }
+          ] }
+        }
+      },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+          "expr": "100 * sum(system_memory_usage_bytes{source=\"$source\", state=\"used\"}) / sum(system_memory_usage_bytes{source=\"$source\"})" }
+      ]
+    },
+    {
+      "type": "gauge",
+      "title": "Disk used % (/)",
+      "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent", "min": 0, "max": 100,
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 75 },
+            { "color": "red", "value": 90 }
+          ] }
+        }
+      },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+          "expr": "100 * sum(system_filesystem_usage_bytes{source=\"$source\", state=\"used\", mountpoint=\"/\"}) / sum(system_filesystem_usage_bytes{source=\"$source\", state=~\"used|free\", mountpoint=\"/\"})" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU & RAM % over time",
+      "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 7 },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "calcs": ["last"] } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+          "expr": "100 * (1 - (sum(rate(system_cpu_time_seconds_total{source=\"$source\", state=\"idle\"}[5m])) / sum(rate(system_cpu_time_seconds_total{source=\"$source\"}[5m]))))",
+          "legendFormat": "CPU %" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+          "expr": "100 * sum(system_memory_usage_bytes{source=\"$source\", state=\"used\"}) / sum(system_memory_usage_bytes{source=\"$source\"})",
+          "legendFormat": "RAM %" }
+      ]
+    },
+
+    { "type": "row", "title": "Per-container", "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 } },
+
+    {
+      "type": "timeseries",
+      "title": "Container CPU (% of one core)",
+      "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0 } },
+      "options": { "legend": { "displayMode": "table", "calcs": ["last", "max"] } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+          "expr": "sum by (container_name) (rate(container_cpu_usage_nanoseconds_total{source=\"$source\"}[5m])) / 1e9 * 100",
+          "legendFormat": "{{container_name}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Container memory",
+      "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "bytes", "min": 0 } },
+      "options": { "legend": { "displayMode": "table", "calcs": ["last", "max"] } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${ds_metrics}" },
+          "expr": "sum by (container_name) (container_memory_usage_total_bytes{source=\"$source\"})",
+          "legendFormat": "{{container_name}}" }
+      ]
+    },
+
+    { "type": "row", "title": "Logs", "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 } },
+
+    {
+      "type": "timeseries",
+      "title": "Log volume by level",
+      "datasource": { "type": "loki", "uid": "${ds_logs}" },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 25 },
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0 } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "${ds_logs}" },
+          "expr": "sum by (detected_level) (count_over_time({service_name=\"$source\"} [$__auto]))",
+          "legendFormat": "{{detected_level}}" }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "Logs — $source",
+      "datasource": { "type": "loki", "uid": "${ds_logs}" },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 31 },
+      "options": { "showTime": true, "wrapLogMessage": true, "enableLogDetails": true, "sortOrder": "Descending", "dedupStrategy": "none" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "${ds_logs}" }, "expr": "{service_name=\"$source\"}" }
+      ]
+    }
+  ]
+}

--- a/infra/supabase/otel-config.yml
+++ b/infra/supabase/otel-config.yml
@@ -1,0 +1,133 @@
+# OTel Collector for the Supabase VM: host + container metrics and Kong gateway logs → STACKIT.
+# Env: STACKIT_OBSERVABILITY_{USERNAME,PASSWORD,METRICS_PUSH_URL,LOGS_OTLP_URL}, BAERGPT_ENV,
+# BAERGPT_HOSTNAME. LOGS_OTLP_URL must be the full ingest path (.../otlp/v1/logs), sent verbatim.
+
+extensions:
+  basicauth/stackit:
+    client_auth:
+      username: ${env:STACKIT_OBSERVABILITY_USERNAME}
+      password: ${env:STACKIT_OBSERVABILITY_PASSWORD}
+
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+receivers:
+  hostmetrics:
+    collection_interval: 60s
+    root_path: /hostfs
+    scrapers:
+      cpu: {}
+      memory: {}
+      load: {}
+      disk: {}
+      filesystem: {}
+      network: {}
+      paging: {}
+
+  docker_stats:
+    collection_interval: 60s
+    endpoint: unix:///var/run/docker.sock
+    timeout: 20s
+    api_version: "1.40"  # string, not float; daemons reject the old 1.25 default
+
+  filelog/containers:
+    include:
+      - /var/lib/docker/containers/*/*-json.log
+    start_at: end
+    include_file_path: true
+    operators:
+      - id: container-parser
+        type: container
+        format: docker
+        add_metadata_from_filepath: false
+      - id: extract-container-id
+        type: regex_parser
+        parse_from: attributes["log.file.path"]
+        regex: '^/var/lib/docker/containers/(?P<container_id>[a-f0-9]+)/'
+      - id: rename-container-id
+        type: move
+        from: attributes.container_id
+        to: attributes["container.id"]
+
+processors:
+  memory_limiter:
+    check_interval: 5s
+    limit_mib: 256
+    spike_limit_mib: 56
+
+  attributes/source:
+    actions:
+      - key: source
+        value: supabase-${env:BAERGPT_ENV}
+        action: upsert
+      - key: host
+        value: ${env:BAERGPT_HOSTNAME}
+        action: upsert
+
+  attributes/job-kong:
+    actions:
+      - key: job
+        value: kong
+        action: upsert
+
+  filter/gateway-only:  # keep only Kong access logs + error/crit/alert/emerg; drop everything else
+    error_mode: ignore
+    logs:
+      log_record:
+        - 'not (IsMatch(body, "^\\S+ \\S+ \\S+ \\[.*\\] \".*\" \\d{3} ") or IsMatch(body, "\\[(error|crit|alert|emerg)\\]"))'
+
+  resource/service:  # service.name -> Loki `service_name` stream label (else `unknown_service`)
+    attributes:
+      - key: service.name
+        value: supabase-${env:BAERGPT_ENV}
+        action: upsert
+
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+
+exporters:
+  prometheusremotewrite/stackit:
+    endpoint: ${env:STACKIT_OBSERVABILITY_METRICS_PUSH_URL}
+    auth:
+      authenticator: basicauth/stackit
+    resource_to_telemetry_conversion:
+      enabled: true  # surface docker_stats container.* as metric labels (e.g. container_name)
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+    remote_write_queue:
+      enabled: true
+      num_consumers: 2
+      queue_size: 1000
+
+  otlphttp/stackit:
+    logs_endpoint: ${env:STACKIT_OBSERVABILITY_LOGS_OTLP_URL}
+    auth:
+      authenticator: basicauth/stackit
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+    sending_queue:
+      enabled: true
+      num_consumers: 2
+      queue_size: 1000
+
+service:
+  telemetry:
+    logs:
+      level: info
+  extensions: [basicauth/stackit, health_check]
+  pipelines:
+    metrics:
+      receivers: [hostmetrics, docker_stats]
+      processors: [memory_limiter, resource/service, attributes/source, batch]
+      exporters: [prometheusremotewrite/stackit]
+    logs/containers:
+      receivers: [filelog/containers]
+      processors: [memory_limiter, filter/gateway-only, resource/service, attributes/source, attributes/job-kong, batch]
+      exporters: [otlphttp/stackit]


### PR DESCRIPTION
This adds basic VM monitoring so we can see CPU / RAM / Disk usage in Grafana on Stackit. We are shipping some basic Kong Gateway access logs as well. Shipping also the DB logs is a bit more complex and needs a follow up ticket. 

tldr:
We are adding another container via docker-compose-monitoring.yml that serves as a sidecar to collect all our telemetry and ship it over to stackit. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214498520569542