### PR TITLE
Alerting Setup

### DIFF
--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -1,15 +1,21 @@
 name: Terraform Checks
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
       - "infra/terraform/**"
+      - ".tool-versions"
       - ".github/workflows/terraform-checks.yml"
   push:
     branches:
       - main
     paths:
       - "infra/terraform/**"
+      - ".tool-versions"
+      - ".github/workflows/terraform-checks.yml"
   workflow_dispatch:
 
 jobs:
@@ -18,10 +24,12 @@ jobs:
 
     steps:
       - name: Checkout repository ⬇️
-        uses: actions/checkout@v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install tools via asdf ⚙️
-        uses: asdf-vm/actions/install@v4
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
 
       - name: Check formatting 🎨
         run: terraform fmt -check -recursive -diff infra/terraform

--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -1,0 +1,35 @@
+name: Terraform Checks
+
+on:
+  pull_request:
+    paths:
+      - "infra/terraform/**"
+      - ".github/workflows/terraform-checks.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "infra/terraform/**"
+  workflow_dispatch:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository ⬇️
+        uses: actions/checkout@v5
+
+      - name: Install tools via asdf ⚙️
+        uses: asdf-vm/actions/install@v4
+
+      - name: Check formatting 🎨
+        run: terraform fmt -check -recursive -diff infra/terraform
+
+      - name: Validate observability module ✅
+        working-directory: infra/terraform/observability
+        run: |
+          # -backend=false: validate the config without touching remote state,
+          # so CI needs no STACKIT or object-storage credentials.
+          terraform init -backend=false
+          terraform validate

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 supabase-cli 2.40.7
+terraform 1.15.7

--- a/infra/supabase/MONITORING.md
+++ b/infra/supabase/MONITORING.md
@@ -9,8 +9,15 @@ STACKIT Observability: **metrics** via Prometheus remote-write, **logs** via OTL
   (1Password), per-env metadata from `monitoring.env` (rendered from the inventory).
 - Grafana dashboard: [`grafana/supabase-vm-dashboard.json`](./grafana/supabase-vm-dashboard.json)
   (import it; pick the Thanos + Loki datasources, switch `$source` for staging/prod).
+- Alert rules: [`infra/terraform/observability`](../terraform/observability/)
 
 All telemetry is tagged `source=supabase-<env>` and `host=<hostname>`.
+
+> **These label values are load-bearing.** The alert rules select on `source` (metrics)
+> and `service_name` (logs). Changing `BAERGPT_ENV` or the processors that set them
+> breaks every alert silently — rules with no matching series apply cleanly and simply
+> never fire. After any collector change, re-run the verification queries in the
+> alerting module's README.
 
 ## Metrics
 

--- a/infra/supabase/otel-config.yml
+++ b/infra/supabase/otel-config.yml
@@ -55,6 +55,8 @@ processors:
     limit_mib: 256
     spike_limit_mib: 56
 
+  # Load-bearing: `source` here and `service.name` below are what the alert rules in
+  # infra/terraform/observability select on. Changing them breaks every alert silently.
   attributes/source:
     actions:
       - key: source

--- a/infra/terraform/observability/.gitignore
+++ b/infra/terraform/observability/.gitignore
@@ -1,0 +1,20 @@
+# Terraform working files
+.terraform/
+.terraform.tfstate.lock.info
+
+# State is remote; these catch local leftovers, which can contain resolved secrets.
+*.tfstate
+*.tfstate.*
+
+# Real variable files (commit only the *.example templates)
+*.tfvars
+!*.tfvars.example
+
+# `op run` env files: op:// references, not secrets, but they encode internal vault ids.
+.op.env.observability.*
+!.op.env.observability.*.example
+
+# STACKIT service-account key pulled from 1Password
+sa-key.json
+
+# DO commit .terraform.lock.hcl — it pins the provider version for the team.

--- a/infra/terraform/observability/.op.env.observability.production.example
+++ b/infra/terraform/observability/.op.env.observability.production.example
@@ -1,0 +1,11 @@
+# Copy to .op.env.observability.production and point the ref at your prod STACKIT
+# service-account-key item in 1Password. op:// REFERENCE only — no secret value:
+#
+#   op run --env-file .op.env.observability.production -- terraform plan -var-file=production.tfvars
+STACKIT_SERVICE_ACCOUNT_KEY=op://<vault>/<stackit-production-service-account-item>/<field>
+
+# REQUIRED: state lives in the S3 backend (versions.tf), which authenticates SEPARATELY
+# from the provider, with S3 keys from a STACKIT objectstorage credential. Without these,
+# even `terraform init` fails — there is no metadata-service fallback.
+AWS_ACCESS_KEY_ID=op://<vault>/<tfstate-objectstorage-credential>/access_key
+AWS_SECRET_ACCESS_KEY=op://<vault>/<tfstate-objectstorage-credential>/secret_access_key

--- a/infra/terraform/observability/.op.env.observability.staging.example
+++ b/infra/terraform/observability/.op.env.observability.staging.example
@@ -1,0 +1,16 @@
+# Copy to .op.env.observability.staging and point the ref at your real STACKIT
+# service-account-key item in 1Password. This file holds an op:// REFERENCE only —
+# no secret value — and `op run` resolves it into an env var at runtime (nothing on disk):
+#
+#   op run --env-file .op.env.observability.staging -- terraform plan -var-file=staging.tfvars
+#
+# The SA-key JSON embeds the private key, so this one var fully authenticates the STACKIT
+# key flow (read as inline content by the SDK). project_id/instance_id come from *.tfvars,
+# so no STACKIT_PROJECT_ID is needed here.
+STACKIT_SERVICE_ACCOUNT_KEY=op://<vault>/<stackit-staging-service-account-item>/<field>
+
+# REQUIRED: state lives in the S3 backend (versions.tf), which authenticates SEPARATELY
+# from the provider, with S3 keys from a STACKIT objectstorage credential. Without these,
+# even `terraform init` fails — there is no metadata-service fallback.
+AWS_ACCESS_KEY_ID=op://<vault>/<tfstate-objectstorage-credential>/access_key
+AWS_SECRET_ACCESS_KEY=op://<vault>/<tfstate-objectstorage-credential>/secret_access_key

--- a/infra/terraform/observability/.terraform.lock.hcl
+++ b/infra/terraform/observability/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/stackitcloud/stackit" {
+  version     = "0.100.0"
+  constraints = ">= 0.40.0"
+  hashes = [
+    "h1:muP1xPUnx3fpyoOXSJ+PN1GnsEpsvycXxgjn4+BcnVo=",
+    "h1:xmNLhZhW8ROJZsis/8O2br7No2gnuAmJfeFGOzXpYsk=",
+    "zh:0dde99e7b343fa01f8eefc378171fb8621bedb20f59157d6cc8e3d46c738105f",
+    "zh:4c826cf81f3215ac3febdaa877cf397897ddae42ed97a0358266fa55751e5feb",
+    "zh:64161b8214b1e2a7f91812ead3df31327a57487a1fe45c697322eebb3272256d",
+    "zh:861df34f5b81a8de900d957cbe76cf072f1a7835becfb61c0c2974b06e655476",
+    "zh:873901bc0a79cbb9d03881bd738d70b74354c89a410a099b72fb4954c0617825",
+    "zh:908c611538f596c54a3b3056f748e53cfa65dced782037c440e270e244786aeb",
+    "zh:aafffdb31707fdf5e679c4fc62622d45794bd5c7cc56aaf29d2e9aa88f2f3503",
+    "zh:da6eadbf309284d214c7c49397639c47fb8a2fe4e38d8ba6ecd46f4cdc72bd48",
+    "zh:dbcda6b1ac60990498e903af94e3253a68a66c7cfdf6802143532c38fcb2b097",
+    "zh:eb4007c23b5e340890cb0e967ac65c99add25612562a464a6013fbcdd224a4bf",
+    "zh:eb620993278bbddab95eb575eebe12c8827085001acf38e13d4e3afcd938a826",
+    "zh:ed8dacf190d95648438b05db258ee513725c26fe854c804e027ee9c7bd110186",
+    "zh:f9c4a80d8e851a4114911721cc1385812c9e61cb5da161ef006325bd1958969b",
+    "zh:ffe7dbf40cdb5f70d2cd0a16219248e9c97c48accabdad4e4cf8ff34408157aa",
+  ]
+}

--- a/infra/terraform/observability/README.md
+++ b/infra/terraform/observability/README.md
@@ -1,0 +1,116 @@
+# STACKIT Observability alerting (Terraform)
+
+Alert rules for the Supabase VMs' telemetry (host metrics + Kong logs) that the OTel
+collector ships to STACKIT Observability (see `infra/supabase/MONITORING.md`).
+
+STACKIT's Grafana is read-only, so alerts live in the Prometheus/Alertmanager layer.
+This module manages the alert **rules**. The **receiver** (email, via Brevo) is set
+out-of-band by `set-email-receiver.sh`, because receivers live inside the
+`observability_instance` — which we keep hand-managed so a bad apply can't replace the
+live pipeline. Slack isn't supported by STACKIT's Alertmanager.
+
+## Layout
+
+| File                      | What it manages                                                         |
+| ------------------------- | ----------------------------------------------------------------------- |
+| `versions.tf`             | Terraform + provider pin; S3 remote-state backend                       |
+| `provider.tf`             | `stackit` provider, region `eu01`, env-based auth                       |
+| `variables.tf`            | ids, `target_source`, thresholds; validations incl. the workspace guard |
+| `alerts_metrics.tf`       | host down / disk / memory / CPU (PromQL)                                |
+| `alerts_logs.tf`          | Kong 5xx ratio (LogQL)                                                  |
+| `set-email-receiver.sh`   | one-time API call to set the email receiver + route                     |
+| `.op.env.observability.*` | 1Password `op://` refs for `op run` auth (real files gitignored)        |
+| `*.tfvars.example`        | copy → `staging.tfvars` / `production.tfvars` (gitignored)              |
+
+## Apply
+
+Auth is injected from 1Password via `op run` (like the ansible playbooks); the
+`.op.env.observability.<env>` files hold `op://` references only. `project_id`,
+`instance_id`, and `target_source` (`supabase-<env>`) come from `<env>.tfvars`.
+
+**Every** terraform command needs the `op run` wrapper, `init` and `workspace` included:
+the S3 backend authenticates with `AWS_*` from the env-file and has no metadata-service
+fallback, so an unwrapped `init` fails with "No valid credential sources found".
+
+```sh
+OP="op run --env-file .op.env.observability.staging --"
+
+$OP terraform init                       # commit the generated .terraform.lock.hcl
+$OP terraform workspace select staging   # pick the env's state (see Workspaces)
+$OP terraform plan  -var-file=staging.tfvars
+$OP terraform apply -var-file=staging.tfvars
+```
+
+## Email receiver (one-time, per instance)
+
+Set the receiver + route alerts are delivered to — either in the Portal (Alerting →
+Alert config → add an Email receiver named `email` + a route to it), or the script:
+
+```sh
+set -a; source <(op read "op://<vault>/<note>/notesPlain"); set +a
+./set-email-receiver.sh
+```
+
+`smarthost` must be `host:port` (e.g. `smtp-relay.brevo.com:587`); `from` must be a
+Brevo-verified sender. Env keys are documented in the script header.
+
+## Remote state
+
+State lives in the `baergpt-tfstate` STACKIT Object Storage bucket (S3 backend in
+`versions.tf`). The bucket and its S3 credentials are created by hand; the backend
+authenticates with `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from the env-file,
+separately from the provider's SA key.
+
+## Workspaces (staging vs production)
+
+Each environment is a named **workspace** — the same config, a separate state file
+(`env:/<workspace>/…`); `default` is intentionally empty. A workspace only selects
+_which state_; the _values_ come from `-var-file`. Every run sets two dials that must
+agree, and `variables.tf` validates `terraform.workspace == var.env` — a mismatched run
+fails before it can write to the wrong state.
+
+```sh
+OP="op run --env-file .op.env.observability.staging --"
+
+$OP terraform workspace show                 # which env am I in?
+$OP terraform workspace select staging       # switch state
+$OP terraform apply -var-file=staging.tfvars
+```
+
+New env: `terraform workspace new production`, add `production.tfvars` (`env = "production"`),
+then apply. `variables.tf` validates that `env` is a known environment and that
+`target_source` is `supabase-<env>`, so a typo fails at plan time rather than applying
+rules that silently never fire.
+
+## Verify queries before trusting alerts
+
+A rule whose query matches nothing applies cleanly and never fires, so check each
+environment in Grafana → Explore before relying on it.
+
+- `count by (source) (system_memory_usage_bytes)` — the environment appears, spelled exactly
+  as `target_source`.
+- `count by (state) (system_memory_usage_bytes{source="supabase-<env>"})` — `used`, `free`,
+  `cached` and `buffered` all present, and their sum ≈ the VM's RAM. A sum above real RAM
+  means slab is double-counted and `MemoryHigh` fires late.
+- `count by (mode, mountpoint) (system_filesystem_usage_bytes{source="supabase-<env>"})` —
+  data mounts are `mode="rw"`. Run the `DiskAlmostFull` ratio itself too: a mount already
+  over the threshold fires on apply.
+- `{service_name="supabase-<env>"}` on Loki — access lines match `|~ "\" 5\\d\\d "`. The 5xx
+  ratio has no series when there are no 5xx, so an empty graph is healthy.
+
+Prove delivery once per instance: add a throwaway `expression = "vector(1)"`, `for = "0s"`
+rule, apply, confirm the mail lands, delete, re-apply.
+
+## Gotchas
+
+- **No `up` metric** — metrics are pushed, not scraped, so host-down uses `absent(...)`,
+  which fires _because_ nothing matches. Every other rule does the opposite: no matching
+  series looks exactly like a healthy one.
+- **Receiver name must equal the route's receiver.**
+- **Commit `.terraform.lock.hcl`** so everyone uses the same provider version.
+- **Editing any rule replaces the whole group** — `rules` forces replacement, so a one-word
+  change plans as `1 to add, 1 to destroy` and leaves a sub-second gap in evaluation.
+- **A dead logs pipeline is not alerted** — metrics and logs ship independently, so
+  `HostOrCollectorDown` can stay silent while the Kong rule goes blind. `absent_over_time`
+  would cover it, but not at current traffic, where a quiet hour looks identical to a
+  broken pipeline.

--- a/infra/terraform/observability/README.md
+++ b/infra/terraform/observability/README.md
@@ -77,7 +77,7 @@ $OP terraform workspace select staging       # switch state
 $OP terraform apply -var-file=staging.tfvars
 ```
 
-New env: `terraform workspace new production`, add `production.tfvars` (`env = "production"`),
+New env: `$OP terraform workspace new production`, add `production.tfvars` (`env = "production"`),
 then apply. `variables.tf` validates that `env` is a known environment and that
 `target_source` is `supabase-<env>`, so a typo fails at plan time rather than applying
 rules that silently never fire.
@@ -114,3 +114,8 @@ rule, apply, confirm the mail lands, delete, re-apply.
   `HostOrCollectorDown` can stay silent while the Kong rule goes blind. `absent_over_time`
   would cover it, but not at current traffic, where a quiet hour looks identical to a
   broken pipeline.
+- **No state locking** — STACKIT doesn't honor S3 conditional-write locks
+  ([stackitcloud/terraform-provider-stackit#1534]), so `use_lockfile` is off. Don't run
+  concurrent applies against one workspace.
+
+[stackitcloud/terraform-provider-stackit#1534]: https://github.com/stackitcloud/terraform-provider-stackit/issues/1534

--- a/infra/terraform/observability/alerts_logs.tf
+++ b/infra/terraform/observability/alerts_logs.tf
@@ -21,8 +21,8 @@ resource "stackit_observability_logalertgroup" "kong" {
           / sum(rate({service_name="${var.target_source}"} |~ "\" \\d\\d\\d " [5m]))
           > ${var.kong_5xx_ratio_max}
         and
-        sum(rate({service_name="${var.target_source}"} |~ "\" 5\\d\\d " [5m]))
-          > ${format("%.5f", var.kong_5xx_min_errors_5m / 300)}
+        sum(count_over_time({service_name="${var.target_source}"} |~ "\" 5\\d\\d " [5m]))
+          >= ${var.kong_5xx_min_errors_5m}
       EOT
       )
       for = "2m"

--- a/infra/terraform/observability/alerts_logs.tf
+++ b/infra/terraform/observability/alerts_logs.tf
@@ -1,0 +1,39 @@
+# LogQL alert rules over the Kong gateway logs (infra/supabase/otel-config.yml,
+# filter/gateway-only), stream label service_name = supabase-<env>.
+#
+# The filters match the access-log shape `"GET /path HTTP/1.1" 502 1234` — quote, space,
+# three-digit status. LogQL unquotes Go-style escapes, so regex backslashes must be
+# doubled (\\d); \" stays single. HCL heredocs pass backslashes through verbatim.
+
+resource "stackit_observability_logalertgroup" "kong" {
+  project_id  = var.project_id
+  instance_id = var.instance_id
+  name        = "${var.env}-kong-logs"
+  interval    = "60s"
+
+  rules = [
+    # A share of traffic, not an absolute rate: traffic floors near 0.003 req/s, so any
+    # threshold quiet at peak is unreachable off-peak. The floor suppresses lone failures.
+    {
+      alert = "KongHigh5xxRate"
+      expression = trimspace(<<-EOT
+        sum(rate({service_name="${var.target_source}"} |~ "\" 5\\d\\d " [5m]))
+          / sum(rate({service_name="${var.target_source}"} |~ "\" \\d\\d\\d " [5m]))
+          > ${var.kong_5xx_ratio_max}
+        and
+        sum(rate({service_name="${var.target_source}"} |~ "\" 5\\d\\d " [5m]))
+          > ${format("%.5f", var.kong_5xx_min_errors_5m / 300)}
+      EOT
+      )
+      for = "2m"
+      labels = {
+        severity = "critical"
+        source   = var.target_source
+      }
+      annotations = {
+        summary     = "Kong 5xx above ${var.kong_5xx_ratio_max} of requests on ${var.target_source}"
+        description = "The Supabase API gateway is returning {{ $value | humanizePercentage }} 5xx over 5m. Check upstream services (rest/auth/storage) and the DB."
+      }
+    },
+  ]
+}

--- a/infra/terraform/observability/alerts_metrics.tf
+++ b/infra/terraform/observability/alerts_metrics.tf
@@ -1,0 +1,88 @@
+# PromQL alert rules over the Supabase VM telemetry (infra/supabase/MONITORING.md).
+# The collector emits *_usage_bytes, not the *_utilization metrics (disabled by default),
+# so disk and memory are expressed as used/total ratios.
+
+resource "stackit_observability_alertgroup" "host" {
+  project_id  = var.project_id
+  instance_id = var.instance_id
+  name        = "${var.env}-host"
+  interval    = "60s"
+
+  rules = [
+    # Push pipeline has no `up` metric, so absence of an always-present series is the signal.
+    {
+      alert = "HostOrCollectorDown"
+      expression = trimspace(<<-EOT
+        absent(system_memory_usage_bytes{source="${var.target_source}"})
+      EOT
+      )
+      for = "5m"
+      labels = {
+        severity = "critical"
+        source   = var.target_source
+      }
+      annotations = {
+        summary     = "No metrics from ${var.target_source} for 5m"
+        description = "The Supabase VM or its OTel collector stopped reporting. Check the host and the otel-collector container."
+      }
+    },
+
+    # mode="rw" excludes read-only mounts (snap squashfs loops), which sit at 100% forever.
+    {
+      alert = "DiskAlmostFull"
+      expression = trimspace(<<-EOT
+        sum by (host, mountpoint) (system_filesystem_usage_bytes{source="${var.target_source}", mode="rw", state="used"})
+          / sum by (host, mountpoint) (system_filesystem_usage_bytes{source="${var.target_source}", mode="rw", state=~"used|free"})
+          > ${var.disk_used_ratio_max}
+      EOT
+      )
+      for = "10m"
+      labels = {
+        severity = "critical"
+        source   = var.target_source
+      }
+      annotations = {
+        summary     = "Disk above ${var.disk_used_ratio_max} on ${var.target_source}"
+        description = "Filesystem {{ $labels.mountpoint }} on {{ $labels.host }} is over {{ $value | humanizePercentage }} full."
+      }
+    },
+
+    # These states sum to MemTotal; summing all of them double-counts slab (`cached`
+    # already includes SReclaimable) and makes the alert fire late.
+    {
+      alert = "MemoryHigh"
+      expression = trimspace(<<-EOT
+        sum by (host) (system_memory_usage_bytes{source="${var.target_source}", state="used"})
+          / sum by (host) (system_memory_usage_bytes{source="${var.target_source}", state=~"used|free|cached|buffered"})
+          > ${var.mem_used_ratio_max}
+      EOT
+      )
+      for = "10m"
+      labels = {
+        severity = "warning"
+        source   = var.target_source
+      }
+      annotations = {
+        summary     = "Memory above ${var.mem_used_ratio_max} on ${var.target_source}"
+        description = "Used memory on {{ $labels.host }} has been over {{ $value | humanizePercentage }} for 10m."
+      }
+    },
+
+    {
+      alert = "CPULoadHigh"
+      expression = trimspace(<<-EOT
+        system_cpu_load_average_15m{source="${var.target_source}"} > ${var.cpu_load_15m_max}
+      EOT
+      )
+      for = "15m"
+      labels = {
+        severity = "warning"
+        source   = var.target_source
+      }
+      annotations = {
+        summary     = "15m load average above ${var.cpu_load_15m_max} on ${var.target_source}"
+        description = "Load on {{ $labels.host }} has been {{ $value }} for 15m (threshold ${var.cpu_load_15m_max})."
+      }
+    },
+  ]
+}

--- a/infra/terraform/observability/alerts_metrics.tf
+++ b/infra/terraform/observability/alerts_metrics.tf
@@ -10,13 +10,15 @@ resource "stackit_observability_alertgroup" "host" {
 
   rules = [
     # Push pipeline has no `up` metric, so absence of an always-present series is the signal.
+    # absent_over_time's own [5m] window is the detection delay, so for = "0s" (a plain
+    # absent() only flips true after staleness, and for = "5m" would then double the delay).
     {
       alert = "HostOrCollectorDown"
       expression = trimspace(<<-EOT
-        absent(system_memory_usage_bytes{source="${var.target_source}"})
+        absent_over_time(system_memory_usage_bytes{source="${var.target_source}"}[5m])
       EOT
       )
-      for = "5m"
+      for = "0s"
       labels = {
         severity = "critical"
         source   = var.target_source
@@ -57,14 +59,14 @@ resource "stackit_observability_alertgroup" "host" {
           > ${var.mem_used_ratio_max}
       EOT
       )
-      for = "10m"
+      for = "5m"
       labels = {
         severity = "warning"
         source   = var.target_source
       }
       annotations = {
         summary     = "Memory above ${var.mem_used_ratio_max} on ${var.target_source}"
-        description = "Used memory on {{ $labels.host }} has been over {{ $value | humanizePercentage }} for 10m."
+        description = "Used memory on {{ $labels.host }} has been over {{ $value | humanizePercentage }} for 5m."
       }
     },
 

--- a/infra/terraform/observability/production.tfvars.example
+++ b/infra/terraform/observability/production.tfvars.example
@@ -1,0 +1,15 @@
+# Copy to production.tfvars and fill in. production.tfvars is gitignored.
+# project_id / instance_id are not secret, but we keep them out of git to match
+# the rest of infra/ (values resolved from 1Password / inventory).
+
+project_id    = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+instance_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+env           = "production"
+target_source = "supabase-production"
+
+# Thresholds (override defaults from variables.tf as needed)
+disk_used_ratio_max  = 0.90
+mem_used_ratio_max   = 0.90
+cpu_load_15m_max       = 4
+kong_5xx_ratio_max     = 0.20
+kong_5xx_min_errors_5m = 5

--- a/infra/terraform/observability/provider.tf
+++ b/infra/terraform/observability/provider.tf
@@ -1,0 +1,3 @@
+provider "stackit" {
+  default_region = "eu01"
+}

--- a/infra/terraform/observability/set-email-receiver.sh
+++ b/infra/terraform/observability/set-email-receiver.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# One-time: set the email receiver + route on the instance's Alertmanager config
+# (/alertconfigs). Terraform manages the rules; receivers live inside the
+# hand-managed instance — see the README for why.
+#
+# The PUT REPLACES the whole alert config. smarthost must be host:port; `from`
+# must be a Brevo-verified sender. Env comes from a 1Password note:
+#   set -a; source <(op read "op://<vault>/<note>/notesPlain"); set +a; ./set-email-receiver.sh
+# =============================================================================
+
+command -v jq >/dev/null || { echo "jq is required (brew install jq)" >&2; exit 1; }
+
+: "${STACKIT_ACCESS_TOKEN:=$(stackit auth get-access-token)}"
+: "${STACKIT_PROJECT_ID:?set STACKIT_PROJECT_ID}"
+: "${STACKIT_INSTANCE_ID:?set STACKIT_INSTANCE_ID}"
+: "${ALERT_EMAIL_TO:?set ALERT_EMAIL_TO (comma-separated recipients, no spaces)}"
+case "$ALERT_EMAIL_TO" in
+  *[$'\n\t']*)
+    echo "ALERT_EMAIL_TO contains a newline or tab — a wrapped 1Password note is the usual cause." >&2
+    exit 1
+    ;;
+esac
+: "${SMTP_SMARTHOST:?set SMTP_SMARTHOST (host:port, e.g. smtp-relay.brevo.com:587)}"
+: "${SMTP_FROM:?set SMTP_FROM (Brevo-verified sender)}"
+: "${SMTP_USER:?set SMTP_USER}"
+: "${SMTP_PASS:?set SMTP_PASS}"
+SMTP_AUTH_IDENTITY="${SMTP_AUTH_IDENTITY:-$SMTP_USER}"
+
+API="https://argus.api.eu01.stackit.cloud/v1/projects/${STACKIT_PROJECT_ID}/instances/${STACKIT_INSTANCE_ID}/alertconfigs"
+auth=(-H "Authorization: Bearer ${STACKIT_ACCESS_TOKEN}")
+
+echo ">>> Current alert config BEFORE (the PUT below REPLACES this):"
+curl -fsS "${auth[@]}" "$API"
+echo
+
+read -r -p ">>> Replace the config above with the email receiver? [y/N] " reply
+case "$reply" in [yY]*) ;; *) echo "Aborted."; exit 1 ;; esac
+
+# jq (not a heredoc) so quotes/backslashes in SMTP_PASS can't break the JSON.
+# One emailConfigs entry per recipient — the API validates `to` as a single address and
+# rejects a comma-separated list. groupBy must match the labels the rules set (alerts_*.tf).
+PAYLOAD=$(jq -n \
+  --arg to "$ALERT_EMAIL_TO" \
+  --arg from "$SMTP_FROM" \
+  --arg smarthost "$SMTP_SMARTHOST" \
+  --arg user "$SMTP_USER" \
+  --arg pass "$SMTP_PASS" \
+  --arg identity "$SMTP_AUTH_IDENTITY" \
+  '{
+    receivers: [
+      {
+        name: "email",
+        emailConfigs: (
+          $to
+          | split(",")
+          | map(gsub("^\\s+|\\s+$"; ""))
+          | map(select(length > 0))
+          | map({
+              to: .,
+              from: $from,
+              smarthost: $smarthost,
+              authUsername: $user,
+              authPassword: $pass,
+              authIdentity: $identity,
+              sendResolved: true
+            })
+        )
+      }
+    ],
+    route: {
+      receiver: "email",
+      groupBy: ["alertname", "source"],
+      groupWait: "30s",
+      groupInterval: "5m",
+      repeatInterval: "3h"
+    }
+  }')
+
+echo ">>> PUT ${API}"
+# -d @- keeps the SMTP password out of the process table (argv is world-readable).
+printf '%s' "$PAYLOAD" |
+  curl --fail-with-body -sS -X PUT "$API" "${auth[@]}" -H "Content-Type: application/json" -d @-
+echo
+
+echo ">>> Current alert config AFTER (confirm the email receiver landed):"
+curl -fsS "${auth[@]}" "$API"
+echo

--- a/infra/terraform/observability/staging.tfvars.example
+++ b/infra/terraform/observability/staging.tfvars.example
@@ -1,0 +1,15 @@
+# Copy to staging.tfvars and fill in. staging.tfvars is gitignored.
+# project_id / instance_id are not secret, but we keep them out of git to match
+# the rest of infra/ (values resolved from 1Password / inventory).
+
+project_id    = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+instance_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+env           = "staging"
+target_source = "supabase-staging"
+
+# Thresholds (override defaults from variables.tf as needed)
+disk_used_ratio_max  = 0.90
+mem_used_ratio_max   = 0.90
+cpu_load_15m_max       = 2
+kong_5xx_ratio_max     = 0.20
+kong_5xx_min_errors_5m = 5

--- a/infra/terraform/observability/variables.tf
+++ b/infra/terraform/observability/variables.tf
@@ -68,6 +68,11 @@ variable "cpu_load_15m_max" {
   type        = number
   default     = 4
   description = "Fire when the 15m load average exceeds this. Set to ~= number of vCPUs."
+
+  validation {
+    condition     = var.cpu_load_15m_max > 0
+    error_message = "cpu_load_15m_max must be positive."
+  }
 }
 
 variable "kong_5xx_ratio_max" {
@@ -85,4 +90,9 @@ variable "kong_5xx_min_errors_5m" {
   type        = number
   default     = 5
   description = "Floor: the ratio must also be backed by this many 5xx in the 5m window."
+
+  validation {
+    condition     = floor(var.kong_5xx_min_errors_5m) == var.kong_5xx_min_errors_5m && var.kong_5xx_min_errors_5m >= 1
+    error_message = "kong_5xx_min_errors_5m is a whole-number count >= 1."
+  }
 }

--- a/infra/terraform/observability/variables.tf
+++ b/infra/terraform/observability/variables.tf
@@ -1,0 +1,88 @@
+variable "project_id" {
+  type        = string
+  description = "STACKIT project ID that owns the Observability instance."
+}
+
+variable "instance_id" {
+  type        = string
+  description = "Observability (Argus) instance ID that receives the OTel telemetry."
+}
+
+variable "env" {
+  type        = string
+  description = "Environment: \"staging\" or \"production\". Names the alert groups and must equal the workspace name."
+
+  # A token that isn't in the telemetry selects nothing: rules apply cleanly and never fire.
+  validation {
+    condition     = contains(["staging", "production"], var.env)
+    error_message = "env must be \"staging\" or \"production\"."
+  }
+
+  # Here rather than a resource precondition: validation also runs under `-target` and
+  # `terraform destroy`, which skip preconditions.
+  validation {
+    condition     = var.env == terraform.workspace
+    error_message = "Workspace is \"${terraform.workspace}\" but env is \"${var.env}\". Run: terraform workspace select ${var.env}"
+  }
+}
+
+variable "target_source" {
+  type        = string
+  description = <<-EOT
+    Value of the collector's environment label to alert on — `source` on metrics,
+    `service_name` on logs (both set in infra/supabase/otel-config.yml). Always
+    "supabase-<env>"; confirm it returns series in Grafana -> Explore.
+  EOT
+
+  validation {
+    condition     = var.target_source == "supabase-${var.env}"
+    error_message = "target_source must be \"supabase-${var.env}\"."
+  }
+}
+
+# --- Thresholds (tune per environment via *.tfvars) ------------------------------
+
+variable "disk_used_ratio_max" {
+  type        = number
+  default     = 0.90
+  description = "Fire when a filesystem is more than this fraction full (0-1)."
+
+  validation {
+    condition     = var.disk_used_ratio_max > 0 && var.disk_used_ratio_max < 1
+    error_message = "disk_used_ratio_max is a fraction (0.90), not a percentage (90)."
+  }
+}
+
+variable "mem_used_ratio_max" {
+  type        = number
+  default     = 0.90
+  description = "Fire when used memory exceeds this fraction of total (0-1)."
+
+  validation {
+    condition     = var.mem_used_ratio_max > 0 && var.mem_used_ratio_max < 1
+    error_message = "mem_used_ratio_max is a fraction (0.90), not a percentage (90)."
+  }
+}
+
+variable "cpu_load_15m_max" {
+  type        = number
+  default     = 4
+  description = "Fire when the 15m load average exceeds this. Set to ~= number of vCPUs."
+}
+
+variable "kong_5xx_ratio_max" {
+  type        = number
+  default     = 0.20
+  description = "Fire when 5xx exceed this fraction of all Kong requests over 5m (0-1)."
+
+  validation {
+    condition     = var.kong_5xx_ratio_max > 0 && var.kong_5xx_ratio_max < 1
+    error_message = "kong_5xx_ratio_max is a fraction (0.20), not a percentage (20)."
+  }
+}
+
+variable "kong_5xx_min_errors_5m" {
+  type        = number
+  default     = 5
+  description = "Floor: the ratio must also be backed by this many 5xx in the 5m window."
+}

--- a/infra/terraform/observability/versions.tf
+++ b/infra/terraform/observability/versions.tf
@@ -1,6 +1,5 @@
 terraform {
-  # 1.11 floor: S3-native `use_lockfile` (STACKIT has no DynamoDB) is GA there, not in 1.10.
-  # The CLI version the team runs is pinned in .tool-versions.
+  # Exact CLI version is pinned in .tool-versions.
   required_version = "~> 1.11"
 
   required_providers {
@@ -21,7 +20,8 @@ terraform {
     skip_requesting_account_id  = true
     skip_region_validation      = true
     skip_metadata_api_check     = true
-    use_lockfile                = true # conditional-PUT locking, unverified on STACKIT
+    skip_s3_checksum            = true # STACKIT's S3 API rejects the AWS SDK checksum header
+    # No use_lockfile: STACKIT doesn't honor S3 conditional-write locks (stackitcloud/terraform-provider-stackit#1534).
     # Backend creds are AWS_ACCESS_KEY_ID/SECRET (op run), separate from the provider's SA key.
   }
 }

--- a/infra/terraform/observability/versions.tf
+++ b/infra/terraform/observability/versions.tf
@@ -1,0 +1,27 @@
+terraform {
+  # 1.11 floor: S3-native `use_lockfile` (STACKIT has no DynamoDB) is GA there, not in 1.10.
+  # The CLI version the team runs is pinned in .tool-versions.
+  required_version = "~> 1.11"
+
+  required_providers {
+    stackit = {
+      source  = "stackitcloud/stackit"
+      version = "~> 0.100.0"
+    }
+  }
+
+  # Remote state on STACKIT Object Storage (S3-compatible). See README "Remote state".
+  backend "s3" {
+    bucket                      = "baergpt-tfstate"
+    key                         = "observability/terraform.tfstate" # per-workspace: env:/<ws>/ is prefixed
+    region                      = "eu01"
+    endpoints                   = { s3 = "https://object.storage.eu01.onstackit.cloud" }
+    use_path_style              = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
+    use_lockfile                = true # conditional-PUT locking, unverified on STACKIT
+    # Backend creds are AWS_ACCESS_KEY_ID/SECRET (op run), separate from the provider's SA key.
+  }
+}


### PR DESCRIPTION
I've added some email alerts for metrics/logs in our Supabase VMs via Terraform and some general plumbing to be able to work with TF in this repo. The terraform.tfstate files now live in a bucket as per this Asana ticket: https://app.asana.com/1/1201970074282735/project/1208836734369129/task/1216208045259019?focus=true

More info here: https://app.notion.com/p/citylabberlin/Alerting-Research-38ea2fee956d80c59af5d9f3454fd2f0

We should now get alerts when: 
1. The VM or its OTel collector stops reporting (no metrics for 5 minutes)
2. Any writable filesystem goes above 90% full
3. Used memory stays above 90% for 10 minutes
4. The 15-minute load average stays above the vCPU count (4 on production, 2 on staging) i.e. work is queuing for CPU or disk
5. Kong returns 5xx for more than 20% of requests over 5 minutes, and at least 5 requests actually failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added observability alerting for host availability, disk usage, memory usage, CPU load, and Kong 5xx error rates.
  * Added staging/production configuration templates and example environment files.
  * Added a one-time utility to configure email alert notifications.

* **Documentation**
  * Added setup and operational guidance for alerting rules, verification steps, and common gotchas.
  * Documented alert “load-bearing” label requirements to reduce silent alert failures.

* **Chores**
  * Added automated Terraform checks (formatting and validation) and pinned Terraform/provider versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->