### PR TITLE
feat: add cf quota and increase ram

### DIFF
--- a/infra/terraform/cloud-foundry/README.md
+++ b/infra/terraform/cloud-foundry/README.md
@@ -14,6 +14,20 @@ Provisions one CF org (`baergpt`) with `staging` and `prod` spaces in the
 | `spaces.tf`    | spaces, space quotas, org/space roles                                |
 | `outputs.tf`   | api_url                                                              |
 
+## Quotas
+
+`var.quota_id` is the org-wide plan ("Kontingent"); `var.spaces` subdivides it. The org
+quota always binds, so raising a space beyond it silently does nothing.
+
+The portal shows plan names but not their ids, and the `stackit` CLI has no SCF commands.
+`quota_id` is the CF org-quota GUID:
+
+```sh
+cf curl /v3/organization_quotas | jq '.resources[] | {name, guid, memory_mb: .apps.total_memory_in_mb}'
+```
+
+Switch plans in the portal, then update `quota_id` to match.
+
 ## Auth
 
 Auth is injected from 1Password via `op run`, like the observability module. The

--- a/infra/terraform/cloud-foundry/org.tf
+++ b/infra/terraform/cloud-foundry/org.tf
@@ -2,6 +2,7 @@ resource "stackit_scf_organization" "org" {
   project_id = var.project_id
   name       = var.org_name
   region     = var.region
+  quota_id   = var.quota_id
 }
 
 # Machine user the CF provider authenticates as.

--- a/infra/terraform/cloud-foundry/terraform.tfvars.example
+++ b/infra/terraform/cloud-foundry/terraform.tfvars.example
@@ -2,12 +2,13 @@
 project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" # baergpt-berlin-prod
 org_name   = "baergpt"
 region     = "eu01"
+quota_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 # Accounts granted organization_user + space_developer on both spaces (must exist in UAA):
 operators = ["you@example.org"]
 
 # Override per-space caps to fit the org quota if needed:
 # spaces = {
-#   staging = { allow_ssh = true,  total_memory = 4096, total_app_instances = 10, total_routes = 10 }
-#   prod    = { allow_ssh = false, total_memory = 8192, total_app_instances = 20, total_routes = 20 }
+#   staging = { allow_ssh = true,  total_memory = 4096,  total_app_instances = 10, total_routes = 10 }
+#   prod    = { allow_ssh = false, total_memory = 18432, total_app_instances = 20, total_routes = 20 }
 # }

--- a/infra/terraform/cloud-foundry/variables.tf
+++ b/infra/terraform/cloud-foundry/variables.tf
@@ -15,6 +15,11 @@ variable "org_name" {
   description = "Name of the Cloud Foundry organization. Must be unique across the platform."
 }
 
+variable "quota_id" {
+  type        = string
+  description = "CF org-quota GUID (\"Kontingent\")."
+}
+
 variable "operators" {
   type        = list(string)
   default     = []
@@ -31,7 +36,7 @@ variable "spaces" {
   }))
   default = {
     staging = { allow_ssh = true, total_memory = 4096, total_app_instances = 10, total_routes = 10 }
-    prod    = { allow_ssh = false, total_memory = 8192, total_app_instances = 20, total_routes = 20 }
+    prod    = { allow_ssh = false, total_memory = 18432, total_app_instances = 20, total_routes = 20 }
   }
 
   validation {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a Cloud Foundry organization quota.
  - Increased the default production space memory allocation from 8,192 MB to 18,432 MB.
  - Added quota configuration guidance, including how to retrieve the required quota identifier.

- **Documentation**
  - Documented quota binding behavior and plan-switching considerations.
  - Updated configuration examples to include the organization quota setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->