### PR TITLE
improve auth/storage backup/restore

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -172,6 +172,10 @@ During a playbook run, the `.env` is fetched from 1Password, written temporarily
 
 ## Backups & Restore
 
+Each snapshot holds: roles, the `public` schema, all data, the **`auth`/`storage` RLS
+policies + triggers** (`auth_storage_objects.sql`), migration history, and the
+storage-bucket files — gpg-encrypted and pushed to object storage via rclone.
+
 ### Configuration
 
 Each environment needs a config file in `backups/configs/`:
@@ -202,4 +206,14 @@ See the example file for all required variables (rclone remotes, SSH credentials
 ./backups/restore_env.sh backups/configs/staging.env latest
 ```
 
-The restore script will prompt for confirmation before overwriting data.
+The restore prompts before overwriting, then asserts the `auth`/`storage` policies +
+triggers and RLS landed — it exits non-zero if the restore is incomplete. Pass `--yes`
+(or `RESTORE_ASSUME_YES=1`) to skip the prompt for automation.
+
+### Disaster Recovery Drill
+
+Full DR drill — wipe staging to bare, restore the latest snapshot, assert. Watch out, this is **DESTRUCTIVE** albeit staging-only; leaves staging on the restored snapshot.
+
+```bash
+./backups/dr-drill.sh backups/configs/staging.env
+```

--- a/infra/backups/backup_env.sh
+++ b/infra/backups/backup_env.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Supabase CLI Backup Script
 # 
 # Uses official supabase db dump commands for proper backup handling.
-# Captures auth/storage customizations automatically via supabase db diff.
+# Captures auth/storage customizations (RLS policies + triggers) from the live catalog.
 #
 # Usage:
 #   backup_env.sh configs/staging.env
@@ -128,23 +128,49 @@ supabase db dump --db-url "$DB_URL" -f "$WORK_DIR/data.sql" --use-copy --data-on
 echo "  $(wc -l < "$WORK_DIR/data.sql") lines, $(log_file_size "$WORK_DIR/data.sql")"
 
 # -----------------------------------------------------------------------------
-# 5. Capture auth/storage customizations (triggers, RLS policies, etc.)
+# 5. Capture auth/storage customizations (RLS policies + triggers)
 # -----------------------------------------------------------------------------
-echo "[$ENV][DB] Capturing auth/storage customizations..."
-supabase db diff --db-url "$DB_URL" --schema auth,storage \
-  > "$WORK_DIR/auth_storage_changes.sql" 2>/dev/null || touch "$WORK_DIR/auth_storage_changes.sql"
-if [[ -s "$WORK_DIR/auth_storage_changes.sql" ]]; then
-  echo "  $(wc -l < "$WORK_DIR/auth_storage_changes.sql") lines, $(log_file_size "$WORK_DIR/auth_storage_changes.sql")"
-else
-  echo "  No customizations found"
+# Snapshot the live catalog as idempotent DDL. NOT `supabase db diff`: it reports
+# only drift vs migrations, so these migration-defined objects come back empty.
+echo "[$ENV][DB] Capturing auth/storage policies + triggers..."
+psql "$DB_URL" -X -At -v ON_ERROR_STOP=1 -f - > "$WORK_DIR/auth_storage_objects.sql" <<'SQL'
+-- RLS policies (app-defined; we don't touch base tables or RLS-enable flags)
+SELECT format('DROP POLICY IF EXISTS %I ON %I.%I;', policyname, schemaname, tablename)
+     || format(' CREATE POLICY %I ON %I.%I AS %s FOR %s TO %s%s%s;',
+          policyname, schemaname, tablename, permissive, cmd,
+          array_to_string(roles, ', '),
+          coalesce(' USING (' || qual || ')', ''),
+          coalesce(' WITH CHECK (' || with_check || ')', ''))
+FROM pg_policies WHERE schemaname IN ('auth', 'storage')
+UNION ALL
+-- app triggers only (function outside auth/storage) → excludes gotrue/storage base triggers
+SELECT format('DROP TRIGGER IF EXISTS %I ON %I.%I;', t.tgname, n.nspname, c.relname)
+     || ' ' || pg_get_triggerdef(t.oid) || ';'
+FROM pg_trigger t
+  JOIN pg_class     c  ON c.oid  = t.tgrelid
+  JOIN pg_namespace n  ON n.oid  = c.relnamespace
+  JOIN pg_proc      p  ON p.oid  = t.tgfoid
+  JOIN pg_namespace fn ON fn.oid = p.pronamespace
+WHERE NOT t.tgisinternal
+  AND n.nspname  IN ('auth', 'storage')
+  AND fn.nspname NOT IN ('auth', 'storage', 'pg_catalog', 'extensions');
+SQL
+echo "  $(wc -l < "$WORK_DIR/auth_storage_objects.sql") statements, $(log_file_size "$WORK_DIR/auth_storage_objects.sql")"
+if [[ ! -s "$WORK_DIR/auth_storage_objects.sql" ]]; then
+  echo "❌ auth_storage_objects.sql is empty — auth/storage capture failed; aborting backup."
+  exit 1
 fi
 
 # -----------------------------------------------------------------------------
 # 6. Dump migration history (preserves Supabase CLI migration state)
 # -----------------------------------------------------------------------------
 echo "[$ENV][DB] Dumping migration history..."
+#   1) schema-only -> recreates the supabase_migrations tables (restore target lacks them)
+#   2) --data-only -> the actual history rows
 supabase db dump --db-url "$DB_URL" -f "$WORK_DIR/migrations.sql" \
   --schema supabase_migrations 2>/dev/null || touch "$WORK_DIR/migrations.sql"
+supabase db dump --db-url "$DB_URL" --data-only --use-copy \
+  --schema supabase_migrations 2>/dev/null >> "$WORK_DIR/migrations.sql" || true
 echo "  $(wc -l < "$WORK_DIR/migrations.sql") lines, $(log_file_size "$WORK_DIR/migrations.sql")"
 
 # -----------------------------------------------------------------------------

--- a/infra/backups/dr-drill.sh
+++ b/infra/backups/dr-drill.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# dr-drill.sh — DESTRUCTIVE DR drill for STAGING. Wipes the DB to a bare base
+# schema, restores the latest snapshot, and asserts the restore rebuilt the schema
+# customizations + data. (Restoring over a live DB would false-pass, so we wipe
+# first.) NEVER run against production — guarded to ENV=staging.
+#
+# Usage:
+#   ./dr-drill.sh ./configs/staging.env [SNAPSHOT]           # SNAPSHOT default: latest
+#   DRILL_ASSUME_YES=1 ...  # skip the WIPE-staging confirmation prompt
+
+CONFIG_FILE="${1:?Usage: dr-drill.sh /path/to/staging.env [SNAPSHOT]}"
+SNAPSHOT="${2:-latest}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck disable=SC1090
+source "$CONFIG_FILE"
+
+SUPABASE_DIR="${SUPABASE_DIR:-/opt/supabase-baergpt}"
+# compose reads the root-owned .env, so it needs sudo (docker exec doesn't).
+COMPOSE="sudo docker compose -f docker-compose.yml -f docker-compose.monitoring.yml"
+
+# Safety guards — this script rm -rf's a database.
+[[ "${ENV:-}" == "staging" ]] || { echo "❌ refusing: dr-drill is STAGING-ONLY (ENV='${ENV:-}')."; exit 1; }
+[[ -n "${SUPABASE_DIR}" ]]    || { echo "❌ SUPABASE_DIR is empty — refusing to rm."; exit 1; }
+
+ssh_exec() { ssh -p "$SSH_PORT" -i "$SSH_KEY" "$SSH_USER@$SERVER_IP" "$@"; }
+psql_q()   { ssh_exec "docker exec -i $DB_CONTAINER psql -U postgres -d $DB_NAME -tAc \"$1\"" 2>/dev/null | tr -d '[:space:]'; }
+fail()     { echo "❌ DRILL FAIL: $*"; exit 1; }
+
+ssh_exec "test -f '$SUPABASE_DIR/docker-compose.yml'" \
+  || fail "$SUPABASE_DIR/docker-compose.yml not found on $SERVER_IP — wrong dir, refusing to wipe."
+
+echo "=== DR DRILL (staging) ==="
+echo "Host:     $SSH_USER@$SERVER_IP   dir=$SUPABASE_DIR"
+echo "Snapshot: $SNAPSHOT"
+echo
+echo "⚠️  This DESTROYS staging's database (rm -rf volumes/db/data) and restores it"
+echo "    from the snapshot. Staging will be offline during the drill."
+echo
+if [[ "${DRILL_ASSUME_YES:-0}" != "1" ]]; then
+  read -r -p "Type WIPE-staging to continue: " CONFIRM
+  [[ "$CONFIRM" == "WIPE-staging" ]] || { echo "Aborted."; exit 1; }
+fi
+
+# 1. Wipe to bare — down -v + rm data dir = truly fresh DB (certs in volumes/db/certs are kept).
+echo "[1/4] Stopping stack and wiping the database volume..."
+ssh_exec "cd '$SUPABASE_DIR' && $COMPOSE down -v"
+ssh_exec "sudo rm -rf '$SUPABASE_DIR/volumes/db/data'"
+ssh_exec "cd '$SUPABASE_DIR' && $COMPOSE up -d"
+
+# 2. Wait for the base schema, then guard that it is bare (else the drill would false-pass).
+echo "[2/4] Waiting for db + gotrue/storage-api to recreate the base schema..."
+ready=""
+for _ in $(seq 1 60); do
+  ready=$(psql_q "SELECT (to_regclass('auth.users') IS NOT NULL AND to_regclass('storage.objects') IS NOT NULL)")
+  [[ "$ready" == "t" ]] && break
+  sleep 5
+done
+[[ "$ready" == "t" ]] || fail "base schema not ready after ~5min (db/auth/storage didn't come up)."
+
+BARE_POL=$(psql_q "SELECT count(*) FROM pg_policies WHERE schemaname='storage'")
+BARE_TRG=$(psql_q "SELECT count(*) FROM pg_trigger t JOIN pg_class c ON c.oid=t.tgrelid JOIN pg_namespace n ON n.oid=c.relnamespace JOIN pg_proc p ON p.oid=t.tgfoid JOIN pg_namespace fn ON fn.oid=p.pronamespace WHERE NOT t.tgisinternal AND n.nspname='auth' AND fn.nspname NOT IN ('auth','storage','pg_catalog','extensions')")
+echo "    bare-check: storage policies=$BARE_POL, app auth triggers=$BARE_TRG (expect 0/0)"
+[[ "$BARE_POL" == "0" && "$BARE_TRG" == "0" ]] \
+  || fail "DB is not bare before restore — not reproducing the disaster condition."
+
+# 3. Restore (via bash so the restore script's +x bit doesn't matter).
+echo "[3/4] Restoring snapshot '$SNAPSHOT'..."
+RESTORE_ASSUME_YES=1 bash "$SCRIPT_DIR/restore_env.sh" "$CONFIG_FILE" "$SNAPSHOT" \
+  || fail "restore_env.sh failed (its own assertions may have caught an incomplete restore)."
+
+# 4. Structural assertions: bare -> populated.
+echo "[4/4] Structural assertions..."
+POL=$(psql_q "SELECT count(*) FROM pg_policies WHERE schemaname='storage'")
+TRG=$(psql_q "SELECT count(*) FROM pg_trigger t JOIN pg_class c ON c.oid=t.tgrelid JOIN pg_namespace n ON n.oid=c.relnamespace WHERE NOT t.tgisinternal AND n.nspname='auth'")
+RLS=$(psql_q "SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='storage' AND c.relname='objects'")
+USERS=$(psql_q "SELECT count(*) FROM auth.users")
+OBJS=$(psql_q "SELECT count(*) FROM storage.objects")
+BUK=$(psql_q "SELECT count(*) FROM storage.buckets")
+echo "    storage policies=$POL  auth triggers=$TRG  storage.objects RLS=$RLS  buckets=$BUK  users=$USERS  objects=$OBJS"
+[[ "${POL:-0}"   -gt 0 ]] || fail "no storage policies after restore (capture/restore broken)."
+[[ "${TRG:-0}"   -gt 0 ]] || fail "no auth triggers after restore (capture/restore broken)."
+[[ "$RLS" == "t" ]]        || fail "RLS not enabled on storage.objects (data-exposure risk)."
+[[ "${BUK:-0}"   -gt 0 ]] || fail "no storage buckets after restore (objects orphaned -> 'Bucket not found' 404s)."
+[[ "${USERS:-0}" -gt 0 ]] || fail "no users restored."
+[[ "${OBJS:-0}"  -gt 0 ]] || fail "no storage objects restored."
+
+echo
+echo "✅ DRILL PASS — staging wiped to bare, restored from '$SNAPSHOT', schema customizations + data verified."
+echo "   Staging is left running on the restored snapshot."

--- a/infra/backups/restore_env.sh
+++ b/infra/backups/restore_env.sh
@@ -61,10 +61,15 @@ echo "   - Bucket: $RESTORE_BUCKET"
 echo "   - Database: $DB_NAME"
 echo
 
-read -r -p "Type RESTORE-$ENV to continue: " CONFIRM
-if [[ "$CONFIRM" != "RESTORE-$ENV" ]]; then
-  echo "Aborted."
-  exit 1
+# non-interactive bypass for dr-drill.sh (RESTORE_ASSUME_YES=1, or --yes/-y)
+if [[ "${RESTORE_ASSUME_YES:-0}" == "1" || "${3:-}" == "--yes" || "${3:-}" == "-y" ]]; then
+  echo "[$ENV] Confirmation skipped (RESTORE_ASSUME_YES/--yes)."
+else
+  read -r -p "Type RESTORE-$ENV to continue: " CONFIRM
+  if [[ "$CONFIRM" != "RESTORE-$ENV" ]]; then
+    echo "Aborted."
+    exit 1
+  fi
 fi
 
 WORK_DIR=$(mktemp -d)
@@ -166,18 +171,51 @@ else
   echo "  (no migration history to restore)"
 fi
 
-# https://supabase.com/docs/guides/platform/migrating-within-supabase/backup-restore#schema-changes-to-auth-and-storage
 # -----------------------------------------------------------------------------
-# 8. Apply auth/storage customizations
+# 8. Apply auth/storage customizations (RLS policies + triggers)
 # -----------------------------------------------------------------------------
-echo "[$ENV][DB] Applying auth/storage customizations..."
-if [[ -s "$WORK_DIR/auth_storage_changes.sql" ]]; then
-  cat "$WORK_DIR/auth_storage_changes.sql" | run_psql || {
-    echo "  ⚠ Some customizations may have failed"
-  }
-  echo "  ✓ Customizations applied"
+echo "[$ENV][DB] Applying auth/storage policies + triggers..."
+# New backups write auth_storage_objects.sql; older snapshots used auth_storage_changes.sql.
+AUTH_STORAGE_FILE=""
+for candidate in auth_storage_objects.sql auth_storage_changes.sql; do
+  if [[ -s "$WORK_DIR/$candidate" ]]; then AUTH_STORAGE_FILE="$candidate"; break; fi
+done
+if [[ -n "$AUTH_STORAGE_FILE" ]]; then
+  # ON_ERROR_STOP here but not in run_psql: the data restore must tolerate benign SETs
+  # like transaction_timeout, but policy/trigger DDL must not half-apply silently.
+  cat "$WORK_DIR/$AUTH_STORAGE_FILE" | ssh -p "$SSH_PORT" -i "$SSH_KEY" "$SSH_USER@$SERVER_IP" \
+    "docker exec -i $DB_CONTAINER psql -U postgres -d $DB_NAME -v ON_ERROR_STOP=1" \
+    || echo "  ⚠ Some auth/storage statements failed (the assertion below will catch it)"
+  echo "  ✓ Applied $AUTH_STORAGE_FILE"
+
+# Assertions to test the restore
+  STORAGE_POLICIES=$(ssh -p "$SSH_PORT" -i "$SSH_KEY" "$SSH_USER@$SERVER_IP" \
+    "docker exec -i $DB_CONTAINER psql -U postgres -d $DB_NAME -tAc \
+     \"SELECT count(*) FROM pg_policies WHERE schemaname='storage'\"" | tr -d '[:space:]')
+  AUTH_TRIGGERS=$(ssh -p "$SSH_PORT" -i "$SSH_KEY" "$SSH_USER@$SERVER_IP" \
+    "docker exec -i $DB_CONTAINER psql -U postgres -d $DB_NAME -tAc \
+     \"SELECT count(*) FROM pg_trigger t JOIN pg_class c ON c.oid=t.tgrelid \
+       JOIN pg_namespace n ON n.oid=c.relnamespace \
+       WHERE NOT t.tgisinternal AND n.nspname='auth'\"" | tr -d '[:space:]')
+  OBJECTS_RLS=$(ssh -p "$SSH_PORT" -i "$SSH_KEY" "$SSH_USER@$SERVER_IP" \
+    "docker exec -i $DB_CONTAINER psql -U postgres -d $DB_NAME -tAc \
+     \"SELECT c.relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace \
+       WHERE n.nspname='storage' AND c.relname='objects'\"" | tr -d '[:space:]')
+  STORAGE_BUCKETS=$(ssh -p "$SSH_PORT" -i "$SSH_KEY" "$SSH_USER@$SERVER_IP" \
+    "docker exec -i $DB_CONTAINER psql -U postgres -d $DB_NAME -tAc \
+     \"SELECT count(*) FROM storage.buckets\"" | tr -d '[:space:]')
+  echo "  storage policies: ${STORAGE_POLICIES:-?}, auth triggers: ${AUTH_TRIGGERS:-?}, storage.objects RLS: ${OBJECTS_RLS:-?}, storage buckets: ${STORAGE_BUCKETS:-?}"
+  if [[ "${STORAGE_POLICIES:-0}" -eq 0 || "${AUTH_TRIGGERS:-0}" -eq 0 || "$OBJECTS_RLS" != "t" || "${STORAGE_BUCKETS:-0}" -eq 0 ]]; then
+    echo "❌ Post-restore assertion failed: need storage RLS policies, auth triggers, RLS"
+    echo "   enabled on storage.objects (policies without RLS = data exposure, not just 404s),"
+    echo "   AND ≥1 storage bucket (no buckets = 'Bucket not found' on every download)."
+    echo "   Restore is INCOMPLETE — do not treat this database as recovered."
+    exit 1
+  fi
 else
-  echo "  (no customizations to apply)"
+  echo "  ⚠️  No auth/storage objects in this snapshot (pre-fix backup)."
+  echo "      storage RLS policies + auth.users triggers were NOT restored —"
+  echo "      re-apply them from the repo migrations before trusting this DB."
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
I fixed a couple of things that I had to do by hand when restoring staging from backups.
1. When running a backup, we tried to get auth/storage customizations using the `db diff` command. But that would result in an empty sql file. So instead we are saving those through SQL queries. 
2. We only saved the migrations table, not the actual migrations inside the table. 
3. The restore now verifies itself: after restoring it asserts the storage policies, auth triggers, RLS, and buckets are actually present, and fails loudly if not.
4. There is now a shell script that tests out disaster recovery. It formats all data from staging and recreates the data from the latest backup. This is the testing script I used to verify my work here. I left it in the commit because it might be handy if we need to test our backups down the line. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced backup and restore documentation with improved clarity on snapshot contents and expanded disaster recovery procedures.

* **New Features**
  * Added non-interactive restore mode supporting automation via environment variables or command flags.
  * Introduced automated disaster recovery drill functionality for staging environments.

* **Bug Fixes**
  * Improved backup capture of RLS policies and database triggers.
  * Strengthened post-restore validation to ensure completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215909865038374