### PR TITLE
feat: polish history styling

### DIFF
--- a/apps/frontend/src/components/sidebar/history/history-entry.tsx
+++ b/apps/frontend/src/components/sidebar/history/history-entry.tsx
@@ -22,15 +22,15 @@ export const HistoryEntry: React.FC<HistoryEntryProps> = ({ chat }) => {
 
 	return (
 		<div
-			className={`relative flex flex-row items-center justify-between w-full h-11 md:h-8 text-sm leading-5 font-normal md:px-2 rounded-[3px] md:hover:bg-dunkelblau-90 ${
-				isSelected && "bg-dunkelblau-90"
-			}`}
+			className={`relative flex flex-row items-center justify-between 
+				w-full h-8 text-sm leading-5 font-normal pl-2 pr-1 md:px-2 rounded-[3px] 
+				md:hover:bg-dunkelblau-90 ${isSelected && "bg-dunkelblau-90"}`}
 			tabIndex={-1}
 			onMouseEnter={() => setIsHovered(true)}
 			onMouseLeave={() => setIsHovered(false)}
 		>
 			<button
-				className="md:max-w-[200px] md:w-[200px] w-full mr-3 md:mr-0 truncate rounded-[3px] text-start text-hellblau-50 focus:outline-default focus-visible:outline-default"
+				className="md:max-w-[200px] md:w-[200px] h-full w-full mr-3 md:mr-0 truncate rounded-[3px] text-start text-hellblau-50 focus:outline-default focus-visible:outline-default"
 				onClick={() => {
 					if (typeof window !== "undefined" && window.innerWidth < 1024) {
 						setOpenDrawer(null); // Only close the drawer on mobile

--- a/apps/frontend/src/components/sidebar/history/history-group-by-dropdown.tsx
+++ b/apps/frontend/src/components/sidebar/history/history-group-by-dropdown.tsx
@@ -11,7 +11,7 @@ import {
 
 const options: GroupingOption[] = ["none", "date"];
 
-export function HistoryGroupedByDropdown() {
+export function HistoryGroupByDropdown() {
 	const { groupBy, setGroupBy } = useHistoryGroupByStore();
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 	const selectButtonRef = useRef<HTMLButtonElement>(null);

--- a/apps/frontend/src/components/sidebar/history/history-groups/history-groups-by-date.tsx
+++ b/apps/frontend/src/components/sidebar/history/history-groups/history-groups-by-date.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo } from "react";
-import { HistoryEntry } from "./history-entry";
-import { useChatsStore } from "../../../store/use-chats-store";
+import { HistoryEntry } from "../history-entry.tsx";
+import { useChatsStore } from "../../../../store/use-chats-store.ts";
 import { subDays, format } from "date-fns";
 import { de } from "date-fns/locale";
-import Content from "../../../content.ts";
-import { LoadMoreChatsSpinner } from "./load-more-chats-spinner.tsx";
+import Content from "../../../../content.ts";
+import { LoadMoreChatsSpinner } from "../load-more-chats-spinner.tsx";
 
 const today = new Date();
 const sevenDaysAgo = subDays(today, 7);
@@ -79,10 +79,10 @@ export function HistoryGroupsByDate({
 	}, [chatsToday, chatsLastSevenDays, chatsByMonth]);
 
 	return (
-		<ul className={`w-full flex flex-col gap-6 mb-5`}>
+		<ul className={`w-full flex flex-col mb-5 -mt-1`}>
 			{chatGroups.map(({ label, chats: chatsInGroup }) => (
 				<li key={label} className="flex flex-col">
-					<div className="flex items-center truncate text-sm leading-5 font-bold text-hellblau-50 h-8 md:px-2">
+					<div className="flex items-center truncate text-xs leading-5 h-6 text-dunkelblau-40 md:px-2 first:mb-1">
 						{label}
 					</div>
 					<ul>

--- a/apps/frontend/src/components/sidebar/history/history-groups/history-groups-by-date.tsx
+++ b/apps/frontend/src/components/sidebar/history/history-groups/history-groups-by-date.tsx
@@ -82,7 +82,7 @@ export function HistoryGroupsByDate({
 		<ul className={`w-full flex flex-col mb-5 -mt-1`}>
 			{chatGroups.map(({ label, chats: chatsInGroup }) => (
 				<li key={label} className="flex flex-col">
-					<div className="flex items-center truncate text-xs leading-5 h-6 text-dunkelblau-40 md:px-2 first:mb-1">
+					<div className="flex items-center truncate text-xs leading-5 h-6 text-dunkelblau-40 md:px-2">
 						{label}
 					</div>
 					<ul>

--- a/apps/frontend/src/components/sidebar/history/history-groups/history-groups-by-none.tsx
+++ b/apps/frontend/src/components/sidebar/history/history-groups/history-groups-by-none.tsx
@@ -12,7 +12,7 @@ export function HistoryGroupsByNone({
 
 	return (
 		<>
-			<ul className="mb-5">
+			<ul>
 				{chats.map((chat) => (
 					<li key={chat.id}>
 						<HistoryEntry chat={chat} />

--- a/apps/frontend/src/components/sidebar/history/history.tsx
+++ b/apps/frontend/src/components/sidebar/history/history.tsx
@@ -1,10 +1,10 @@
 import React, { useRef, useState } from "react";
 import { useChatsStore } from "../../../store/use-chats-store.ts";
-import { HistoryGroupsByDate } from "./history-groups-by-date.tsx";
+import { HistoryGroupsByDate } from "./history-groups/history-groups-by-date.tsx";
 import { Skeleton } from "../../primitives/skeletons/skeleton.tsx";
 import Content from "../../../content.ts";
 import { useErrorStore } from "../../../store/error-store.ts";
-import { HistoryGroupedByDropdown } from "./history-grouped-by-dropdown.tsx";
+import { HistoryGroupByDropdown } from "./history-group-by-dropdown.tsx";
 import { useHistoryGroupByStore } from "../../../store/use-history-group-by-store.ts";
 import { HistoryGroupsByNone } from "./history-groups/history-groups-by-none.tsx";
 import { ChevronIcon } from "../../primitives/icons/chevron-icon.tsx";
@@ -30,10 +30,10 @@ export const History: React.FC = () => {
 
 	return (
 		<div
-			className={`flex flex-col gap-[18px] w-full min-h-0 ${errorMessage ? "h-full" : ""}`}
+			className={`flex flex-col w-full min-h-0 ${errorMessage ? "h-full" : ""}`}
 		>
-			<div className="flex justify-between">
-				<h2 className="text-base leading-6 font-semibold text-hellblau-50 md:px-2 px-5 whitespace-nowrap pt-1">
+			<div className="flex justify-between items-center md:px-2 px-5">
+				<h2 className="text-base font-semibold text-hellblau-50  whitespace-nowrap">
 					<button
 						className={
 							"flex items-center focus-visible:outline-default rounded-3px"
@@ -51,12 +51,12 @@ export const History: React.FC = () => {
 					</button>
 				</h2>
 
-				<HistoryGroupedByDropdown />
+				<HistoryGroupByDropdown />
 			</div>
 			{!isHistoryCollapsed && (
 				<div
 					ref={historyContainerRef}
-					className="flex flex-col grow min-h-0 overflow-y-auto px-5 md:px-0 md:pr-4 history-scrollbar"
+					className="flex flex-col grow min-h-0 overflow-y-auto pl-3 pr-6 md:px-0 md:pr-4 history-scrollbar"
 				>
 					<div className="w-full h-full">
 						<div

--- a/apps/frontend/src/components/sidebar/history/history.tsx
+++ b/apps/frontend/src/components/sidebar/history/history.tsx
@@ -33,7 +33,7 @@ export const History: React.FC = () => {
 			className={`flex flex-col w-full min-h-0 ${errorMessage ? "h-full" : ""}`}
 		>
 			<div className="flex justify-between items-center md:px-2 px-5">
-				<h2 className="text-base font-semibold text-hellblau-50  whitespace-nowrap">
+				<h2 className="text-sm font-semibold text-hellblau-50  whitespace-nowrap">
 					<button
 						className={
 							"flex items-center focus-visible:outline-default rounded-3px"

--- a/apps/frontend/src/components/sidebar/history/load-more-chats-spinner.tsx
+++ b/apps/frontend/src/components/sidebar/history/load-more-chats-spinner.tsx
@@ -20,7 +20,7 @@ export function LoadMoreChatsSpinner({
 	useIntersectionObserver({ containerRef, ref, hasLoadedAllChats });
 
 	return (
-		<div className="flex justify-center pl-2 text-hellblau-50 text-xs">
+		<div className="flex justify-center pl-2 text-dunkelblau-40 text-xs mt-2">
 			{hasLoadedAllChats && <span>{Content["chatHistory.allLoaded"]}</span>}
 
 			{!hasLoadedAllChats && (


### PR DESCRIPTION
The chat history was missing a few stylings that weren't mentionned in the ticket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved spacing, alignment, and sizing across the chat history sidebar, including tighter header layout and updated scroll padding.
  * Refined grouped history header typography and list spacing for clearer readability and better truncation.
  * Updated loading indicator color styling for a more consistent look.
* **Bug Fixes**
  * Fixed the grouped-by dropdown control to use the correct naming for consistent labeling and presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->