### PR TITLE
Add STACKIT Cloud Foundry Terraform module

### DIFF
--- a/infra/terraform/cloud-foundry/.gitignore
+++ b/infra/terraform/cloud-foundry/.gitignore
@@ -1,0 +1,14 @@
+# Local state (remote backend is authoritative)
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.tfstate.lock.info
+
+# Secrets / local values
+*.tfvars
+*.tfvars.json
+.op.env.cloud-foundry
+
+# Crash logs
+crash.log
+crash.*.log

--- a/infra/terraform/cloud-foundry/.op.env.cloud-foundry.example
+++ b/infra/terraform/cloud-foundry/.op.env.cloud-foundry.example
@@ -1,0 +1,13 @@
+# Copy to .op.env.cloud-foundry and point the refs at your real STACKIT items in 1Password.
+# Holds op:// REFERENCES only — no secret values. `op run` resolves them at runtime:
+#
+#   op run --env-file .op.env.cloud-foundry -- terraform plan
+#
+# The CF provider authenticates from the org-manager user Terraform creates (in state),
+# so no extra CF credentials belong here.
+STACKIT_SERVICE_ACCOUNT_KEY=op://<vault>/<stackit-prod-service-account-item>/<field>
+
+# REQUIRED: S3 backend (versions.tf) authenticates SEPARATELY with an objectstorage credential.
+# Without these even `terraform init` fails — there is no metadata-service fallback.
+AWS_ACCESS_KEY_ID=op://<vault>/<tfstate-objectstorage-credential>/access_key
+AWS_SECRET_ACCESS_KEY=op://<vault>/<tfstate-objectstorage-credential>/secret_access_key

--- a/infra/terraform/cloud-foundry/.terraform.lock.hcl
+++ b/infra/terraform/cloud-foundry/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudfoundry/cloudfoundry" {
+  version     = "1.16.0"
+  constraints = "~> 1.16"
+  hashes = [
+    "h1:ekKSqFx7oO8kgugzhOqCR3BtUn+wLNl7B6vt5ZsOlmw=",
+    "zh:03dad6df1a8e51e968ec8a02e3d12a9af0614beb73b8ed334bd3d73365dc53bf",
+    "zh:17a7eaaf3b274dd4eb858e8b7b3e86433937aa691834c0a6fdf36b2c2e92dac6",
+    "zh:1a98052106e7050aabda964c8b3d3e90271ca13646989a3dbdfa1da9cf605495",
+    "zh:208c7cffb3a8ef5cb36120fc1b3f8aa24c3becb4e533667a817dd48a231c62bf",
+    "zh:3090390b00e3af957f42407d54f1bb02cf11339686f70b0910b123bf4dd5d617",
+    "zh:40567a4130acd3469a9499afd36a6c95d71b3ba8316f6257d0fb2e1bb99d87d3",
+    "zh:6b585c2e53c1af99ca218667c3e0b2a68eb698fba59641e4c4ac1243e63e85b4",
+    "zh:78297ea472f3c560f397df6720435f7295f34d192b2b0711f26ba0624f033206",
+    "zh:7e023da8e9a6268df299d0fc2134b715192d7c35b14f0217a0396494135ec227",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:a1f26478c2df65f79df124669f57215dddaa3d7f679c14d260ca82d308b046c5",
+    "zh:a8ae988e5e05add6418f240afde3c33551b440358d43a8fc8dcecc628f2beefc",
+    "zh:d22741c3e2f82d04273a0f5ba130996d01153f0dfa5ebf4baad3c45cd1baf2b4",
+    "zh:d89c0c8e4ea5e961b6f7ac4c4378d32a6c627b32e8826b0ca92e2674f66e6a82",
+  ]
+}
+
+provider "registry.terraform.io/stackitcloud/stackit" {
+  version     = "0.100.0"
+  constraints = "~> 0.100.0"
+  hashes = [
+    "h1:muP1xPUnx3fpyoOXSJ+PN1GnsEpsvycXxgjn4+BcnVo=",
+    "zh:0dde99e7b343fa01f8eefc378171fb8621bedb20f59157d6cc8e3d46c738105f",
+    "zh:4c826cf81f3215ac3febdaa877cf397897ddae42ed97a0358266fa55751e5feb",
+    "zh:64161b8214b1e2a7f91812ead3df31327a57487a1fe45c697322eebb3272256d",
+    "zh:861df34f5b81a8de900d957cbe76cf072f1a7835becfb61c0c2974b06e655476",
+    "zh:873901bc0a79cbb9d03881bd738d70b74354c89a410a099b72fb4954c0617825",
+    "zh:908c611538f596c54a3b3056f748e53cfa65dced782037c440e270e244786aeb",
+    "zh:aafffdb31707fdf5e679c4fc62622d45794bd5c7cc56aaf29d2e9aa88f2f3503",
+    "zh:da6eadbf309284d214c7c49397639c47fb8a2fe4e38d8ba6ecd46f4cdc72bd48",
+    "zh:dbcda6b1ac60990498e903af94e3253a68a66c7cfdf6802143532c38fcb2b097",
+    "zh:eb4007c23b5e340890cb0e967ac65c99add25612562a464a6013fbcdd224a4bf",
+    "zh:eb620993278bbddab95eb575eebe12c8827085001acf38e13d4e3afcd938a826",
+    "zh:ed8dacf190d95648438b05db258ee513725c26fe854c804e027ee9c7bd110186",
+    "zh:f9c4a80d8e851a4114911721cc1385812c9e61cb5da161ef006325bd1958969b",
+    "zh:ffe7dbf40cdb5f70d2cd0a16219248e9c97c48accabdad4e4cf8ff34408157aa",
+  ]
+}

--- a/infra/terraform/cloud-foundry/README.md
+++ b/infra/terraform/cloud-foundry/README.md
@@ -1,0 +1,71 @@
+# STACKIT Cloud Foundry environments (Terraform)
+
+Provisions one CF org (`baergpt`) with `staging` and `prod` spaces in the
+`baergpt-berlin-prod` STACKIT project.
+
+## Layout
+
+| File           | Manages                                                              |
+| -------------- | -------------------------------------------------------------------- |
+| `versions.tf`  | Terraform + provider pins; S3 remote-state backend                   |
+| `provider.tf`  | `stackit` + `cloudfoundry` providers (CF wired from the org-manager) |
+| `variables.tf` | project id, org name, region, operators, per-space quota + ssh       |
+| `org.tf`       | CF org + technical org-manager + platform data source                |
+| `spaces.tf`    | spaces, space quotas, org/space roles                                |
+| `outputs.tf`   | api_url                                                              |
+
+## Auth
+
+Auth is injected from 1Password via `op run`, like the observability module. The
+`.op.env.cloud-foundry` file holds `op://` references only.
+
+```sh
+cp terraform.tfvars.example terraform.tfvars              # fill in project_id + operators
+cp .op.env.cloud-foundry.example .op.env.cloud-foundry   # point op:// refs at your 1Password items
+
+OP="op run --env-file .op.env.cloud-foundry --"
+```
+
+> **State is sensitive.** Application secrets (Supabase/Mistral keys) are set via
+> `cf set-env` and never touch Terraform, but the auto-generated org-manager password
+> _is_ persisted in state because the CF provider authenticates from it. Treat the
+> remote state (STACKIT Object Storage) as a secret store.
+
+## Apply
+
+The CF provider is configured from the org-manager's password, which is unknown until
+that resource exists. So the **first** apply bootstraps the org-manager, then applies
+the rest:
+
+```sh
+$OP terraform init
+$OP terraform apply -target=stackit_scf_organization_manager.manager
+$OP terraform apply
+```
+
+Every later change is a plain `$OP terraform apply` — no `-target`.
+
+> **No state locking.** STACKIT doesn't honor S3 conditional-write locks
+> ([stackitcloud/terraform-provider-stackit#1534]), so `use_lockfile` is off. Don't run
+> concurrent applies against this state.
+
+[stackitcloud/terraform-provider-stackit#1534]: https://github.com/stackitcloud/terraform-provider-stackit/issues/1534
+
+## SSH access
+
+### Cloud Foundry app containers — `cf ssh`
+
+Gated per space by `allow_ssh` (**on** for `staging`, **off** for `prod`). The caller
+also needs the `space_developer` role, which this module grants (together with
+`organization_user` membership) to the accounts in `var.operators`. Any additional human
+or CI identity is granted out-of-band.
+
+```sh
+cf api <api_url>            # from `terraform output api_url`
+cf login --sso
+cf target -o baergpt -s staging
+cf ssh <app-name>          # opens a shell in instance 0
+```
+
+`prod` has SSH disabled. To debug a prod incident, set that space's `allow_ssh = true`
+in `variables.tf`, `terraform apply`, then revert when done.

--- a/infra/terraform/cloud-foundry/org.tf
+++ b/infra/terraform/cloud-foundry/org.tf
@@ -1,0 +1,19 @@
+resource "stackit_scf_organization" "org" {
+  project_id = var.project_id
+  name       = var.org_name
+  region     = var.region
+}
+
+# Machine user the CF provider authenticates as.
+# Auto-deleted when the org is removed.
+resource "stackit_scf_organization_manager" "manager" {
+  project_id = var.project_id
+  org_id     = stackit_scf_organization.org.org_id
+  region     = var.region
+}
+
+data "stackit_scf_platform" "platform" {
+  project_id  = var.project_id
+  platform_id = stackit_scf_organization.org.platform_id
+  region      = var.region
+}

--- a/infra/terraform/cloud-foundry/outputs.tf
+++ b/infra/terraform/cloud-foundry/outputs.tf
@@ -1,0 +1,4 @@
+output "api_url" {
+  value       = data.stackit_scf_platform.platform.api_url
+  description = "Cloud Foundry API URL (use with `cf api`)."
+}

--- a/infra/terraform/cloud-foundry/provider.tf
+++ b/infra/terraform/cloud-foundry/provider.tf
@@ -1,0 +1,11 @@
+provider "stackit" {
+  default_region = var.region
+}
+
+# Configured from the technical org-manager user created in org.tf. On the FIRST apply these
+# values are unknown, so the org-manager must be applied first with -target (see README).
+provider "cloudfoundry" {
+  api_url  = data.stackit_scf_platform.platform.api_url
+  user     = stackit_scf_organization_manager.manager.username
+  password = stackit_scf_organization_manager.manager.password
+}

--- a/infra/terraform/cloud-foundry/spaces.tf
+++ b/infra/terraform/cloud-foundry/spaces.tf
@@ -1,0 +1,40 @@
+resource "cloudfoundry_space" "this" {
+  for_each  = var.spaces
+  name      = each.key
+  org       = stackit_scf_organization.org.org_id
+  allow_ssh = each.value.allow_ssh
+}
+
+resource "cloudfoundry_space_quota" "this" {
+  for_each                 = var.spaces
+  name                     = "${each.key}-quota"
+  org                      = stackit_scf_organization.org.org_id
+  allow_paid_service_plans = false
+  total_memory             = each.value.total_memory
+  total_app_instances      = each.value.total_app_instances
+  total_routes             = each.value.total_routes
+  spaces                   = [cloudfoundry_space.this[each.key].id]
+}
+
+# Access is granted in two steps. Step 1: make each operator account a member of the CF
+# org. CF refuses to grant any per-space role to someone who isn't an org member first.
+resource "cloudfoundry_org_role" "member" {
+  for_each = toset(var.operators)
+  username = each.value
+  type     = "organization_user"
+  org      = stackit_scf_organization.org.org_id
+}
+
+# Step 2: give each operator the "developer" role in BOTH spaces — the role that lets them
+# deploy and manage apps in each. (cf ssh also needs allow_ssh, so it works on staging only.)
+resource "cloudfoundry_space_role" "developer" {
+  for_each = merge([
+    for operator in var.operators : {
+      for space_name in keys(var.spaces) :
+      "${operator}:${space_name}" => { username = operator, space = space_name }
+    }
+  ]...)
+  user  = cloudfoundry_org_role.member[each.value.username].user
+  type  = "space_developer"
+  space = cloudfoundry_space.this[each.value.space].id
+}

--- a/infra/terraform/cloud-foundry/terraform.tfvars.example
+++ b/infra/terraform/cloud-foundry/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored.
+project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" # baergpt-berlin-prod
+org_name   = "baergpt"
+region     = "eu01"
+
+# Accounts granted organization_user + space_developer on both spaces (must exist in UAA):
+operators = ["you@example.org"]
+
+# Override per-space caps to fit the org quota if needed:
+# spaces = {
+#   staging = { allow_ssh = true,  total_memory = 4096, total_app_instances = 10, total_routes = 10 }
+#   prod    = { allow_ssh = false, total_memory = 8192, total_app_instances = 20, total_routes = 20 }
+# }

--- a/infra/terraform/cloud-foundry/variables.tf
+++ b/infra/terraform/cloud-foundry/variables.tf
@@ -1,0 +1,41 @@
+variable "project_id" {
+  type        = string
+  description = "STACKIT project ID that owns the Cloud Foundry org (baergpt-berlin-prod)."
+}
+
+variable "region" {
+  type        = string
+  default     = "eu01"
+  description = "STACKIT region hosting the Cloud Foundry platform."
+}
+
+variable "org_name" {
+  type        = string
+  default     = "baergpt"
+  description = "Name of the Cloud Foundry organization. Must be unique across the platform."
+}
+
+variable "operators" {
+  type        = list(string)
+  default     = []
+  description = "CF usernames granted organization_user + space_developer on both spaces (the operating/CI account). Each must already exist in UAA (logged in once)."
+}
+
+# Per-space settings. Keys must be exactly "staging" and "prod".
+variable "spaces" {
+  type = map(object({
+    allow_ssh           = bool
+    total_memory        = number # MB, whole-space cap
+    total_app_instances = number
+    total_routes        = number
+  }))
+  default = {
+    staging = { allow_ssh = true, total_memory = 4096, total_app_instances = 10, total_routes = 10 }
+    prod    = { allow_ssh = false, total_memory = 8192, total_app_instances = 20, total_routes = 20 }
+  }
+
+  validation {
+    condition     = toset(keys(var.spaces)) == toset(["staging", "prod"])
+    error_message = "spaces must contain exactly the keys \"staging\" and \"prod\"."
+  }
+}

--- a/infra/terraform/cloud-foundry/versions.tf
+++ b/infra/terraform/cloud-foundry/versions.tf
@@ -1,0 +1,31 @@
+terraform {
+  # Exact CLI version is pinned in .tool-versions.
+  required_version = "~> 1.11"
+
+  required_providers {
+    stackit = {
+      source  = "stackitcloud/stackit"
+      version = "~> 0.100.0" # scf_* resources are GA since late 2025; 0.100 already includes them
+    }
+    cloudfoundry = {
+      source  = "cloudfoundry/cloudfoundry"
+      version = "~> 1.16"
+    }
+  }
+
+  # Remote state on STACKIT Object Storage (S3-compatible), same bucket as observability.
+  backend "s3" {
+    bucket                      = "baergpt-tfstate"
+    key                         = "cloud-foundry/terraform.tfstate"
+    region                      = "eu01"
+    endpoints                   = { s3 = "https://object.storage.eu01.onstackit.cloud" }
+    use_path_style              = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
+    skip_s3_checksum            = true # STACKIT's S3 API rejects the AWS SDK checksum header
+    # No use_lockfile: STACKIT doesn't honor S3 conditional-write locks (stackitcloud/terraform-provider-stackit#1534).
+    # Backend creds are AWS_ACCESS_KEY_ID/SECRET (op run), separate from the provider SA key.
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Terraform setup to provision a Cloud Foundry organization plus staging and production spaces, including quotas and operator access roles.
  - Added per-space configuration for resource limits and SSH enablement.
  - Exposed the Cloud Foundry API URL for CLI use.
- **Documentation**
  - Added a README with setup and operational steps, including 1Password-based authentication, apply workflow, and state sensitivity guidance.
  - Added example configuration templates for credentials and Terraform variables.
- **Chores**
  - Added provider lock file and updated ignore rules for local Terraform artifacts and secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215648063343451