### PR TITLE
feat: remove document title from section

### DIFF
--- a/apps/frontend/src/components/documents/desktop-documents.tsx
+++ b/apps/frontend/src/components/documents/desktop-documents.tsx
@@ -143,27 +143,22 @@ export function DesktopDocuments({ hasUserItems }: { hasUserItems: boolean }) {
 							}
 							onBlur={hideTooltip}
 						>
-							<DocumentIcon variant="black" />
+							<DocumentIcon variant="darkBlue" />
 						</button>
-						<h2
-							className={`text-dunkelblau-200 text-2xl font-bold flex gap-x-2 ${isCollapsed && "hidden"}`}
-						>
-							{Content["documentsSection.title"]}
-						</h2>
 					</div>
 					<button
 						className={`p-1 rounded-3px hover:bg-hellblau-60 focus-visible:outline-default ${isCollapsed && "hidden"}`}
 						onClick={() => setIsCollapsed(true)}
 						aria-label={Content["documentsSection.hideFiles.ariaLabel"]}
 					>
-						<CloseIcon />
+						<CloseIcon variant="darkBlue" />
 					</button>
 				</div>
 
 				{!isCollapsed && (
 					<>
 						{currentFolder && (
-							<div className="mt-8">
+							<div className="mt-4">
 								<DocumentBreadcrumbs />
 							</div>
 						)}
@@ -172,7 +167,7 @@ export function DesktopDocuments({ hasUserItems }: { hasUserItems: boolean }) {
 							<>
 								<PublicFolders />
 
-								<h2 className="mt-8 leading-6 text-dunkelblau-100">
+								<h2 className="mt-5 leading-6 text-dunkelblau-100">
 									{Content["documentsSection.mainFolder.label"]}
 								</h2>
 							</>

--- a/apps/frontend/src/components/documents/document-list/public-folders.tsx
+++ b/apps/frontend/src/components/documents/document-list/public-folders.tsx
@@ -15,13 +15,13 @@ export function PublicFolders() {
 
 	return (
 		<>
-			<h2 className="md:mt-9 pl-0.5 leading-6 text-dunkelblau-100">
+			<h2 className="md:mt-4 pl-0.5 leading-6 text-dunkelblau-100">
 				{Content["documentSection.publicFolder.label"]}
 			</h2>
 			<ul
 				className={`mt-2 flex items-center w-full hover:bg-hellblau-55 group`}
 			>
-				<li className="flex items-center w-full border-b-[0.5px] border-y-hellblau-110">
+				<li className="flex items-center w-full border-y-[0.5px] border-y-hellblau-110">
 					<button
 						className={`flex h-11 pl-5 md:pl-2.5 w-0 items-center grow gap-x-1 rounded-3px focus-visible:outline-default`}
 						onClick={() => setCurrentFolder(baseKnowledgeFolder)}

--- a/apps/frontend/src/content.ts
+++ b/apps/frontend/src/content.ts
@@ -750,7 +750,6 @@ export const Content = {
 	"eyeStruckThroughIcon.imgAlt": "Ein durchgestrichenes Augen-Icon",
 
 	/* -------------------- DocumentsSection -------------------- */
-	"documentsSection.title": "Dateien",
 	"documentSection.publicFolder.label": "Bibliothek",
 	"documentSection.publicFolder.baseKnowledge.label": "Verwaltungswissen",
 	"documentsSection.mainFolder.label": "Meine Dateien",

--- a/apps/frontend/tests/e2e/document.spec.ts
+++ b/apps/frontend/tests/e2e/document.spec.ts
@@ -889,7 +889,7 @@ test.describe("Documents", () => {
 
 		// The panel should be open by default
 		const documentPanelHeading = page.getByRole("heading", {
-			name: "Dateien",
+			name: "Meine Dateien",
 			exact: true,
 		});
 		await expect(documentPanelHeading).toBeVisible();


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216628798661720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the desktop documents panel collapse/expand icons for better visual consistency.
  * Refined breadcrumbs and folder header spacing/typography across the documents panel.
  * Improved “Public folder” section spacing and simplified its vertical border styling.
* **Content**
  * Removed the unused documents section title translation entry.
* **Tests**
  * Updated the documents panel E2E checks to expect the German heading “Meine Dateien”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->