### PR TITLE
feat: rename hilfecenter

### DIFF
--- a/apps/admin-panel/src/content.ts
+++ b/apps/admin-panel/src/content.ts
@@ -1,10 +1,10 @@
 export const Content = {
 	/* -------------------- Header -------------------- */
 	"header.logo.alt": "BärGPT Logo",
-	"header.navigation.help.label": "Hilfecenter",
+	"header.navigation.help.label": "Hilfe und Tipps",
 	"header.navigation.help.mobileLabel": "Hilfe",
 	"header.navigation.profile": "Profil",
-	"header.navigation.help.ariaLabel": "Zum Hilfecenter",
+	"header.navigation.help.ariaLabel": "Hilfe und Tipps",
 	"header.navigation.help.link": "https://hilfe.baergpt.berlin/",
 	"header.navigation.profile.ariaLabel": "Zur Profil-Seite",
 

--- a/apps/frontend/src/content.ts
+++ b/apps/frontend/src/content.ts
@@ -1,10 +1,10 @@
 export const Content = {
 	/* -------------------- Header -------------------- */
 	"header.logo.alt": "BärGPT Logo",
-	"header.navigation.help.label": "Hilfecenter",
+	"header.navigation.help.label": "Hilfe und Tipps",
 	"header.navigation.help.mobileLabel": "Hilfe",
 	"header.navigation.profile": "Profil",
-	"header.navigation.help.ariaLabel": "Hilfecenter",
+	"header.navigation.help.ariaLabel": "Hilfe und Tipps",
 	"header.navigation.help.link": "https://hilfe.baergpt.berlin/",
 	"header.navigation.profile.ariaLabel": "Zur Profil-Seite",
 	"header.navigation.landingPage.login.label": "Anmelden",
@@ -597,7 +597,8 @@ export const Content = {
 		"Bei Fragen zu diesen Nutzungsbedingungen oder zu BärGPT wenden Sie sich bitte an:",
 	"termsOfUsePage.section12.sub4.p1.contact.email.label": "E-Mail: ",
 	"termsOfUsePage.section12.sub4.p1.contact.email": "support@baergpt.berlin",
-	"termsOfUsePage.section12.sub4.p1.contact.helpcenter.label": "Hilfecenter: ",
+	"termsOfUsePage.section12.sub4.p1.contact.helpcenter.label":
+		"Hilfe und Tipps: ",
 	"termsOfUsePage.section12.sub4.p1.contact.helpcenter.link":
 		"https://hilfe.baergpt.berlin",
 	//consent
@@ -1252,7 +1253,7 @@ export const Content = {
 	"footer.support.link": "mailto:support@baergpt.berlin",
 	"footer.github": "GitHub",
 	"footer.github.link": "https://github.com/technologiestiftung/baergpt",
-	"footer.helpcenter": "Hilfecenter",
+	"footer.helpcenter": "Hilfe und Tipps",
 	"footer.helpcenter.link": "https://hilfe.baergpt.berlin/",
 	"footer.feedback": "Feedback geben",
 	"footer.feedback.link": "https://citylabberlin.typeform.com/to/GhoCHw0J",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated German help navigation labels to “Hilfe und Tipps” across the admin panel and frontend.
  * Applied the updated wording to mobile, accessibility, terms-of-use contact, and footer labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216517904644489