### PR TITLE
fix: Align `AllowedEmailDomain` type with backend API contract

### DIFF
--- a/apps/admin-panel/src/common.ts
+++ b/apps/admin-panel/src/common.ts
@@ -50,7 +50,10 @@ export type Document = {
 
 export type AllowedEmailDomain = {
 	domain: string;
-	date_added: string;
-	added_by_user: string;
 	is_active: boolean;
+	created_at: string;
+	created_by: string | null;
+	last_status_change_at: string | null;
+	last_status_change_by: string | null;
+	user_count: number;
 };

--- a/apps/admin-panel/src/components/add-new-domain-form/columns.tsx
+++ b/apps/admin-panel/src/components/add-new-domain-form/columns.tsx
@@ -32,11 +32,11 @@ export const columns: ColumnDef<AllowedEmailDomain>[] = [
 	},
 	{
 		header: Content["domainAllowlistTable.tableHeader.dateAdded"],
-		accessorKey: "date_added",
+		accessorKey: "created_at",
 	},
 	{
 		header: Content["domainAllowlistTable.tableHeader.addedBy"],
-		accessorKey: "added_by_user",
+		accessorKey: "created_by",
 	},
 	{
 		header: Content["domainAllowlistTable.tableHeader.isActive"],

--- a/apps/admin-panel/src/routes/domain-allowlist/index.tsx
+++ b/apps/admin-panel/src/routes/domain-allowlist/index.tsx
@@ -56,7 +56,7 @@ export const DomainAllowlistPage: React.FC = () => {
 		globalFilterFn: (row, _columnId, filterValue: string) => {
 			const {
 				domain = "",
-				added_by_user = "",
+				created_by = "",
 				is_active = "",
 			} = row.original as AllowedEmailDomain;
 			const query = filterValue.toLowerCase();
@@ -66,7 +66,7 @@ export const DomainAllowlistPage: React.FC = () => {
 			const queryWords = query.split(/\s+/).filter((word) => word.length > 0);
 			const searchableFields = [
 				domain?.toLowerCase() || "",
-				added_by_user?.toLowerCase() || "",
+				created_by?.toLowerCase() || "",
 				is_active?.toString() || "",
 			];
 			const result = queryWords.every((word) =>

--- a/apps/admin-panel/src/store/use-domain-store.ts
+++ b/apps/admin-panel/src/store/use-domain-store.ts
@@ -8,15 +8,21 @@ async function fetchAllowedEmailDomains(
 	return [
 		{
 			domain: "example.com",
-			date_added: new Date().toISOString(),
-			added_by_user: "test@example.com",
 			is_active: true,
+			created_at: new Date().toISOString(),
+			created_by: "test@example.com",
+			last_status_change_at: null,
+			last_status_change_by: null,
+			user_count: 0,
 		},
 		{
 			domain: "legacy.berlin.de",
-			date_added: new Date().toISOString(),
-			added_by_user: "admin@berlin.de",
 			is_active: false,
+			created_at: new Date().toISOString(),
+			created_by: "admin@berlin.de",
+			last_status_change_at: new Date().toISOString(),
+			last_status_change_by: "admin@berlin.de",
+			user_count: 3,
 		},
 	];
 }


### PR DESCRIPTION
Match the admin-panel domain types; rename `date_added` to `created_at` and `added_by_user` to `created_by`, and add `last_status_change_at/by` and `user_count`. No behavior change; the store still uses mocked data until the API is wired up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin panel domain allowlist now tracks additional metadata: creation timestamp and user, last status change details, and user count per domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->