### PR TITLE
feat: implement test mode with mock models 

### DIFF
--- a/apps/backend/src/monitoring/instrumentation.ts
+++ b/apps/backend/src/monitoring/instrumentation.ts
@@ -9,7 +9,7 @@ export const sentryClient = Sentry.init({
 	dsn: config.sentryDsn || "",
 	environment: config.nodeEnv || "development",
 	tracesSampleRate: 1.0,
-	enabled: ["production", "staging", "test"].includes(config.nodeEnv),
+	enabled: ["production", "staging"].includes(config.nodeEnv),
 	skipOpenTelemetrySetup: true,
 });
 

--- a/apps/backend/src/services/document-extraction-service.ts
+++ b/apps/backend/src/services/document-extraction-service.ts
@@ -9,6 +9,9 @@ import XLSX from "xlsx";
 import { captureError } from "../monitoring/capture-error";
 import { getDocumentProxy } from "unpdf";
 import { ocrTempFileName } from "../constants";
+import { mockOcrPages, mockWordToPdf } from "./external-mocks";
+
+const isTestMode = config.nodeEnv === "test";
 
 export class DocumentExtractionService {
 	async extractDocument(
@@ -123,6 +126,10 @@ export class WordDocumentExtractionService {
 		wordDoc: Buffer;
 	}): Promise<Uint8Array> {
 		const { fileName, wordDoc } = args;
+
+		if (isTestMode) {
+			return mockWordToPdf();
+		}
 
 		const form = new FormData();
 		const bytes = new Uint8Array(
@@ -356,6 +363,10 @@ class MistralOCRService {
 	async extractTextFromPdfWithMistral(
 		pdfBytes: Uint8Array,
 	): Promise<ParsedPage[]> {
+		if (isTestMode) {
+			return mockOcrPages();
+		}
+
 		const client = new Mistral({ apiKey: config.mistralApiKey });
 
 		const buffer = createBufferView(pdfBytes);

--- a/apps/backend/src/services/embedding-service.ts
+++ b/apps/backend/src/services/embedding-service.ts
@@ -13,7 +13,7 @@ import {
 } from "./token-utils";
 import { BaseContentDbService } from "./db-service/base-db-service";
 import { embed, embedMany } from "ai";
-import { mistral } from "@ai-sdk/mistral";
+import { getEmbeddingModel } from "./llm-provider";
 import { captureError } from "../monitoring/capture-error";
 
 export class EmbeddingService {
@@ -31,7 +31,7 @@ export class EmbeddingService {
 		userId: string | undefined,
 	): Promise<EmbeddingResponse> {
 		const { embedding, usage } = await embed({
-			model: mistral.embeddingModel(config.mistralEmbeddingModel),
+			model: getEmbeddingModel(),
 			value: input,
 			experimental_telemetry: {
 				isEnabled: config.isTracingEnabled,
@@ -94,7 +94,7 @@ export class EmbeddingService {
 
 		for (const subBatch of subBatches) {
 			const { embeddings, usage } = await embedMany({
-				model: mistral.embeddingModel(config.mistralEmbeddingModel),
+				model: getEmbeddingModel(),
 				values: subBatch,
 				experimental_telemetry: {
 					isEnabled: config.isTracingEnabled,

--- a/apps/backend/src/services/external-mocks.ts
+++ b/apps/backend/src/services/external-mocks.ts
@@ -1,0 +1,141 @@
+import type {
+	EmbeddingModelV3,
+	EmbeddingModelV3Result,
+	LanguageModelV3,
+	LanguageModelV3FinishReason,
+	LanguageModelV3GenerateResult,
+	LanguageModelV3StreamPart,
+	LanguageModelV3StreamResult,
+	LanguageModelV3Usage,
+} from "@ai-sdk/provider";
+import { MockEmbeddingModelV3, MockLanguageModelV3 } from "ai/test";
+import { simulateReadableStream } from "ai";
+import { ChatPromptClient, TextPromptClient } from "@langfuse/client";
+import { config } from "../config";
+import type { ParsedPage } from "../types/common";
+import { countTokens } from "./token-utils";
+
+/**
+ * Canned mock implementations for the external services this backend talks to
+ * (Mistral chat + embeddings, Mistral OCR, Gotenberg). They are returned by the
+ * provider factories / service methods whenever `NODE_ENV === "test"` so the
+ * test suite never reaches the network. The responses are deliberately static:
+ * there are no behavioural assertions, the goal is only to keep the real code
+ * paths running without external calls.
+ */
+
+const MOCK_USAGE: LanguageModelV3Usage = {
+	inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+	outputTokens: { total: 1, text: 1, reasoning: 0 },
+};
+
+const MOCK_FINISH_REASON: LanguageModelV3FinishReason = {
+	unified: "stop",
+	raw: "stop",
+};
+
+/**
+ * Plain-text generations (summaries, one-sentence summaries) just receive this
+ * string. `generateTags` parses the text as JSON and expects a `tags` array, so
+ * returning a JSON object keeps that path working too. Structured-output calls
+ * (`Output.object`, used by the streaming citation extraction) ask for a JSON
+ * response format; we return an empty object for those. Those paths are not
+ * exercised by the test suite — if they ever are, the empty object may need to
+ * be shaped to the specific schema.
+ */
+function mockGenerateText(isJsonResponse: boolean): string {
+	return isJsonResponse ? "{}" : '{"tags":["mock-tag"]}';
+}
+
+export function mockLanguageModel(): LanguageModelV3 {
+	return new MockLanguageModelV3({
+		doGenerate: async (options): Promise<LanguageModelV3GenerateResult> => ({
+			content: [
+				{
+					type: "text",
+					text: mockGenerateText(options.responseFormat?.type === "json"),
+				},
+			],
+			finishReason: MOCK_FINISH_REASON,
+			usage: MOCK_USAGE,
+			warnings: [],
+		}),
+		doStream: async (): Promise<LanguageModelV3StreamResult> => ({
+			stream: simulateReadableStream<LanguageModelV3StreamPart>({
+				chunks: [
+					{ type: "stream-start", warnings: [] },
+					{ type: "text-start", id: "0" },
+					{ type: "text-delta", id: "0", delta: "mock response" },
+					{ type: "text-end", id: "0" },
+					{
+						type: "finish",
+						finishReason: MOCK_FINISH_REASON,
+						usage: MOCK_USAGE,
+					},
+				],
+			}),
+		}),
+	});
+}
+
+export function mockEmbeddingModel(): EmbeddingModelV3 {
+	return new MockEmbeddingModelV3({
+		doEmbed: async ({ values }): Promise<EmbeddingModelV3Result> => ({
+			embeddings: values.map(() =>
+				new Array(config.mistralEmbeddingDimensions).fill(0),
+			),
+			usage: { tokens: values.length },
+			warnings: [],
+		}),
+	});
+}
+
+export function mockOcrPages(): ParsedPage[] {
+	const content = "Mock OCR content.";
+	return [
+		{
+			content,
+			pageNumber: 1,
+			tokenCount: countTokens(content),
+		},
+	];
+}
+
+export function mockWordToPdf(): Uint8Array {
+	return new TextEncoder().encode("%PDF-1.4\n%mock\n");
+}
+
+/**
+ * Fallback Langfuse prompt clients so `prompt.get` never reaches the Langfuse
+ * API in tests. They are constructed with `isFallback = true` and a single
+ * static message; `compile()` and `toJSON()` behave like real prompt clients.
+ */
+export function mockTextPrompt(name: string): TextPromptClient {
+	return new TextPromptClient(
+		{
+			name,
+			version: 0,
+			labels: [],
+			tags: [],
+			type: "text",
+			prompt: "Mock prompt.",
+		},
+		true,
+	);
+}
+
+export function mockChatPrompt(name: string): ChatPromptClient {
+	return new ChatPromptClient(
+		{
+			name,
+			version: 0,
+			labels: [],
+			tags: [],
+			type: "chat",
+			prompt: [
+				{ type: "chatmessage", role: "system", content: "Mock prompt." },
+			],
+		},
+		true,
+	);
+}

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -11,7 +11,7 @@ import {
 import { ModelService } from "./model-service";
 import { logMemory } from "../monitoring/memory-logger";
 import { EmbeddingService } from "./embedding-service";
-import { ChatPromptClient, TextPromptClient } from "@langfuse/client";
+import type { ChatPromptClient, TextPromptClient } from "@langfuse/client";
 import { updateActiveTrace } from "@langfuse/tracing";
 import { getChatPrompt, getTextPrompt } from "./prompt-provider";
 import { type Document, type LLMHandler } from "../types/common";

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -11,12 +11,9 @@ import {
 import { ModelService } from "./model-service";
 import { logMemory } from "../monitoring/memory-logger";
 import { EmbeddingService } from "./embedding-service";
-import {
-	LangfuseClient,
-	ChatPromptClient,
-	TextPromptClient,
-} from "@langfuse/client";
+import { ChatPromptClient, TextPromptClient } from "@langfuse/client";
 import { updateActiveTrace } from "@langfuse/tracing";
+import { getChatPrompt, getTextPrompt } from "./prompt-provider";
 import { type Document, type LLMHandler } from "../types/common";
 import { BaseContentDbService } from "./db-service/base-db-service";
 import { LLM_PARAMETERS } from "../constants";
@@ -41,7 +38,6 @@ import {
 } from "./token-utils";
 import type { WebSearchResult } from "../tools/web-search";
 
-const langfuse = new LangfuseClient();
 const modelService = new ModelService();
 
 type RelevantTools = {
@@ -66,9 +62,8 @@ export class GenerationService {
 		promptName: string,
 	): Promise<number> {
 		try {
-			const client = await langfuse.prompt.get(promptName, {
+			const client = await getChatPrompt(promptName, {
 				label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
-				type: "chat",
 			});
 
 			const compiled = client.compile({ docContent: "" }) as ModelMessage[];
@@ -91,9 +86,8 @@ export class GenerationService {
 
 		const llmHandler = modelService.resolveLlmHandler(llmIdentifier);
 
-		const summaryPromptClient = await langfuse.prompt.get("summary", {
+		const summaryPromptClient = await getChatPrompt("summary", {
 			label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
-			type: "chat",
 		});
 
 		const compiledSummaryPrompt = summaryPromptClient.compile({
@@ -117,13 +111,9 @@ export class GenerationService {
 
 		const llmHandler = modelService.resolveLlmHandler(llmIdentifier);
 
-		const summaryPromptClient = await langfuse.prompt.get(
-			"one-sentence-summary",
-			{
-				label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
-				type: "chat",
-			},
-		);
+		const summaryPromptClient = await getChatPrompt("one-sentence-summary", {
+			label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
+		});
 
 		const compiledSummaryPrompt = summaryPromptClient.compile({
 			docContent: input,
@@ -150,9 +140,8 @@ export class GenerationService {
 				? input
 				: input.map((page) => page.content).join("\n");
 
-		const taggingPromptClient = await langfuse.prompt.get("tagging", {
+		const taggingPromptClient = await getChatPrompt("tagging", {
 			label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
-			type: "chat",
 		});
 		const compiledTaggingPrompt = taggingPromptClient.compile({
 			docContent: docContent,
@@ -317,10 +306,9 @@ export class GenerationService {
 								}),
 							);
 							try {
-								const citationPromptClient = await langfuse.prompt.get(
+								const citationPromptClient = await getChatPrompt(
 									"document-citation-extraction",
 									{
-										type: "chat",
 										label:
 											config.nodeEnv === "test"
 												? "development"
@@ -399,14 +387,13 @@ export class GenerationService {
 
 						if (allWebSources.length > 0) {
 							try {
-								const webCitationPromptClient = await langfuse.prompt.get(
+								const webCitationPromptClient = await getChatPrompt(
 									"web-citation-extraction",
 									{
 										label:
 											config.nodeEnv === "test"
 												? "development"
 												: config.nodeEnv,
-										type: "chat",
 									},
 								);
 
@@ -464,10 +451,9 @@ export class GenerationService {
 
 						if (allParlaChunks.length > 0) {
 							try {
-								const parlaCitationPromptClient = await langfuse.prompt.get(
+								const parlaCitationPromptClient = await getChatPrompt(
 									"document-citation-extraction",
 									{
-										type: "chat",
 										label:
 											config.nodeEnv === "test"
 												? "development"
@@ -618,17 +604,16 @@ export class GenerationService {
 			config.featureFlagWebSearchAllowed &&
 			activeTools.includes("webSearchTool")
 		) {
-			freeChatPromptClient = await langfuse.prompt.get(
+			freeChatPromptClient = await getTextPrompt(
 				"free-chat-with-web-search-enabled",
 				{ label: config.nodeEnv === "test" ? "development" : config.nodeEnv },
 			);
 		} else if (activeTools.includes("ragSearchTool")) {
-			freeChatPromptClient = await langfuse.prompt.get(
-				"free-chat-with-documents",
-				{ label: config.nodeEnv === "test" ? "development" : config.nodeEnv },
-			);
+			freeChatPromptClient = await getTextPrompt("free-chat-with-documents", {
+				label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
+			});
 		} else {
-			freeChatPromptClient = await langfuse.prompt.get("free-chat", {
+			freeChatPromptClient = await getTextPrompt("free-chat", {
 				label: config.nodeEnv === "test" ? "development" : config.nodeEnv,
 			});
 		}

--- a/apps/backend/src/services/llm-provider.ts
+++ b/apps/backend/src/services/llm-provider.ts
@@ -1,0 +1,32 @@
+import type { EmbeddingModelV3, LanguageModelV3 } from "@ai-sdk/provider";
+import { mistral } from "@ai-sdk/mistral";
+import { config } from "../config";
+import { mockEmbeddingModel, mockLanguageModel } from "./external-mocks";
+
+/**
+ * Central factories for the Mistral models. In `test` mode they return static
+ * mocks (see external-mocks.ts) so the suite never calls the Mistral API; in
+ * every other environment they return the real provider models.
+ *
+ * IMPORTANT: if you want the test mode locally, you need to put
+ *            NODE_ENV=test in your backend .env file. Also when
+ *            you want to use a backend in test mode for e2e tests.
+ */
+
+const isTestMode = config.nodeEnv === "test";
+
+export function getLanguageModel(identifier: string): LanguageModelV3 {
+	if (isTestMode) {
+		return mockLanguageModel();
+	}
+
+	return mistral(identifier);
+}
+
+export function getEmbeddingModel(): EmbeddingModelV3 {
+	if (isTestMode) {
+		return mockEmbeddingModel();
+	}
+
+	return mistral.embeddingModel(config.mistralEmbeddingModel);
+}

--- a/apps/backend/src/services/model-service.ts
+++ b/apps/backend/src/services/model-service.ts
@@ -1,6 +1,6 @@
 import { config } from "../config";
 import { LLMHandler } from "../types/common";
-import { mistral } from "@ai-sdk/mistral";
+import { getLanguageModel } from "./llm-provider";
 
 type ModelProvider = "Mistral";
 
@@ -73,12 +73,12 @@ export class ModelService {
 	handlers: Record<string, LLMHandler> = {
 		"mistral-small": new LLMHandler(
 			"mistral-small",
-			mistral(config.smallModelIdentifier),
+			getLanguageModel(config.smallModelIdentifier),
 			"https://api.mistral.ai/v1",
 		),
 		"mistral-large": new LLMHandler(
 			"mistral-large",
-			mistral(config.largeModelIdentifier),
+			getLanguageModel(config.largeModelIdentifier),
 			"https://api.mistral.ai/v1",
 		),
 	};

--- a/apps/backend/src/services/prompt-provider.ts
+++ b/apps/backend/src/services/prompt-provider.ts
@@ -1,0 +1,57 @@
+import { LangfuseClient } from "@langfuse/client";
+import type { ChatMessage } from "@langfuse/core";
+import { config } from "../config";
+import { mockChatPrompt, mockTextPrompt } from "./external-mocks";
+
+/**
+ * Central access point for Langfuse prompts. In `test` mode it returns static
+ * fallback prompt clients (see external-mocks.ts) so the suite never calls the
+ * Langfuse API; otherwise it delegates to the real client.
+ *
+ * IMPORTANT: if you want the test mode locally, you need to put
+ *            NODE_ENV=test in your backend .env file. Also when
+ *            you want to use a backend in test mode for e2e tests.
+ */
+
+const isTestMode = config.nodeEnv === "test";
+
+const langfuse = new LangfuseClient();
+
+type BasePromptOptions = {
+	label?: string;
+	version?: number;
+	cacheTtlSeconds?: number;
+	maxRetries?: number;
+};
+
+/**
+ * Fetches a "text" Langfuse prompt: a single template string.
+ * `compile()` returns that string with its variables filled in.
+ */
+export async function getTextPrompt(
+	name: string,
+	options?: BasePromptOptions & { fallback?: string },
+) {
+	if (isTestMode) {
+		return mockTextPrompt(name);
+	}
+
+	return langfuse.prompt.get(name, { ...options, type: "text" });
+}
+
+/**
+ * Fetches a "chat" Langfuse prompt. "Chat" refers to the prompt format —
+ * an array of role-tagged messages (system + user) — not an end-user
+ * conversation. We use it for self-contained, one-shot backend inferences
+ * like summaries or tagging because it improves instruction-following.
+ */
+export async function getChatPrompt(
+	name: string,
+	options?: BasePromptOptions & { fallback?: ChatMessage[] },
+) {
+	if (isTestMode) {
+		return mockChatPrompt(name);
+	}
+
+	return langfuse.prompt.get(name, { ...options, type: "chat" });
+}


### PR DESCRIPTION
⚠️⚠️⚠️ Important ⚠️⚠️⚠️

When you use `NODE_ENV=development` in your local `.env` file, you will bypass the test mode. If you want to use the test mode with external API mocks, put `NODE_ENV=test` in your `.env` file. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216045779106301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend stability by using consistent model and prompt selection across AI features.
  * Test environments now avoid external AI/telemetry calls, reducing flaky behavior and improving reliability.
  * Document conversion and text extraction now return predictable results in tests, helping prevent false failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->