### PR TITLE
chore: drop jina embeddings

### DIFF
--- a/apps/backend/supabase/migrations/20260727091136_delete_old_embeddings.sql
+++ b/apps/backend/supabase/migrations/20260727091136_delete_old_embeddings.sql
@@ -1,0 +1,2 @@
+ALTER TABLE document_chunks
+DROP COLUMN IF EXISTS chunk_jina_embedding;

--- a/libs/db-schema/index.ts
+++ b/libs/db-schema/index.ts
@@ -239,7 +239,6 @@ export type Database = {
 				Row: {
 					access_group_id: string | null;
 					chunk_index: number;
-					chunk_jina_embedding: string | null;
 					chunk_mistral_embedding: string | null;
 					content: string;
 					document_id: number | null;
@@ -252,7 +251,6 @@ export type Database = {
 				Insert: {
 					access_group_id?: string | null;
 					chunk_index: number;
-					chunk_jina_embedding?: string | null;
 					chunk_mistral_embedding?: string | null;
 					content: string;
 					document_id?: number | null;
@@ -265,7 +263,6 @@ export type Database = {
 				Update: {
 					access_group_id?: string | null;
 					chunk_index?: number;
-					chunk_jina_embedding?: string | null;
 					chunk_mistral_embedding?: string | null;
 					content?: string;
 					document_id?: number | null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an obsolete document embedding field from the database schema.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213579998468061