### PR TITLE
fix: cleanup logic for OCR failures

### DIFF
--- a/apps/backend/src/integration/document-extraction-service.test.ts
+++ b/apps/backend/src/integration/document-extraction-service.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mock fns so we can reference them inside vi.mock and assert on them
+const { uploadMock, ocrProcessMock, deleteMock } = vi.hoisted(() => ({
+	uploadMock: vi.fn(),
+	ocrProcessMock: vi.fn(),
+	deleteMock: vi.fn(),
+}));
+
+vi.mock("@mistralai/mistralai", () => ({
+	Mistral: vi.fn().mockImplementation(() => ({
+		files: {
+			upload: uploadMock,
+			delete: deleteMock,
+		},
+		ocr: {
+			process: ocrProcessMock,
+		},
+	})),
+}));
+
+vi.mock("../monitoring/capture-error", () => ({
+	captureError: vi.fn(),
+}));
+
+import {
+	DocumentExtractionService,
+	MistralOCRService,
+} from "../services/document-extraction-service";
+import { captureError } from "../monitoring/capture-error";
+
+describe("MistralOCRService cleanup on OCR failure", () => {
+	const captureErrorMock = captureError as ReturnType<typeof vi.fn>;
+	const service = new DocumentExtractionService();
+	const givenPdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // "%PDF"
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Exercise the real extraction logic instead of the NODE_ENV=test static mocks
+		vi.spyOn(
+			MistralOCRService.prototype,
+			"shouldMockExternalServices",
+		).mockReturnValue(false);
+		uploadMock.mockResolvedValue({ id: "uploaded-file-id" });
+		deleteMock.mockResolvedValue(undefined);
+	});
+
+	it("deletes the uploaded file after a successful OCR extraction", async () => {
+		ocrProcessMock.mockResolvedValueOnce({
+			pages: [{ markdown: "# Page one" }, { markdown: "Page two content" }],
+		});
+
+		const actualPages = await service.extractPdfAsMarkdownPages(givenPdfBytes);
+
+		// The extraction succeeds and returns one ParsedPage per OCR page
+		expect(actualPages).toHaveLength(2);
+		expect(actualPages[0]).toMatchObject({
+			content: "# Page one",
+			pageNumber: 1,
+		});
+		expect(actualPages[1]).toMatchObject({
+			content: "Page two content",
+			pageNumber: 2,
+		});
+
+		// Cleanup still runs on the happy path
+		expect(deleteMock).toHaveBeenCalledOnce();
+		expect(deleteMock).toHaveBeenCalledWith({ fileId: "uploaded-file-id" });
+
+		// No errors should be captured when everything works
+		expect(captureErrorMock).not.toHaveBeenCalled();
+	});
+
+	it("deletes the uploaded file even when ocr.process throws", async () => {
+		const givenOcrError = new Error("OCR processing failed");
+		ocrProcessMock.mockRejectedValueOnce(givenOcrError);
+
+		await expect(
+			service.extractPdfAsMarkdownPages(givenPdfBytes),
+		).rejects.toThrow(givenOcrError);
+
+		// The fix: cleanup runs in `finally`, so delete is still called
+		expect(deleteMock).toHaveBeenCalledOnce();
+		expect(deleteMock).toHaveBeenCalledWith({ fileId: "uploaded-file-id" });
+	});
+
+	it("deletes the uploaded file even when the OCR response has no pages", async () => {
+		ocrProcessMock.mockResolvedValueOnce({ pages: [] });
+
+		await expect(
+			service.extractPdfAsMarkdownPages(givenPdfBytes),
+		).rejects.toThrow("No pages found in OCR response");
+
+		expect(deleteMock).toHaveBeenCalledOnce();
+		expect(deleteMock).toHaveBeenCalledWith({ fileId: "uploaded-file-id" });
+	});
+
+	it("does not capture a 404 when deleting an already-removed file", async () => {
+		ocrProcessMock.mockRejectedValueOnce(new Error("OCR processing failed"));
+		deleteMock.mockRejectedValueOnce({ statusCode: 404 });
+
+		await expect(
+			service.extractPdfAsMarkdownPages(givenPdfBytes),
+		).rejects.toThrow("OCR processing failed");
+
+		expect(deleteMock).toHaveBeenCalledOnce();
+		// 404 on delete is benign and must NOT be reported
+		expect(captureErrorMock).not.toHaveBeenCalledWith(
+			expect.objectContaining({ statusCode: 404 }),
+		);
+	});
+
+	it("captures a non-404 delete failure without masking the OCR error", async () => {
+		const givenOcrError = new Error("OCR processing failed");
+		const givenDeleteError = { statusCode: 500, message: "delete failed" };
+		ocrProcessMock.mockRejectedValueOnce(givenOcrError);
+		deleteMock.mockRejectedValueOnce(givenDeleteError);
+
+		// The original OCR error must still propagate (finally must not swallow it)
+		await expect(
+			service.extractPdfAsMarkdownPages(givenPdfBytes),
+		).rejects.toThrow(givenOcrError);
+
+		expect(deleteMock).toHaveBeenCalledOnce();
+		expect(captureErrorMock).toHaveBeenCalledWith(givenDeleteError);
+	});
+});

--- a/apps/backend/src/services/document-extraction-service.ts
+++ b/apps/backend/src/services/document-extraction-service.ts
@@ -359,11 +359,20 @@ export class ExcelExtractionService {
 	}
 }
 
-class MistralOCRService {
+export class MistralOCRService {
+	/**
+	 * A function (not a const) so it can be mocked in tests
+	 * that assert the real internal logic of specific
+	 * methods, e.g. `extractTextFromPdfWithMistral()`.
+	 */
+	shouldMockExternalServices(): boolean {
+		return config.nodeEnv === "test";
+	}
+
 	async extractTextFromPdfWithMistral(
 		pdfBytes: Uint8Array,
 	): Promise<ParsedPage[]> {
-		if (isTestMode) {
+		if (this.shouldMockExternalServices()) {
 			return mockOcrPages();
 		}
 
@@ -379,28 +388,32 @@ class MistralOCRService {
 			purpose: "ocr",
 		});
 
-		const ocrResponse = await client.ocr.process({
-			model: "mistral-ocr-latest",
-			document: {
-				type: "file",
-				fileId: uploaded_pdf.id,
-			},
-		});
-
-		if (!ocrResponse.pages) {
-			throw new Error("No pages found in OCR response");
-		}
 		try {
-			await client.files.delete({ fileId: uploaded_pdf.id }); // delete file from Mistral's cloud storage
-		} catch (error) {
-			if (error?.status !== 404 && error?.statusCode !== 404) {
-				captureError(error);
+			const ocrResponse = await client.ocr.process({
+				model: "mistral-ocr-latest",
+				document: {
+					type: "file",
+					fileId: uploaded_pdf.id,
+				},
+			});
+
+			if (!ocrResponse.pages || ocrResponse.pages.length === 0) {
+				throw new Error("No pages found in OCR response");
+			}
+
+			return ocrResponse.pages.map((page, index) => ({
+				content: page.markdown,
+				pageNumber: index + 1,
+				tokenCount: countTokens(page.markdown),
+			}));
+		} finally {
+			try {
+				await client.files.delete({ fileId: uploaded_pdf.id });
+			} catch (error) {
+				if (error?.status !== 404 && error?.statusCode !== 404) {
+					captureError(error);
+				}
 			}
 		}
-		return ocrResponse.pages.map((page, index) => ({
-			content: page.markdown,
-			pageNumber: index + 1,
-			tokenCount: countTokens(page.markdown),
-		}));
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of PDF text extraction by ensuring OCR uploads are cleaned up even when OCR fails or returns no pages.
  * Treated missing or empty OCR page results as an error to avoid incomplete extractions.
  * Continued to suppress “not found” (404) during cleanup while still surfacing other cleanup issues appropriately.
* **Tests**
  * Added automated coverage for successful extraction, OCR failures, empty OCR responses, and cleanup behavior (including 404 and non-404 delete outcomes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215321929843186