### PR TITLE
Feat: personal prompt

### DIFF
--- a/apps/backend/src/integration/personal-system-prompt.integration.test.ts
+++ b/apps/backend/src/integration/personal-system-prompt.integration.test.ts
@@ -7,9 +7,9 @@ import { UserScopedDbService } from "../services/db-service/user-scoped-db-servi
 const OWNER_USER_ID = "33333333-3333-4333-8333-333333333333";
 const OTHER_USER_ID = "44444444-4444-4444-8444-444444444444";
 const INSERT_TRIGGER_USER_ID = "55555555-5555-4555-8555-555555555555";
-const OWNER_EMAIL = "psp-owner@local.berlin.de";
-const OTHER_EMAIL = "psp-other@local.berlin.de";
-const INSERT_TRIGGER_EMAIL = "psp-insert-trigger@local.berlin.de";
+const OWNER_EMAIL = "psp-owner@ts.berlin";
+const OTHER_EMAIL = "psp-other@ts.berlin";
+const INSERT_TRIGGER_EMAIL = "psp-insert-trigger@ts.berlin";
 
 const createTestUser = async (userId: string, email: string) => {
 	const { error } = await serviceRoleDbClient.auth.admin.createUser({

--- a/apps/backend/src/integration/personal-system-prompt.integration.test.ts
+++ b/apps/backend/src/integration/personal-system-prompt.integration.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { sign } from "hono/jwt";
+import { config } from "../config";
+import { serviceRoleDbClient, createUserScopedDbClient } from "../supabase";
+import { UserScopedDbService } from "../services/db-service/user-scoped-db-service";
+
+const OWNER_USER_ID = "33333333-3333-4333-8333-333333333333";
+const OTHER_USER_ID = "44444444-4444-4444-8444-444444444444";
+const OWNER_EMAIL = "psp-owner@local.berlin.de";
+const OTHER_EMAIL = "psp-other@local.berlin.de";
+
+const createTestUser = async (userId: string, email: string) => {
+	const { error } = await serviceRoleDbClient.auth.admin.createUser({
+		id: userId,
+		email,
+		password: "SecureTestPassword123!",
+		email_confirm: true,
+	});
+
+	if (error && !error.message.includes("already registered")) {
+		throw error;
+	}
+};
+
+const setPersonalSystemPrompt = async (
+	userId: string,
+	personalSystemPrompt: string | null,
+) => {
+	const { error } = await serviceRoleDbClient
+		.from("profiles")
+		.update({ personal_system_prompt: personalSystemPrompt })
+		.eq("id", userId);
+
+	if (error) {
+		throw error;
+	}
+};
+
+const createValidJwtToken = async (
+	userId: string,
+	email: string,
+): Promise<string> => {
+	return await sign(
+		{
+			exp: Math.floor(Date.now() / 1000) + 60 * 60,
+			sub: userId,
+			email,
+			role: "authenticated",
+		},
+		config.supabaseJwtKey,
+	);
+};
+
+const serviceForUser = async (
+	userId: string,
+	email: string,
+): Promise<UserScopedDbService> => {
+	const token = await createValidJwtToken(userId, email);
+	return new UserScopedDbService(createUserScopedDbClient(token));
+};
+
+describe("getPersonalSystemPrompt", () => {
+	beforeAll(async () => {
+		await createTestUser(OWNER_USER_ID, OWNER_EMAIL);
+		await createTestUser(OTHER_USER_ID, OTHER_EMAIL);
+	}, 20_000);
+
+	afterAll(async () => {
+		await serviceRoleDbClient.auth.admin.deleteUser(OWNER_USER_ID);
+		await serviceRoleDbClient.auth.admin.deleteUser(OTHER_USER_ID);
+	});
+
+	it("returns the trimmed personal system prompt for the authenticated user", async () => {
+		await setPersonalSystemPrompt(
+			OWNER_USER_ID,
+			"  Antworte immer auf Englisch.  ",
+		);
+		const service = await serviceForUser(OWNER_USER_ID, OWNER_EMAIL);
+
+		const result = await service.getPersonalSystemPrompt(OWNER_USER_ID);
+
+		expect(result).toBe("Antworte immer auf Englisch.");
+	});
+
+	it("returns null when the user has no personal system prompt", async () => {
+		await setPersonalSystemPrompt(OWNER_USER_ID, null);
+		const service = await serviceForUser(OWNER_USER_ID, OWNER_EMAIL);
+
+		const result = await service.getPersonalSystemPrompt(OWNER_USER_ID);
+
+		expect(result).toBeNull();
+	});
+
+	it("returns null for a whitespace-only personal system prompt", async () => {
+		await setPersonalSystemPrompt(OWNER_USER_ID, "   ");
+		const service = await serviceForUser(OWNER_USER_ID, OWNER_EMAIL);
+
+		const result = await service.getPersonalSystemPrompt(OWNER_USER_ID);
+
+		expect(result).toBeNull();
+	});
+
+	it("never exposes another user's personal system prompt (RLS scoping)", async () => {
+		await setPersonalSystemPrompt(OWNER_USER_ID, "SECRET OWNER PROMPT");
+		const otherUserService = await serviceForUser(OTHER_USER_ID, OTHER_EMAIL);
+
+		// RLS limits reads to the caller's own row, so requesting the owner's
+		// prompt as another user resolves to no visible row and rejects.
+		await expect(
+			otherUserService.getPersonalSystemPrompt(OWNER_USER_ID),
+		).rejects.toBeTruthy();
+	});
+});

--- a/apps/backend/src/integration/personal-system-prompt.integration.test.ts
+++ b/apps/backend/src/integration/personal-system-prompt.integration.test.ts
@@ -105,9 +105,11 @@ describe("getPersonalSystemPrompt", () => {
 		const otherUserService = await serviceForUser(OTHER_USER_ID, OTHER_EMAIL);
 
 		// RLS limits reads to the caller's own row, so requesting the owner's
-		// prompt as another user resolves to no visible row and rejects.
+		// prompt as another user resolves to no visible row. The owner's row
+		// exists, so the PGRST116 ("0 rows" from .single()) proves it was hidden
+		// by RLS rather than simply absent.
 		await expect(
 			otherUserService.getPersonalSystemPrompt(OWNER_USER_ID),
-		).rejects.toBeTruthy();
+		).rejects.toMatchObject({ code: "PGRST116" });
 	});
 });

--- a/apps/backend/src/integration/personal-system-prompt.integration.test.ts
+++ b/apps/backend/src/integration/personal-system-prompt.integration.test.ts
@@ -6,8 +6,10 @@ import { UserScopedDbService } from "../services/db-service/user-scoped-db-servi
 
 const OWNER_USER_ID = "33333333-3333-4333-8333-333333333333";
 const OTHER_USER_ID = "44444444-4444-4444-8444-444444444444";
+const INSERT_TRIGGER_USER_ID = "55555555-5555-4555-8555-555555555555";
 const OWNER_EMAIL = "psp-owner@local.berlin.de";
 const OTHER_EMAIL = "psp-other@local.berlin.de";
+const INSERT_TRIGGER_EMAIL = "psp-insert-trigger@local.berlin.de";
 
 const createTestUser = async (userId: string, email: string) => {
 	const { error } = await serviceRoleDbClient.auth.admin.createUser({
@@ -36,6 +38,22 @@ const setPersonalSystemPrompt = async (
 	}
 };
 
+const getPersonalSystemPromptFromProfile = async (
+	userId: string,
+): Promise<string | null> => {
+	const { data, error } = await serviceRoleDbClient
+		.from("profiles")
+		.select("personal_system_prompt")
+		.eq("id", userId)
+		.single();
+
+	if (error) {
+		throw error;
+	}
+
+	return data?.personal_system_prompt ?? null;
+};
+
 const createValidJwtToken = async (
 	userId: string,
 	email: string,
@@ -59,57 +77,77 @@ const serviceForUser = async (
 	return new UserScopedDbService(createUserScopedDbClient(token));
 };
 
-describe("getPersonalSystemPrompt", () => {
+describe("personal system prompt integration", () => {
 	beforeAll(async () => {
 		await createTestUser(OWNER_USER_ID, OWNER_EMAIL);
 		await createTestUser(OTHER_USER_ID, OTHER_EMAIL);
+		await createTestUser(INSERT_TRIGGER_USER_ID, INSERT_TRIGGER_EMAIL);
 	}, 20_000);
 
 	afterAll(async () => {
 		await serviceRoleDbClient.auth.admin.deleteUser(OWNER_USER_ID);
 		await serviceRoleDbClient.auth.admin.deleteUser(OTHER_USER_ID);
+		await serviceRoleDbClient.auth.admin.deleteUser(INSERT_TRIGGER_USER_ID);
 	});
 
-	it("returns the trimmed personal system prompt for the authenticated user", async () => {
-		await setPersonalSystemPrompt(
-			OWNER_USER_ID,
-			"  Antworte immer auf Englisch.  ",
-		);
-		const service = await serviceForUser(OWNER_USER_ID, OWNER_EMAIL);
+	describe("getPersonalSystemPrompt", () => {
+		it("returns null when the user has no personal system prompt", async () => {
+			await setPersonalSystemPrompt(OWNER_USER_ID, null);
+			const service = await serviceForUser(OWNER_USER_ID, OWNER_EMAIL);
 
-		const result = await service.getPersonalSystemPrompt(OWNER_USER_ID);
+			const result = await service.getPersonalSystemPrompt(OWNER_USER_ID);
 
-		expect(result).toBe("Antworte immer auf Englisch.");
+			expect(result).toBeNull();
+		});
+
+		it("never exposes another user's personal system prompt (RLS scoping)", async () => {
+			await setPersonalSystemPrompt(OWNER_USER_ID, "SECRET OWNER PROMPT");
+			const otherUserService = await serviceForUser(OTHER_USER_ID, OTHER_EMAIL);
+
+			// RLS limits reads to the caller's own row, so requesting the owner's
+			// prompt as another user resolves to no visible row.
+			const result =
+				await otherUserService.getPersonalSystemPrompt(OWNER_USER_ID);
+
+			expect(result).toBeNull();
+		});
 	});
 
-	it("returns null when the user has no personal system prompt", async () => {
-		await setPersonalSystemPrompt(OWNER_USER_ID, null);
-		const service = await serviceForUser(OWNER_USER_ID, OWNER_EMAIL);
+	describe("normalize_personal_system_prompt trigger", () => {
+		it("should normalize whitespace-only values to null on profile insert", async () => {
+			const whitespaceOnlyPrompt = " \n\t  ";
 
-		const result = await service.getPersonalSystemPrompt(OWNER_USER_ID);
+			const { error: deleteProfileError } = await serviceRoleDbClient
+				.from("profiles")
+				.delete()
+				.eq("id", INSERT_TRIGGER_USER_ID);
+			expect(deleteProfileError).toBeNull();
 
-		expect(result).toBeNull();
-	});
+			const { error: insertProfileError } = await serviceRoleDbClient
+				.from("profiles")
+				.insert({
+					id: INSERT_TRIGGER_USER_ID,
+					personal_system_prompt: whitespaceOnlyPrompt,
+				});
+			expect(insertProfileError).toBeNull();
 
-	it("returns null for a whitespace-only personal system prompt", async () => {
-		await setPersonalSystemPrompt(OWNER_USER_ID, "   ");
-		const service = await serviceForUser(OWNER_USER_ID, OWNER_EMAIL);
+			const storedPrompt = await getPersonalSystemPromptFromProfile(
+				INSERT_TRIGGER_USER_ID,
+			);
 
-		const result = await service.getPersonalSystemPrompt(OWNER_USER_ID);
+			expect(storedPrompt).toBeNull();
+		});
 
-		expect(result).toBeNull();
-	});
+		it("should trim surrounding whitespace on personal system prompt update", async () => {
+			await setPersonalSystemPrompt(
+				OWNER_USER_ID,
+				"\n\t  Bitte antworte kurz und praezise.  \t",
+			);
 
-	it("never exposes another user's personal system prompt (RLS scoping)", async () => {
-		await setPersonalSystemPrompt(OWNER_USER_ID, "SECRET OWNER PROMPT");
-		const otherUserService = await serviceForUser(OTHER_USER_ID, OTHER_EMAIL);
+			const storedPrompt =
+				await getPersonalSystemPromptFromProfile(OWNER_USER_ID);
 
-		// RLS limits reads to the caller's own row, so requesting the owner's
-		// prompt as another user resolves to no visible row. The owner's row
-		// exists, so the PGRST116 ("0 rows" from .single()) proves it was hidden
-		// by RLS rather than simply absent.
-		await expect(
-			otherUserService.getPersonalSystemPrompt(OWNER_USER_ID),
-		).rejects.toMatchObject({ code: "PGRST116" });
+			expect(storedPrompt).toBe("Bitte antworte kurz und praezise.");
+		});
 	});
 });

--- a/apps/backend/src/routes/llms.ts
+++ b/apps/backend/src/routes/llms.ts
@@ -82,8 +82,19 @@ llms.post("/just-chatting", async (c: Context) => {
 		}
 
 		const authenticatedUserId = c.get("authenticatedUserId");
-		const userSystemPrompt =
-			await userScopedDbService.getPersonalSystemPrompt(authenticatedUserId);
+		if (!authenticatedUserId) {
+			return c.json({ error: "Unauthorized" }, 401);
+		}
+		let userSystemPrompt: string | null = null;
+		try {
+			userSystemPrompt =
+				await userScopedDbService.getPersonalSystemPrompt(authenticatedUserId);
+		} catch (error) {
+			if (config.nodeEnv !== "production") {
+				throw error;
+			}
+			captureError(error);
+		}
 
 		const { messages: promptMessages, promptClient: langfusePrompt } =
 			await generationService.createPrompt({

--- a/apps/backend/src/routes/llms.ts
+++ b/apps/backend/src/routes/llms.ts
@@ -86,15 +86,8 @@ llms.post("/just-chatting", async (c: Context) => {
 			return c.json({ error: "Unauthorized" }, 401);
 		}
 		let userSystemPrompt: string | null = null;
-		try {
-			userSystemPrompt =
-				await userScopedDbService.getPersonalSystemPrompt(authenticatedUserId);
-		} catch (error) {
-			if (config.nodeEnv !== "production") {
-				throw error;
-			}
-			captureError(error);
-		}
+		userSystemPrompt =
+			await userScopedDbService.getPersonalSystemPrompt(authenticatedUserId);
 
 		const { messages: promptMessages, promptClient: langfusePrompt } =
 			await generationService.createPrompt({

--- a/apps/backend/src/routes/llms.ts
+++ b/apps/backend/src/routes/llms.ts
@@ -81,11 +81,16 @@ llms.post("/just-chatting", async (c: Context) => {
 			activeTools.push("ragSearchTool");
 		}
 
+		const authenticatedUserId = c.get("authenticatedUserId");
+		const userSystemPrompt =
+			await userScopedDbService.getPersonalSystemPrompt(authenticatedUserId);
+
 		const { messages: promptMessages, promptClient: langfusePrompt } =
 			await generationService.createPrompt({
 				previousMessages: messages,
 				isAddressedFormal,
 				activeTools,
+				userSystemPrompt,
 			});
 		const response = await generationService.generateTextStreamResponse({
 			llmHandler,

--- a/apps/backend/src/services/db-service/user-scoped-db-service.ts
+++ b/apps/backend/src/services/db-service/user-scoped-db-service.ts
@@ -25,6 +25,21 @@ export class UserScopedDbService extends BaseContentDbService {
 		}
 	}
 
+	async getPersonalSystemPrompt(userId: string): Promise<string | null> {
+		const { data, error } = await this.client
+			.from("profiles")
+			.select("personal_system_prompt")
+			.eq("id", userId)
+			.single();
+
+		if (error) {
+			throw error;
+		}
+
+		const personalSystemPrompt = data?.personal_system_prompt?.trim();
+		return personalSystemPrompt ? personalSystemPrompt : null;
+	}
+
 	async updateUsage(userId: string, tokenAmount: number): Promise<void> {
 		try {
 			await this.updateUserColumnValue(

--- a/apps/backend/src/services/db-service/user-scoped-db-service.ts
+++ b/apps/backend/src/services/db-service/user-scoped-db-service.ts
@@ -33,11 +33,11 @@ export class UserScopedDbService extends BaseContentDbService {
 			.single();
 
 		if (error) {
-			throw error;
+			captureError(error);
+			return null;
 		}
 
-		const personalSystemPrompt = data?.personal_system_prompt?.trim();
-		return personalSystemPrompt ? personalSystemPrompt : null;
+		return data?.personal_system_prompt ?? null;
 	}
 
 	async updateUsage(userId: string, tokenAmount: number): Promise<void> {

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -40,6 +40,28 @@ import type { WebSearchResult } from "../tools/web-search";
 
 const modelService = new ModelService();
 
+/**
+ * Langfuse currently does not support conditional sections in prompts.
+ * So we wrap a user's personal system prompt with the preamble that instructs the
+ * model how to treat it. Returns an empty string when there is no prompt.
+ */
+export function buildUserSystemPromptBlock(
+	userSystemPrompt: string | null | undefined,
+): string {
+	if (!userSystemPrompt) {
+		return "";
+	}
+
+	const preamble = [
+		"# NUTZER ANWEISUNGEN",
+		"",
+		"Die nutzende Person hat folgende benutzerdefinierte Anweisungen angegeben.",
+		"Befolge diese, sofern sie nicht im Widerspruch zu den obigen Anweisungen stehen:",
+	].join("\n");
+
+	return `\n\n${preamble}\n\n${userSystemPrompt}`;
+}
+
 type RelevantTools = {
 	tools: Record<string, Tool>;
 	toolChoice: ToolChoice<Record<string, Tool>>;
@@ -588,8 +610,14 @@ export class GenerationService {
 		previousMessages: ModelMessage[];
 		isAddressedFormal: boolean;
 		activeTools: ActiveTools[];
+		userSystemPrompt?: string | null;
 	}) {
-		const { previousMessages, isAddressedFormal, activeTools } = args;
+		const {
+			previousMessages,
+			isAddressedFormal,
+			activeTools,
+			userSystemPrompt,
+		} = args;
 
 		const currentDate = new Date().toLocaleDateString("de-DE", {
 			year: "numeric",
@@ -621,6 +649,7 @@ export class GenerationService {
 		const compiledFreeChatPrompt = freeChatPromptClient.compile({
 			currentDate: currentDate,
 			addressForm: addressForm,
+			userSystemPrompt: buildUserSystemPromptBlock(userSystemPrompt),
 		});
 
 		const freeChatPrompt: ModelMessage = {

--- a/apps/backend/supabase/migrations/20260618120000_add_personal_system_prompt_to_profiles.sql
+++ b/apps/backend/supabase/migrations/20260618120000_add_personal_system_prompt_to_profiles.sql
@@ -1,0 +1,7 @@
+-- Add a per-user personal system prompt to profiles.
+-- Injected into the global system prompt on every /just-chatting request.
+-- Length is capped at 500 characters as defense-in-depth (the frontend also enforces this).
+ALTER TABLE profiles
+ADD COLUMN IF NOT EXISTS personal_system_prompt TEXT CONSTRAINT personal_system_prompt_length CHECK (CHAR_LENGTH(personal_system_prompt) <= 500);
+
+COMMENT ON COLUMN profiles.personal_system_prompt IS 'User-defined personal system prompt, merged into the global system prompt on every chat request. NULL means none set.';

--- a/apps/backend/supabase/migrations/20260622120000_normalize_personal_system_prompt.sql
+++ b/apps/backend/supabase/migrations/20260622120000_normalize_personal_system_prompt.sql
@@ -1,0 +1,27 @@
+-- Trigger to normalise the personal system prompt on write.
+-- Trim surrounding whitespace, new lines and tabs. Collapse empty/whitespace-only values to NULL.
+CREATE OR REPLACE FUNCTION public.normalize_personal_system_prompt () RETURNS TRIGGER LANGUAGE plpgsql
+SET
+    search_path = '' AS $$
+BEGIN
+	NEW.personal_system_prompt := NULLIF(
+		regexp_replace(NEW.personal_system_prompt, '^\s+|\s+$', '', 'g'),
+		''
+	);
+	RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS normalize_personal_system_prompt_trigger ON public.profiles;
+
+CREATE TRIGGER normalize_personal_system_prompt_trigger BEFORE INSERT
+OR
+UPDATE OF personal_system_prompt ON public.profiles FOR EACH ROW
+EXECUTE FUNCTION public.normalize_personal_system_prompt ();
+
+-- Backfill existing rows to the normalized form.
+UPDATE public.profiles
+SET
+    personal_system_prompt = NULLIF(REGEXP_REPLACE(personal_system_prompt, '^\s+|\s+$', '', 'g'), '')
+WHERE
+    personal_system_prompt IS NOT NULL;

--- a/apps/frontend/src/api/user/update-personal-prompt.ts
+++ b/apps/frontend/src/api/user/update-personal-prompt.ts
@@ -1,0 +1,21 @@
+import { supabase } from "../../../supabase-client";
+import { useAuthStore } from "../../store/auth-store";
+
+export async function updatePersonalPrompt(
+	personalPrompt: string,
+): Promise<{ error: Error | null }> {
+	const userId = useAuthStore.getState().session?.user?.id;
+	if (!userId) {
+		return { error: new Error("User is not authenticated") };
+	}
+
+	const { error } = await supabase
+		.from("profiles")
+		.update({
+			personal_system_prompt: personalPrompt,
+		})
+		.eq("id", userId)
+		.select();
+
+	return { error };
+}

--- a/apps/frontend/src/common.ts
+++ b/apps/frontend/src/common.ts
@@ -106,6 +106,7 @@ export type User = {
 	academic_title?: string | null;
 	personal_title?: string | null;
 	is_addressed_formal?: boolean | null;
+	personal_system_prompt?: string | null;
 };
 
 export type CitationWithDetails = {

--- a/apps/frontend/src/components/profile/chat-settings/chat-settings.tsx
+++ b/apps/frontend/src/components/profile/chat-settings/chat-settings.tsx
@@ -91,7 +91,10 @@ export const ChatSettings = () => {
 					maxLength={500}
 					aria-describedby="personalPromptSubtitle personalPromptCounter"
 				/>
-				<p id="personalPromptCounter" className="text-xs leading-6 font-normal text-dunkelblau-40">
+				<p
+					id="personalPromptCounter"
+					className="text-xs leading-6 font-normal text-dunkelblau-40"
+				>
 					{`${personalPrompt.length} / 500 ${Content["profile.chatSettings.personalPrompt.characters"]}`}
 				</p>
 

--- a/apps/frontend/src/components/profile/chat-settings/chat-settings.tsx
+++ b/apps/frontend/src/components/profile/chat-settings/chat-settings.tsx
@@ -1,8 +1,20 @@
 import Content from "../../../content";
 import { useUserStore } from "../../../store/user-store.ts";
+import { type FormEvent, useState, useEffect } from "react";
+import { SubmitButton } from "../../primitives/buttons/submit-button.tsx";
+import { useToastStore } from "../../../store/use-toast-store.ts";
 
 export const ChatSettings = () => {
-	const { user, updateAddressedFormal } = useUserStore();
+	const { user, updateAddressedFormal, updatePersonalPrompt } = useUserStore();
+	const [personalPrompt, setPersonalPrompt] = useState(
+		user?.personal_system_prompt ?? "",
+	);
+
+	useEffect(() => {
+		setPersonalPrompt(user?.personal_system_prompt ?? "");
+	}, [user?.personal_system_prompt]);
+
+	const hasChanges = personalPrompt !== (user?.personal_system_prompt ?? "");
 
 	const isAddressedFormal = user?.is_addressed_formal ?? true;
 
@@ -10,17 +22,29 @@ export const ChatSettings = () => {
 		await updateAddressedFormal(!isAddressedFormal);
 	};
 
+	const { addSuccess } = useToastStore();
+
 	const changeSalutationTo = isAddressedFormal
 		? Content["profile.chatSettings.informal"]
 		: Content["profile.chatSettings.formal"];
 
+	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+
+		const { error } = await updatePersonalPrompt(personalPrompt);
+
+		if (!error) {
+			addSuccess(Content["profile.chatSettings.personalPromptUpdateSuccess"]);
+		}
+	};
+
 	return (
-		<div className="flex flex-col gap-y-2">
+		<div className="flex flex-col gap-y-4">
 			<h3 className="text-base leading-6 font-semibold ">
 				{Content["profile.chatSettings.title"]}
 			</h3>
 			<div className="flex justify-between items-center flex-row gap-5">
-				<p className="text-base leading-6 font-normal">
+				<p className="text-sm leading-6 font-normal">
 					{Content["profile.chatSettings.salutation"]}
 				</p>
 				<label className="inline-flex items-center cursor-pointer relative">
@@ -38,6 +62,43 @@ export const ChatSettings = () => {
 					/>
 				</label>
 			</div>
+			<form
+				onSubmit={handleSubmit}
+				className="flex justify-between flex-col gap-4"
+			>
+				<div>
+					<label
+						htmlFor="personalPrompt"
+						className="text-sm leading-6 font-semibold block cursor-pointer"
+					>
+						{Content["profile.chatSettings.personalPrompt.title"]}
+					</label>
+					<p
+						id="personalPromptSubtitle"
+						className="text-sm text-dunkelblau-60 leading-6 font-normal"
+					>
+						{Content["profile.chatSettings.personalPrompt.subtitle"]}
+					</p>
+				</div>
+				<textarea
+					id="personalPrompt"
+					className="w-full min-h-[90px] max-h-60 p-2.5 text-sm border border-dunkelblau-200 rounded-3px placeholder:text-sm placeholder:text-schwarz-60 focus-visible:outline-default"
+					placeholder={
+						Content["profile.chatSettings.personalPrompt.placeholder"]
+					}
+					value={personalPrompt}
+					onChange={(e) => setPersonalPrompt(e.target.value)}
+					maxLength={500}
+					aria-describedby="personalPromptSubtitle personalPromptCounter"
+				/>
+				<p id="personalPromptCounter" className="text-xs leading-6 font-normal text-dunkelblau-40">
+					{`${personalPrompt.length} / 500 ${Content["profile.chatSettings.personalPrompt.characters"]}`}
+				</p>
+
+				<SubmitButton disabled={!hasChanges} className="mt-4 self-end">
+					{Content["profile.submitButton"]}
+				</SubmitButton>
+			</form>
 		</div>
 	);
 };

--- a/apps/frontend/src/content.ts
+++ b/apps/frontend/src/content.ts
@@ -1029,6 +1029,15 @@ export const Content = {
 	"profile.chatSettings.ariaLabel": "Anrede ändern zu",
 	"profile.chatSettings.formal": "Siezen",
 	"profile.chatSettings.informal": "Duzen",
+	"profile.chatSettings.personalPrompt.title":
+		"Welche Präferenzen soll BärGPT berücksichtigen?",
+	"profile.chatSettings.personalPrompt.subtitle":
+		"Gilt für alle Unterhaltungen im Rahmen von BärGPTs Richtlinien.",
+	"profile.chatSettings.personalPrompt.placeholder":
+		"z.B. Antworte knapp und in einfacher Sprache.",
+	"profile.chatSettings.personalPrompt.characters": "Zeichen",
+	"profile.chatSettings.personalPromptUpdateSuccess":
+		"Persönliche Präferenzen wurden aktualisiert",
 
 	/* -------------------- Email Changed -------------------- */
 	"emailChanged.title": "Ihre neue E-Mail-Adresse wurde erfolgreich geändert.",

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -10,7 +10,7 @@
 	html {
 		scroll-behavior: smooth;
 	}
-	
+
 	.markdown-container p {
 		@apply my-1.5 hyphens-auto;
 		word-break: break-word;

--- a/apps/frontend/src/store/user-store.ts
+++ b/apps/frontend/src/store/user-store.ts
@@ -7,6 +7,7 @@ import { updateProfilesTable } from "../api/auth/update-profiles-table.ts";
 import { updateUserMetadata } from "../api/auth/update-user-metadata.ts";
 import { useErrorStore } from "./error-store.ts";
 import { updateAddressedFormal } from "../api/user/update-addressed-formal.ts";
+import { updatePersonalPrompt } from "../api/user/update-personal-prompt.ts";
 
 interface UserStore {
 	user: User | null;
@@ -18,7 +19,12 @@ interface UserStore {
 		personal_title: string;
 	}) => Promise<void>;
 	deleteAccount: () => Promise<{ error: Error | null }>;
-	updateAddressedFormal: (isAddressedFormal: boolean) => Promise<void>;
+	updateAddressedFormal: (
+		isAddressedFormal: boolean,
+	) => Promise<{ error: Error | null }>;
+	updatePersonalPrompt: (
+		personalPrompt: string,
+	) => Promise<{ error: Error | null }>;
 }
 
 export const useUserStore = create<UserStore>((set, get) => ({
@@ -67,10 +73,23 @@ export const useUserStore = create<UserStore>((set, get) => ({
 
 		if (error) {
 			useErrorStore.getState().handleError(error);
-			return;
+			return { error };
 		}
 
 		await get().getUser(new AbortController().signal);
+		return { error: null };
+	},
+
+	async updatePersonalPrompt(personalPrompt: string) {
+		const { error } = await updatePersonalPrompt(personalPrompt);
+
+		if (error) {
+			useErrorStore.getState().handleError(error);
+			return { error };
+		}
+
+		await get().getUser(new AbortController().signal);
+		return { error: null };
 	},
 
 	deleteAccount: async () => {

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -14,6 +14,7 @@ export default {
 				"warning-85": "#E45F5F",
 				"warning-10": "#FEF4F5",
 				"schwarz-40": "#737373",
+				"schwarz-60": "#666666",
 				"schwarz-100": "#000000",
 				"dunkelblau-200": "#030812",
 				"dunkelblau-100": "#0C2753",

--- a/apps/frontend/tests/e2e/user.spec.ts
+++ b/apps/frontend/tests/e2e/user.spec.ts
@@ -119,6 +119,99 @@ testWithLoggedInUser.describe("User Profile", () => {
 	);
 
 	testWithLoggedInUser(
+		"should allow user to update personal prompt",
+		async ({ page }) => {
+			await page.goto("/profile/");
+
+			await page.waitForResponse(
+				(res) =>
+					res.url().includes("/rest/v1/profiles") &&
+					res.request().method() === "GET" &&
+					res.ok(),
+			);
+
+			const newPrompt = "This is a new personal prompt for testing.";
+			const promptInput = page.locator("#personalPrompt");
+
+			await expect(promptInput).toBeVisible();
+
+			await promptInput.fill(newPrompt);
+			await expect(promptInput).toHaveValue(newPrompt);
+
+			const submitButton = page
+				.locator("form")
+				.filter({ has: promptInput })
+				.getByRole("button", { name: Content["profile.submitButton"] });
+
+			await expect(submitButton).toBeEnabled();
+
+			let updateRequestDetails: { personal_system_prompt?: string } | null =
+				null;
+			await page.route("**/rest/v1/profiles*", async (route) => {
+				if (route.request().method() === "PATCH") {
+					updateRequestDetails = route.request().postDataJSON();
+					await route.fulfill({
+						status: 200,
+						contentType: "application/json",
+						body: JSON.stringify([{ personal_system_prompt: newPrompt }]),
+					});
+				} else {
+					await route.fallback();
+				}
+			});
+
+			await Promise.all([
+				page.waitForResponse(
+					(res) =>
+						res.url().includes("/rest/v1/profiles") &&
+						res.request().method() === "PATCH",
+				),
+				submitButton.click(),
+			]);
+
+			expect(updateRequestDetails).toEqual(
+				expect.objectContaining({
+					personal_system_prompt: newPrompt,
+				}),
+			);
+
+			await expect(
+				page.getByText(
+					Content["profile.chatSettings.personalPromptUpdateSuccess"],
+				),
+			).toBeVisible();
+		},
+	);
+
+	testWithLoggedInUser(
+		"should respect max character limit for personal prompt",
+		async ({ page }) => {
+			await page.goto("/profile/");
+
+			await page.waitForResponse(
+				(res) =>
+					res.url().includes("/rest/v1/profiles") &&
+					res.request().method() === "GET" &&
+					res.ok(),
+			);
+
+			const promptInput = page.locator("#personalPrompt");
+			await expect(promptInput).toBeVisible();
+
+			await expect(promptInput).toHaveAttribute("maxLength", "500");
+
+			const longText = "a".repeat(505);
+			await promptInput.fill(longText);
+
+			const inputValue = await promptInput.inputValue();
+			expect(inputValue.length).toBe(500);
+
+			const counterText = page.locator("#personalPromptCounter");
+			await expect(counterText).toContainText("500 / 500");
+		},
+	);
+
+	testWithLoggedInUser(
 		"should stay on profile page when account deletion fails",
 		async ({ page, account }) => {
 			await page.goto("/profile/");

--- a/libs/db-schema/index.ts
+++ b/libs/db-schema/index.ts
@@ -440,6 +440,7 @@ export type Database = {
 					num_embedding_tokens: number | null;
 					num_inference_tokens: number | null;
 					num_inferences: number | null;
+					personal_system_prompt: string | null;
 					personal_title: string | null;
 				};
 				Insert: {
@@ -452,6 +453,7 @@ export type Database = {
 					num_embedding_tokens?: number | null;
 					num_inference_tokens?: number | null;
 					num_inferences?: number | null;
+					personal_system_prompt?: string | null;
 					personal_title?: string | null;
 				};
 				Update: {
@@ -464,6 +466,7 @@ export type Database = {
 					num_embedding_tokens?: number | null;
 					num_inference_tokens?: number | null;
 					num_inferences?: number | null;
+					personal_system_prompt?: string | null;
 					personal_title?: string | null;
 				};
 				Relationships: [];


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215155758024241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “personal preferences” prompt to chat settings (max 500 characters) with a live character counter and save success message.
  * Saved personal prompts are automatically applied to `/just-chatting`.

* **Behavior Updates**
  * `/just-chatting` now requires authentication; missing auth returns **401 Unauthorized**.
  * Personal prompts are applied per user, and whitespace-only inputs are treated as unset (stored as `null`).

* **Tests**
  * Added end-to-end tests for saving and the 500-character limit, plus backend integration tests for normalization and access isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->