### PR TITLE
feat: add GitHub Container Registry workflow 

### DIFF
--- a/.github/actions/wait-for-backend/action.yml
+++ b/.github/actions/wait-for-backend/action.yml
@@ -1,13 +1,56 @@
-name: Wait for backend server to be ready
-description: Polls until the backend server at localhost:3000 is accepting connections
+name: Wait for backend
+description: Polls GHCR until the given image tag is available, then pulls it, runs it in a container and waits until it's running
+
+inputs:
+  github-token:
+    description: The github token of the current organisation
+    required: true
 
 runs:
   using: composite
+
   steps:
-    - name: Wait for Backend to be ready ⏳
+    - name: Log in to GitHub Container Registry 🔑
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0, pinned to commit sha to avoid sha-hulud like attacks
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github-token }}
+
+    - name: Compute backend image name with latest tag 🏷️
+      id: image
+      shell: bash
+      run: |
+        echo "image=ghcr.io/${{ github.repository_owner }}/baergpt-backend:content-sha-${{ hashFiles('apps/backend/**', '!apps/backend/node_modules/**', 'libs/db-schema/**', 'libs/typescript-config/**', 'turbo.json', 'package.json', 'package-lock.json', '.dockerignore') }}" >> "$GITHUB_OUTPUT"
+
+    - name: Wait for image and pull it 🐳
       shell: bash
       run: |
         timeout=600
+        counter=0
+        until docker pull "${{ steps.image.outputs.image }}" >/dev/null 2>&1; do
+          if [ $counter -gt $timeout ]; then
+            echo "Timed out waiting for image ${{ steps.image.outputs.image }}"
+            exit 1
+          fi
+          echo "Waiting for ${{ steps.image.outputs.image }} to be available on GHCR..."
+          sleep 5
+          counter=$((counter + 5))
+        done
+        echo "Image ${{ steps.image.outputs.image }} pulled successfully!"
+
+    - name: Run Backend in container 🖥️
+      shell: bash
+      run: |
+        docker run -d --name backend-container \
+          --network host \
+          --env-file "$RUNNER_TEMP/backend.env" \
+          ${{ steps.image.outputs.image }}
+
+    - name: Wait for Backend to be ready ⏳
+      shell: bash
+      run: |
+        timeout=60
         counter=0
         until curl -s http://localhost:3000/ >/dev/null; do
           if [ $counter -gt $timeout ]; then

--- a/.github/workflows/admin-panel-tests.yml
+++ b/.github/workflows/admin-panel-tests.yml
@@ -1,10 +1,13 @@
 name: Admin Panel Tests
+
 permissions:
-  contents: write
-  packages: write
+  contents: read
+  packages: read
+
 on:
   pull_request:
     branches: [main, staging]
+
 jobs:
   admin-panel-tests:
     runs-on: ubuntu-latest
@@ -34,36 +37,10 @@ jobs:
 
       - name: Fetch backend .env from 1Password ⬇️
         run: |
-          cd apps/backend
           echo "Fetching backend .env from 1Password..."
-          op read "op://${{ secrets.OP_VAULT_ID }}/${{ secrets.OP_BACKEND_TEST_ENV_ITEM_ID }}/notesPlain" > .env
+          op read "op://${{ secrets.OP_VAULT_ID }}/${{ secrets.OP_BACKEND_TEST_ENV_ITEM_ID }}/notesPlain" > "$RUNNER_TEMP/backend.env"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
-      - name: Cache backend build 💾
-        id: cache-backend-build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0, pinned to commit sha to avoid sha-hulud like attacks
-        with:
-          path: |
-            ./apps/backend/dist
-          key: ${{ runner.os }}-node-backend-${{ hashFiles('./apps/backend/**/*', '!./apps/backend/node_modules/**/*', '**/package-lock.json') }}
-
-      - name: Build backend 🏗️
-        if: steps.cache-backend-build.outputs.cache-hit != 'true'
-        run: |
-          cd apps/backend
-          npm run check-types
-          npm run build
-
-      # You might wonder why we are running the backend with `&` at the end.
-      # This will allow the backend to start in the background while other steps can
-      # be done in parallel. This saves time in the CI process.
-      - name: Start backend server 🖥️
-        run: |
-          cd apps/backend
-          set -a && . .env && set +a
-          nohup npm run start > backend.log 2>&1 &
-          echo $! > backend.pid
 
       - name: Install Playwright Browser 🧭
         run: |
@@ -87,6 +64,8 @@ jobs:
 
       - name: Wait for Backend to be ready ⏳
         uses: ./.github/actions/wait-for-backend
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for Supabase to be ready ⏳
         uses: ./.github/actions/wait-for-supabase
@@ -99,12 +78,12 @@ jobs:
       - name: Capture backend logs after admin panel E2E test after failure 📋
         if: failure()
         run: |
-          if [ -f apps/backend/backend.log ]; then
-            echo "=== Backend server logs ==="
-            cat apps/backend/backend.log
+          if docker inspect backend-container >/dev/null 2>&1; then
+            echo "=== Backend container logs ==="
+            docker logs backend-container
             echo "=== End backend logs ==="
           else
-            echo "Backend log file not found"
+            echo "backend-container not found"
           fi
 
       - name: Upload admin-panel E2E test results ⬆️

--- a/.github/workflows/backend-image-build-and-push.yml
+++ b/.github/workflows/backend-image-build-and-push.yml
@@ -1,0 +1,67 @@
+name: Backend image build and push to registry
+
+on:
+  pull_request:
+    branches: [staging, main]
+    paths:
+      - "apps/backend/**"
+      - "libs/db-schema/**"
+      - "libs/typescript-config/**"
+      - "turbo.json"
+      - "package.json"
+      - "package-lock.json"
+      - ".dockerignore"
+      - ".github/workflows/backend-image-build-and-push.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/baergpt-backend
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code ⬇️
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0, pinned to commit sha to avoid sha-hulud like attacks
+        with:
+          fetch-depth: "2"
+
+      - name: Compute image tag 🏷️
+        id: tag
+        run: |
+          echo "tag=content-sha-${{ hashFiles('apps/backend/**', '!apps/backend/node_modules/**', 'libs/db-schema/**', 'libs/typescript-config/**', 'turbo.json', 'package.json', 'package-lock.json', '.dockerignore') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry 🔑
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0, pinned to commit sha to avoid sha-hulud like attacks
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if image already exists in GHCR 🔍
+        id: check
+        run: |
+          if docker manifest inspect ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }} >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push image 🐳
+        if: steps.check.outputs.exists != 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0, pinned to commit sha to avoid sha-hulud like attacks
+        with:
+          context: .
+          file: apps/backend/Dockerfile
+          platforms: linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+            ${{ env.IMAGE_NAME }}:commit-${{ github.sha }}

--- a/.github/workflows/backend-image-build-and-push.yml
+++ b/.github/workflows/backend-image-build-and-push.yml
@@ -43,6 +43,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Runner's default docker driver can't export cache (type=gha); switches
+      # to the docker-container driver, which supports --cache-to.
+      - name: Set up Docker Buildx ⚙️
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0, pinned to commit sha to avoid sha-hulud like attacks
+
       - name: Check if image already exists in GHCR 🔍
         id: check
         run: |

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -26,20 +26,6 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
-      - name: Cache backend build 💾
-        id: cache-backend-build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0, pinned to commit sha to avoid sha-hulud like attacks
-        with:
-          path: |
-            ./apps/backend/dist
-          key: ${{ runner.os }}-node-backend-${{ hashFiles('./apps/backend/**/*', '!./apps/backend/node_modules/**/*', '**/package-lock.json') }}
-
-      - name: Check Build 🏗️
-        if: steps.cache-backend-build.outputs.cache-hit != 'true'
-        run: |
-          cd apps/backend
-          npm run build
-
       - name: Wait for Supabase to be ready ⏳
         uses: ./.github/actions/wait-for-supabase
 

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -36,34 +36,9 @@ jobs:
         run: |
           cd apps/backend
           echo "Fetching backend .env from 1Password..."
-          op read "op://${{ secrets.OP_VAULT_ID }}/${{ secrets.OP_BACKEND_TEST_ENV_ITEM_ID }}/notesPlain" > .env
+          op read "op://${{ secrets.OP_VAULT_ID }}/${{ secrets.OP_BACKEND_TEST_ENV_ITEM_ID }}/notesPlain" > "$RUNNER_TEMP/backend.env"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
-      - name: Cache backend build 💾
-        id: cache-backend-build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0, pinned to commit sha to avoid sha-hulud like attacks
-        with:
-          path: |
-            ./apps/backend/dist
-          key: ${{ runner.os }}-node-backend-${{ hashFiles('./apps/backend/**/*', '!./apps/backend/node_modules/**/*', '**/package-lock.json') }}
-
-      - name: Build backend 🏗️
-        if: steps.cache-backend-build.outputs.cache-hit != 'true'
-        run: |
-          cd apps/backend
-          npm run check-types
-          npm run build
-
-      # You might wonder why we are running the backend with `&` at the end.
-      # This will allow the backend to start in the background while other steps can
-      # be done in parallel. This saves time in the CI process.
-      - name: Start backend server 🖥️
-        run: |
-          cd apps/backend
-          set -a && . .env && set +a
-          nohup npm run start > backend.log 2>&1 &
-          echo $! > backend.pid
 
       - name: Install Playwright Browser 🧭
         run: |
@@ -97,6 +72,8 @@ jobs:
 
       - name: Wait for Backend to be ready ⏳
         uses: ./.github/actions/wait-for-backend
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for Supabase to be ready ⏳
         uses: ./.github/actions/wait-for-supabase
@@ -109,12 +86,12 @@ jobs:
       - name: Capture backend logs after frontend E2E test after failure 📋
         if: failure()
         run: |
-          if [ -f apps/backend/backend.log ]; then
-            echo "=== Backend server logs ==="
-            cat apps/backend/backend.log
+          if docker inspect backend-container >/dev/null 2>&1; then
+            echo "=== Backend container logs ==="
+            docker logs backend-container
             echo "=== End backend logs ==="
           else
-            echo "Backend log file not found"
+            echo "backend-container not found"
           fi
 
       - name: Upload frontend E2E test results ⬆️

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,7 +1,7 @@
 name: Frontend Tests
 permissions:
-  contents: write
-  packages: write
+  contents: read
+  packages: read
 on:
   pull_request:
     branches: [main, staging]

--- a/.github/workflows/maintenance-tests.yml
+++ b/.github/workflows/maintenance-tests.yml
@@ -46,17 +46,6 @@ jobs:
           cd apps/maintenance-mode
           npm run test:e2e -- --project="${{ matrix.browser }}"
 
-      - name: Capture backend logs after maintenance mode E2E test after failure 📋
-        if: failure()
-        run: |
-          if [ -f apps/backend/backend.log ]; then
-            echo "=== Backend server logs ==="
-            cat apps/backend/backend.log
-            echo "=== End backend logs ==="
-          else
-            echo "Backend log file not found"
-          fi
-
       - name: Upload maintenance mode E2E test results ⬆️
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1, pinned to commit sha to avoid sha-hulud like attacks
         if: ${{ failure() && !cancelled() }}


### PR DESCRIPTION
This PR adds a new workflow to build the backend image and push it to the github registry. It will be tagged with both the commit hash and the hash of the files inside the directory to make sure it will only be rebuilt when really needed. 

This image will now also be used in admin-panel and frontend test workflows. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215648063343450
  - https://app.asana.com/0/0/1215648063343448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automated backend Docker image builds and publishing to the container registry for backend-related changes.
  - Improved CI backend bootstrap to pull a matching backend image and wait for service readiness.
- **Bug Fixes**
  - Improved CI handling of generated backend environment configuration using temporary runner storage.
  - Updated E2E failure logging to prefer backend container logs when available.
- **Tests**
  - Streamlined backend CI test flow by removing redundant build/caching.
  - Reduced backend readiness polling timeout for faster feedback.
- **Chores**
  - Tightened CI workflow permissions to read-only for actions that don’t require write access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->