### PR TITLE
fix: handle registration attempts with an already-registered email

### DIFF
--- a/apps/admin-panel/src/components/unconfirmed-email/unconfirmed-email.tsx
+++ b/apps/admin-panel/src/components/unconfirmed-email/unconfirmed-email.tsx
@@ -23,18 +23,13 @@ export function UnconfirmedEmail() {
 	return (
 		<div className="flex w-full min-h-[95svh] justify-center items-center bg-hellblau-100 px-6">
 			<div className="bg-white w-full rounded-3px max-w-4xl border border-black flex flex-col p-6 md:py-10 md:px-12">
-				<h1 className="text-xl md:text-4xl font-bold">
-					{Content["unconfirmedEmail.h1"]}
+				<h1 className="text-xl md:text-4xl mt-1 leading-8">
+					{Content["unconfirmedEmail.h2"]}
 				</h1>
 
-				<h2 className="text-xl md:text-4xl mt-1 leading-8">
-					{Content["unconfirmedEmail.h2"]}
-				</h2>
-
-				<ul className="list-disc leading-6 md:text-xl md:leading-7 max-w-[170rem] ml-5 mt-4 md:mt-8">
-					<li>{Content["unconfirmedEmail.list.li.1"]}</li>
-					<li>{Content["unconfirmedEmail.list.li.2"]}</li>
-				</ul>
+				<p className="leading-6 md:text-xl md:leading-7 max-w-[170rem] mt-4 md:mt-8">
+					{Content["unconfirmedEmail.text"]}
+				</p>
 				<div className="mt-10 md:mt-16 w-full">
 					<span className="text-lg leading-7 font-semibold">
 						{Content["unconfirmedEmail.p"]}

--- a/apps/admin-panel/src/components/unconfirmed-email/unconfirmed-email.tsx
+++ b/apps/admin-panel/src/components/unconfirmed-email/unconfirmed-email.tsx
@@ -3,7 +3,7 @@ import { useAuthStore } from "../../store/use-auth-store.ts";
 import Content from "../../content.ts";
 
 export function UnconfirmedEmail() {
-	const { resendConfirmationEmail } = useAuthStore();
+	const { resendConfirmationEmail, unconfirmedEmail } = useAuthStore();
 	const [emailSent, setEmailSent] = useState(false);
 
 	const handleResendEmail = async () => {
@@ -28,7 +28,10 @@ export function UnconfirmedEmail() {
 				</h1>
 
 				<p className="leading-6 md:text-xl md:leading-7 max-w-[170rem] mt-4 md:mt-8">
-					{Content["unconfirmedEmail.text"]}
+					{Content["unconfirmedEmail.text.beforeEmail"]}{" "}
+					<strong>{unconfirmedEmail}</strong>
+					<br />
+					{Content["unconfirmedEmail.text.afterEmail"]}
 				</p>
 				<div className="mt-10 md:mt-16 w-full">
 					<span className="text-lg leading-7 font-semibold">

--- a/apps/admin-panel/src/content.ts
+++ b/apps/admin-panel/src/content.ts
@@ -25,7 +25,9 @@ export const Content = {
 
 	/* ---------------------- Unconfirmed Email ---------------------- */
 	"unconfirmedEmail.h2": "Sie erhalten in Kürze eine E-Mail",
-	"unconfirmedEmail.text": "Prüfen Sie den Posteingang Ihres E-Mail-Postfaches",
+	"unconfirmedEmail.text.beforeEmail":
+		"Prüfen Sie den Posteingang folgender Adresse:",
+	"unconfirmedEmail.text.afterEmail": "Klicken Sie auf den Link in der E-Mail.",
 	"unconfirmedEmail.p": "Keine E-Mail bekommen?",
 	"unconfirmedEmail.list1.li1": "Bitte prüfen Sie auch Ihren Spam-Ordner",
 	"unconfirmedEmail.list1.li2":

--- a/apps/admin-panel/src/content.ts
+++ b/apps/admin-panel/src/content.ts
@@ -24,12 +24,8 @@ export const Content = {
 	"loginPage.submitButton": "Anmelden",
 
 	/* ---------------------- Unconfirmed Email ---------------------- */
-	"unconfirmedEmail.h1": "Registrierung fast abgeschlossen",
 	"unconfirmedEmail.h2": "Sie erhalten in Kürze eine E-Mail",
-	"unconfirmedEmail.list.li.1":
-		"Prüfen Sie den Posteingang Ihres E-Mail-Postfaches",
-	"unconfirmedEmail.list.li.2":
-		"Klicken Sie auf den Link in der E-Mail, um die Registrierung abzuschließen",
+	"unconfirmedEmail.text": "Prüfen Sie den Posteingang Ihres E-Mail-Postfaches",
 	"unconfirmedEmail.p": "Keine E-Mail bekommen?",
 	"unconfirmedEmail.list1.li1": "Bitte prüfen Sie auch Ihren Spam-Ordner",
 	"unconfirmedEmail.list1.li2":

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -8,6 +8,7 @@ import documents from "./routes/documents";
 import llms from "./routes/llms";
 import { config, verifyConfig } from "./config";
 import admin from "./routes/admin";
+import auth from "./routes/auth";
 import favicon from "./routes/favicon";
 import { captureError } from "./monitoring/capture-error";
 import { logMemory } from "./monitoring/memory-logger";
@@ -34,6 +35,8 @@ app.use(
 
 // Unauthenticated liveness probe for Docker/CF health checks
 app.get("/health", (c) => c.json({ status: "ok" }));
+
+app.route("/auth", auth);
 
 app.use("*", basicAuth);
 app.use("*", sentryTracing);

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -36,10 +36,11 @@ app.use(
 // Unauthenticated liveness probe for Docker/CF health checks
 app.get("/health", (c) => c.json({ status: "ok" }));
 
+app.use("*", sentryTracing);
+
 app.route("/auth", auth);
 
 app.use("*", basicAuth);
-app.use("*", sentryTracing);
 
 // Route modules
 app.route("/documents", documents);

--- a/apps/backend/src/integration/routes/auth.integration.test.ts
+++ b/apps/backend/src/integration/routes/auth.integration.test.ts
@@ -9,47 +9,56 @@ describe("/auth/register", () => {
 		"auth-register-test-suite-unconfirmed@ts.berlin";
 	const givenPassword = "SecurePassword123!";
 
-	const userIds: Record<string, string> = {};
+	// Fixed IDs for users we create via admin.createUser below;
+	// givenNewEmail's user is created indirectly through the real signUp()
+	// call inside the endpoint, which never returns its ID (deliberately,
+	// per the uniform-response design), so that one still needs a lookup.
+	const givenConfirmedUserId = "a1a1a1a1-0000-4000-8000-000000000001";
+	const givenUnconfirmedUserId = "a1a1a1a1-0000-4000-8000-000000000002";
 
-	async function deleteTestUsersIfAny(): Promise<void> {
-		const { data, error } = await serviceRoleDbClient.auth.admin.listUsers();
-		expect(error).toBeNull();
-
-		for (const user of data.users) {
-			if (
-				![givenNewEmail, givenConfirmedEmail, givenUnconfirmedEmail].includes(
-					user.email,
-				)
-			) {
-				continue;
-			}
-			await serviceRoleDbClient.auth.admin.deleteUser(user.id);
-		}
-	}
+	const userIds: Record<string, string> = {
+		[givenConfirmedEmail]: givenConfirmedUserId,
+		[givenUnconfirmedEmail]: givenUnconfirmedUserId,
+	};
 
 	beforeAll(async () => {
-		await deleteTestUsersIfAny();
-
-		const { data: confirmedData, error: confirmedError } =
+		const { error: confirmedError } =
 			await serviceRoleDbClient.auth.admin.createUser({
+				id: givenConfirmedUserId,
 				email: givenConfirmedEmail,
 				password: givenPassword,
 				email_confirm: true,
 			});
 		expect(confirmedError).toBeNull();
-		userIds[givenConfirmedEmail] = confirmedData.user.id;
 
-		const { data: unconfirmedData, error: unconfirmedError } =
+		const { error: unconfirmedError } =
 			await serviceRoleDbClient.auth.admin.createUser({
+				id: givenUnconfirmedUserId,
 				email: givenUnconfirmedEmail,
 				password: givenPassword,
 				email_confirm: false,
 			});
 		expect(unconfirmedError).toBeNull();
-		userIds[givenUnconfirmedEmail] = unconfirmedData.user.id;
 	});
 
-	afterAll(deleteTestUsersIfAny);
+	afterAll(async () => {
+		for (const id of [givenConfirmedUserId, givenUnconfirmedUserId]) {
+			const { error } = await serviceRoleDbClient.auth.admin.deleteUser(id);
+			if (error && error.status !== 404) {
+				throw error;
+			}
+		}
+
+		const { data, error } = await serviceRoleDbClient.auth.admin.listUsers();
+		expect(error).toBeNull();
+
+		const leftoverNewUser = data.users.find(
+			(user) => user.email === givenNewEmail,
+		);
+		if (leftoverNewUser) {
+			await serviceRoleDbClient.auth.admin.deleteUser(leftoverNewUser.id);
+		}
+	});
 
 	it("creates a new user for an email that doesn't exist yet", async () => {
 		const response = await app.request("/auth/register", {

--- a/apps/backend/src/integration/routes/auth.integration.test.ts
+++ b/apps/backend/src/integration/routes/auth.integration.test.ts
@@ -56,7 +56,11 @@ describe("/auth/register", () => {
 			(user) => user.email === givenNewEmail,
 		);
 		if (leftoverNewUser) {
-			await serviceRoleDbClient.auth.admin.deleteUser(leftoverNewUser.id);
+			const { error: deleteError } =
+				await serviceRoleDbClient.auth.admin.deleteUser(leftoverNewUser.id);
+			if (deleteError) {
+				throw deleteError;
+			}
 		}
 	});
 

--- a/apps/backend/src/integration/routes/auth.integration.test.ts
+++ b/apps/backend/src/integration/routes/auth.integration.test.ts
@@ -1,0 +1,214 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import app from "../../index";
+import { serviceRoleDbClient } from "../../supabase";
+
+describe("/auth/register", () => {
+	const givenNewEmail = "auth-register-test-suite-new@ts.berlin";
+	const givenConfirmedEmail = "auth-register-test-suite-confirmed@ts.berlin";
+	const givenUnconfirmedEmail =
+		"auth-register-test-suite-unconfirmed@ts.berlin";
+	const givenPassword = "SecurePassword123!";
+
+	const userIds: Record<string, string> = {};
+
+	async function deleteTestUsersIfAny(): Promise<void> {
+		const { data, error } = await serviceRoleDbClient.auth.admin.listUsers();
+		expect(error).toBeNull();
+
+		for (const user of data.users) {
+			if (
+				![givenNewEmail, givenConfirmedEmail, givenUnconfirmedEmail].includes(
+					user.email,
+				)
+			) {
+				continue;
+			}
+			await serviceRoleDbClient.auth.admin.deleteUser(user.id);
+		}
+	}
+
+	beforeAll(async () => {
+		await deleteTestUsersIfAny();
+
+		const { data: confirmedData, error: confirmedError } =
+			await serviceRoleDbClient.auth.admin.createUser({
+				email: givenConfirmedEmail,
+				password: givenPassword,
+				email_confirm: true,
+			});
+		expect(confirmedError).toBeNull();
+		userIds[givenConfirmedEmail] = confirmedData.user.id;
+
+		const { data: unconfirmedData, error: unconfirmedError } =
+			await serviceRoleDbClient.auth.admin.createUser({
+				email: givenUnconfirmedEmail,
+				password: givenPassword,
+				email_confirm: false,
+			});
+		expect(unconfirmedError).toBeNull();
+		userIds[givenUnconfirmedEmail] = unconfirmedData.user.id;
+	});
+
+	afterAll(deleteTestUsersIfAny);
+
+	it("creates a new user for an email that doesn't exist yet", async () => {
+		const response = await app.request("/auth/register", {
+			method: "POST",
+			headers: new Headers({ "Content-Type": "application/json" }),
+			body: JSON.stringify({
+				email: givenNewEmail,
+				password: givenPassword,
+				firstName: "New",
+				lastName: "User",
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ message: "ok" });
+
+		const { data, error } = await serviceRoleDbClient.auth.admin.listUsers();
+		expect(error).toBeNull();
+
+		const createdUser = data.users.find((user) => user.email === givenNewEmail);
+		expect(createdUser).toBeDefined();
+		expect(createdUser?.email_confirmed_at).toBeUndefined();
+		expect(createdUser?.user_metadata?.first_name).toBe("New");
+		expect(createdUser?.user_metadata?.last_name).toBe("User");
+	});
+
+	it("sends a password reset for an existing, confirmed email", async () => {
+		const response = await app.request("/auth/register", {
+			method: "POST",
+			headers: new Headers({ "Content-Type": "application/json" }),
+			body: JSON.stringify({
+				email: givenConfirmedEmail,
+				password: givenPassword,
+				firstName: "Whatever",
+				lastName: "Whatever",
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ message: "ok" });
+
+		const { data, error } = await serviceRoleDbClient.auth.admin.getUserById(
+			userIds[givenConfirmedEmail],
+		);
+		expect(error).toBeNull();
+		expect(data.user.recovery_sent_at).toBeTruthy();
+
+		const { data: listData, error: listError } =
+			await serviceRoleDbClient.auth.admin.listUsers();
+		expect(listError).toBeNull();
+		expect(
+			listData.users.filter((user) => user.email === givenConfirmedEmail),
+		).toHaveLength(1);
+	});
+
+	it("resends the signup confirmation for an existing, unconfirmed email", async () => {
+		const response = await app.request("/auth/register", {
+			method: "POST",
+			headers: new Headers({ "Content-Type": "application/json" }),
+			body: JSON.stringify({
+				email: givenUnconfirmedEmail,
+				password: givenPassword,
+				firstName: "Whatever",
+				lastName: "Whatever",
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ message: "ok" });
+
+		const { data, error } = await serviceRoleDbClient.auth.admin.getUserById(
+			userIds[givenUnconfirmedEmail],
+		);
+		expect(error).toBeNull();
+		expect(data.user.confirmation_sent_at).toBeTruthy();
+
+		const { data: listData, error: listError } =
+			await serviceRoleDbClient.auth.admin.listUsers();
+		expect(listError).toBeNull();
+		expect(
+			listData.users.filter((user) => user.email === givenUnconfirmedEmail),
+		).toHaveLength(1);
+	});
+
+	it("returns 400 when email is missing", async () => {
+		const response = await app.request("/auth/register", {
+			method: "POST",
+			headers: new Headers({ "Content-Type": "application/json" }),
+			body: JSON.stringify({
+				password: givenPassword,
+				firstName: "New",
+				lastName: "User",
+			}),
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("does not return 400 when only email is provided", async () => {
+		const response = await app.request("/auth/register", {
+			method: "POST",
+			headers: new Headers({ "Content-Type": "application/json" }),
+			body: JSON.stringify({
+				email: givenConfirmedEmail,
+			}),
+		});
+
+		expect(response.status).toBe(200);
+	});
+
+	it("sends a password reset for an existing, confirmed email when only email is provided", async () => {
+		const response = await app.request("/auth/register", {
+			method: "POST",
+			headers: new Headers({ "Content-Type": "application/json" }),
+			body: JSON.stringify({
+				email: givenConfirmedEmail,
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ message: "ok" });
+
+		const { data, error } = await serviceRoleDbClient.auth.admin.getUserById(
+			userIds[givenConfirmedEmail],
+		);
+		expect(error).toBeNull();
+		expect(data.user.recovery_sent_at).toBeTruthy();
+
+		const { data: listData, error: listError } =
+			await serviceRoleDbClient.auth.admin.listUsers();
+		expect(listError).toBeNull();
+		expect(
+			listData.users.filter((user) => user.email === givenConfirmedEmail),
+		).toHaveLength(1);
+	});
+
+	it("resends the signup confirmation for an existing, unconfirmed email when only email is provided", async () => {
+		const response = await app.request("/auth/register", {
+			method: "POST",
+			headers: new Headers({ "Content-Type": "application/json" }),
+			body: JSON.stringify({
+				email: givenUnconfirmedEmail,
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ message: "ok" });
+
+		const { data, error } = await serviceRoleDbClient.auth.admin.getUserById(
+			userIds[givenUnconfirmedEmail],
+		);
+		expect(error).toBeNull();
+		expect(data.user.confirmation_sent_at).toBeTruthy();
+
+		const { data: listData, error: listError } =
+			await serviceRoleDbClient.auth.admin.listUsers();
+		expect(listError).toBeNull();
+		expect(
+			listData.users.filter((user) => user.email === givenUnconfirmedEmail),
+		).toHaveLength(1);
+	});
+});

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
+import { ZodError } from "zod";
 import { RegistrationService } from "../services/registration-service";
+import { registerSchema } from "../schemas/register-schema";
 import { captureError } from "../monitoring/capture-error";
 import { serviceRoleDbClient } from "../supabase";
 
@@ -10,11 +12,7 @@ const registrationService = new RegistrationService(serviceRoleDbClient);
 auth.post("/register", async (c) => {
 	try {
 		const body = await c.req.json();
-		const { email, password, firstName, lastName } = body;
-
-		if (!email) {
-			return c.json({ error: "email is required" }, 400);
-		}
+		const { email, password, firstName, lastName } = registerSchema.parse(body);
 
 		await registrationService.registerOrRecover({
 			email,
@@ -26,6 +24,13 @@ auth.post("/register", async (c) => {
 		return c.json({ message: "ok" });
 	} catch (error) {
 		captureError(error);
+
+		if (error instanceof ZodError) {
+			const errors = error.issues
+				.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+				.join("; ");
+			return c.json({ error: `Validation failed: ${errors}` }, 400);
+		}
 
 		if (error instanceof SyntaxError) {
 			return c.json({ error: "Invalid JSON in request body" }, 400);

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -1,0 +1,38 @@
+import { Hono } from "hono";
+import { RegistrationService } from "../services/registration-service";
+import { captureError } from "../monitoring/capture-error";
+import { serviceRoleDbClient } from "../supabase";
+
+const auth = new Hono();
+
+const registrationService = new RegistrationService(serviceRoleDbClient);
+
+auth.post("/register", async (c) => {
+	try {
+		const body = await c.req.json();
+		const { email, password, firstName, lastName } = body;
+
+		if (!email) {
+			return c.json({ error: "email is required" }, 400);
+		}
+
+		await registrationService.registerOrRecover({
+			email,
+			password,
+			firstName,
+			lastName,
+		});
+
+		return c.json({ message: "ok" });
+	} catch (error) {
+		captureError(error);
+
+		if (error instanceof SyntaxError) {
+			return c.json({ error: "Invalid JSON in request body" }, 400);
+		}
+
+		return c.json({ error: "Internal Server Error" }, 500);
+	}
+});
+
+export default auth;

--- a/apps/backend/src/schemas/register-schema.ts
+++ b/apps/backend/src/schemas/register-schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const registerSchema = z.object({
+	email: z.string().min(1, "email is required"),
+	password: z.string().optional(),
+	firstName: z.string().optional(),
+	lastName: z.string().optional(),
+});
+
+export type RegisterInput = z.infer<typeof registerSchema>;

--- a/apps/backend/src/services/registration-service.ts
+++ b/apps/backend/src/services/registration-service.ts
@@ -9,9 +9,12 @@ export class RegistrationService {
 	}
 
 	/**
-	 * Internal failures are captured via Sentry and swallowed so the
-	 * caller always sees the same generic response, regardless of which branch ran
-	 * or whether a step failed.
+	 * Thrown exceptions (network failures, unexpected errors) propagate, since a
+	 * 5xx doesn't reveal which branch was attempted. But the `error` GoTrue
+	 * returns (not throws) from signUp/resend/resetPasswordForEmail can be
+	 * state-correlated, e.g. signUp() returning "User already registered"
+	 * because someone else registered the same email in the gap between our
+	 * check and this call. So those stay swallowed and captured instead.
 	 */
 	async registerOrRecover({
 		email,
@@ -24,64 +27,60 @@ export class RegistrationService {
 		firstName?: string;
 		lastName?: string;
 	}): Promise<void> {
-		try {
-			const { data, error } = await this.client.rpc(
-				"check_email_registration_status",
-				{ p_email: email },
-			);
+		const { data, error } = await this.client.rpc(
+			"check_email_registration_status",
+			{ p_email: email },
+		);
 
-			if (error) {
-				throw error;
-			}
+		if (error) {
+			throw error;
+		}
 
-			const status = data?.[0];
+		const status = data?.[0];
 
-			if (!status?.user_exists) {
-				if (!password) {
-					captureError(
-						new Error(
-							"registerOrRecover called without a password for an email that doesn't exist yet; cannot create user",
-						),
-					);
-					return;
-				}
-
-				const { error: signUpError } = await this.client.auth.signUp({
-					email,
-					password,
-					options: {
-						data: { first_name: firstName, last_name: lastName },
-					},
-				});
-
-				if (signUpError) {
-					throw signUpError;
-				}
-
+		if (!status?.user_exists) {
+			if (!password) {
+				captureError(
+					new Error(
+						"registerOrRecover called without a password for an email that doesn't exist yet; cannot create user",
+					),
+				);
 				return;
 			}
 
-			if (status.is_confirmed) {
-				const { error: resetError } =
-					await this.client.auth.resetPasswordForEmail(email);
-
-				if (resetError) {
-					throw resetError;
-				}
-
-				return;
-			}
-
-			const { error: resendError } = await this.client.auth.resend({
-				type: "signup",
+			const { error: signUpError } = await this.client.auth.signUp({
 				email,
+				password,
+				options: {
+					data: { first_name: firstName, last_name: lastName },
+				},
 			});
 
-			if (resendError) {
-				throw resendError;
+			if (signUpError) {
+				captureError(signUpError);
 			}
-		} catch (error) {
-			captureError(error);
+
+			return;
+		}
+
+		if (status.is_confirmed) {
+			const { error: resetError } =
+				await this.client.auth.resetPasswordForEmail(email);
+
+			if (resetError) {
+				captureError(resetError);
+			}
+
+			return;
+		}
+
+		const { error: resendError } = await this.client.auth.resend({
+			type: "signup",
+			email,
+		});
+
+		if (resendError) {
+			captureError(resendError);
 		}
 	}
 }

--- a/apps/backend/src/services/registration-service.ts
+++ b/apps/backend/src/services/registration-service.ts
@@ -1,0 +1,87 @@
+import type { ServiceRoleDbClient } from "../supabase";
+import { captureError } from "../monitoring/capture-error";
+
+export class RegistrationService {
+	private readonly client: ServiceRoleDbClient;
+
+	constructor(client: ServiceRoleDbClient) {
+		this.client = client;
+	}
+
+	/**
+	 * Internal failures are captured via Sentry and swallowed so the
+	 * caller always sees the same generic response, regardless of which branch ran
+	 * or whether a step failed.
+	 */
+	async registerOrRecover({
+		email,
+		password,
+		firstName,
+		lastName,
+	}: {
+		email: string;
+		password?: string;
+		firstName?: string;
+		lastName?: string;
+	}): Promise<void> {
+		try {
+			const { data, error } = await this.client.rpc(
+				"check_email_registration_status",
+				{ p_email: email },
+			);
+
+			if (error) {
+				throw error;
+			}
+
+			const status = data?.[0];
+
+			if (!status?.user_exists) {
+				if (!password) {
+					captureError(
+						new Error(
+							"registerOrRecover called without a password for an email that doesn't exist yet; cannot create user",
+						),
+					);
+					return;
+				}
+
+				const { error: signUpError } = await this.client.auth.signUp({
+					email,
+					password,
+					options: {
+						data: { first_name: firstName, last_name: lastName },
+					},
+				});
+
+				if (signUpError) {
+					throw signUpError;
+				}
+
+				return;
+			}
+
+			if (status.is_confirmed) {
+				const { error: resetError } =
+					await this.client.auth.resetPasswordForEmail(email);
+
+				if (resetError) {
+					throw resetError;
+				}
+
+				return;
+			}
+
+			const { error: resendError } = await this.client.auth.resend({
+				type: "signup",
+				email,
+			});
+
+			if (resendError) {
+				throw resendError;
+			}
+		} catch (error) {
+			captureError(error);
+		}
+	}
+}

--- a/apps/backend/supabase/migrations/20260728140000_create_check_email_registration_status_function.sql
+++ b/apps/backend/supabase/migrations/20260728140000_create_check_email_registration_status_function.sql
@@ -1,0 +1,29 @@
+-- Looks up whether an email is already registered and, if so, whether it's confirmed.
+-- Used by POST /auth/register to decide whether to create a new user, resend the
+-- signup confirmation, or send a password reset, without leaking existence/
+-- confirmation state to unprivileged callers.
+CREATE OR REPLACE FUNCTION public.check_email_registration_status (p_email TEXT) RETURNS TABLE (user_exists BOOLEAN, is_confirmed BOOLEAN) LANGUAGE plpgsql SECURITY DEFINER
+SET
+    search_path = '' AS $$
+DECLARE
+  v_confirmed_at timestamptz;
+  v_found boolean;
+BEGIN
+  SELECT u.email_confirmed_at INTO v_confirmed_at
+  FROM auth.users u
+  WHERE lower(u.email) = lower(p_email)
+  LIMIT 1;
+
+  v_found := FOUND;
+
+  RETURN QUERY SELECT v_found, (v_found AND v_confirmed_at IS NOT NULL);
+END;
+$$;
+
+REVOKE
+EXECUTE ON FUNCTION public.check_email_registration_status (TEXT)
+FROM
+    PUBLIC;
+
+GRANT
+EXECUTE ON FUNCTION public.check_email_registration_status (TEXT) TO service_role;

--- a/apps/backend/supabase/migrations/20260728140000_create_check_email_registration_status_function.sql
+++ b/apps/backend/supabase/migrations/20260728140000_create_check_email_registration_status_function.sql
@@ -25,5 +25,15 @@ EXECUTE ON FUNCTION public.check_email_registration_status (TEXT)
 FROM
     PUBLIC;
 
+REVOKE
+EXECUTE ON FUNCTION public.check_email_registration_status (TEXT)
+FROM
+    anon;
+
+REVOKE
+EXECUTE ON FUNCTION public.check_email_registration_status (TEXT)
+FROM
+    authenticated;
+
 GRANT
 EXECUTE ON FUNCTION public.check_email_registration_status (TEXT) TO service_role;

--- a/apps/backend/supabase/templates/recovery.html
+++ b/apps/backend/supabase/templates/recovery.html
@@ -74,9 +74,10 @@
 								</h1>
 
 								<p style="font-size: 16px; color: #000000; line-height: 1.5">
-									Sie haben eine Zurücksetzung Ihres Passworts angefordert.
-									Bitte bestätigen Sie Ihre Identität und wählen anschließend
-									ein neues Passwort.
+									Sie haben eine Zurücksetzung Ihres Passworts angefordert oder
+									versucht, sich mit einer bereits registrierten Email-Adresse
+									erneut zu registrieren. Bitte bestätigen Sie Ihre Identität
+									und wählen anschließend ein neues Passwort.
 								</p>
 
 								<p style="font-size: 14px; color: #000000; line-height: 1.5">
@@ -153,7 +154,8 @@
 										rel="noopener noreferrer"
 										style="color: #0c2753; word-break: break-word"
 									>
-										{{ .SiteURL }}/confirm-otp/?type=recovery&email={{ .Email }}&
+										{{ .SiteURL }}/confirm-otp/?type=recovery&email={{ .Email
+										}}&
 									</a>
 									<br /><br />
 									Ihr Code (bitte im Formular eingeben):

--- a/apps/frontend/src/api/auth/register-user.ts
+++ b/apps/frontend/src/api/auth/register-user.ts
@@ -1,4 +1,4 @@
-export async function registerUser({
+export async function registerOrRecoverUser({
 	email,
 	password,
 	firstName,

--- a/apps/frontend/src/api/auth/register-user.ts
+++ b/apps/frontend/src/api/auth/register-user.ts
@@ -1,5 +1,3 @@
-import { supabase } from "../../../supabase-client.ts";
-
 export async function registerUser({
 	email,
 	password,
@@ -7,15 +5,21 @@ export async function registerUser({
 	lastName,
 }: {
 	email: string;
-	password: string;
-	firstName: string;
-	lastName: string;
-}) {
-	return supabase.auth.signUp({
-		email,
-		password,
-		options: {
-			data: { first_name: firstName, last_name: lastName },
+	password?: string;
+	firstName?: string;
+	lastName?: string;
+}): Promise<void> {
+	const url = `${import.meta.env.VITE_API_URL}/auth/register`;
+
+	const response = await fetch(url, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
 		},
+		body: JSON.stringify({ email, password, firstName, lastName }),
 	});
+
+	if (!response.ok) {
+		throw new Error("Registration failed");
+	}
 }

--- a/apps/frontend/src/api/auth/resend-email-confirmation.ts
+++ b/apps/frontend/src/api/auth/resend-email-confirmation.ts
@@ -1,8 +1,0 @@
-import { supabase } from "../../../supabase-client.ts";
-
-export async function resendEmailConfirmation(email: string) {
-	return supabase.auth.resend({
-		email,
-		type: "signup",
-	});
-}

--- a/apps/frontend/src/components/unconfirmed-email/unconfirmed-email.tsx
+++ b/apps/frontend/src/components/unconfirmed-email/unconfirmed-email.tsx
@@ -24,18 +24,13 @@ export function UnconfirmedEmail() {
 	return (
 		<div className="flex w-full min-h-[95svh] justify-center items-center bg-hellblau-100 px-6">
 			<div className="bg-white w-full rounded-3px max-w-4xl border border-black flex flex-col p-6 md:py-10 md:px-12">
-				<h1 className="text-xl md:text-4xl font-bold">
-					{Content["unconfirmedEmail.h1"]}
+				<h1 className="text-xl md:text-4xl mt-1 leading-8">
+					{Content["unconfirmedEmail.h2"]}
 				</h1>
 
-				<h2 className="text-xl md:text-4xl mt-1 leading-8">
-					{Content["unconfirmedEmail.h2"]}
-				</h2>
-
-				<ul className="list-disc leading-6 md:text-xl md:leading-7 max-w-[170rem] ml-5 mt-4 md:mt-8">
-					<li>{Content["unconfirmedEmail.list.li.1"]}</li>
-					<li>{Content["unconfirmedEmail.list.li.2"]}</li>
-				</ul>
+				<p className="leading-6 md:text-xl md:leading-7 max-w-[170rem] mt-4 md:mt-8">
+					{Content["unconfirmedEmail.text"]}
+				</p>
 				<div className="mt-10 md:mt-16 w-full">
 					<span className="text-lg leading-7 font-semibold">
 						{Content["unconfirmedEmail.p"]}

--- a/apps/frontend/src/components/unconfirmed-email/unconfirmed-email.tsx
+++ b/apps/frontend/src/components/unconfirmed-email/unconfirmed-email.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useAuthStore } from "../../store/auth-store.ts";
 import Content from "../../content.ts";
 import { useErrorStore } from "../../store/error-store.ts";

--- a/apps/frontend/src/components/unconfirmed-email/unconfirmed-email.tsx
+++ b/apps/frontend/src/components/unconfirmed-email/unconfirmed-email.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { useAuthStore } from "../../store/auth-store.ts";
 import Content from "../../content.ts";
 import { useErrorStore } from "../../store/error-store.ts";
 
 export function UnconfirmedEmail() {
-	const { resendConfirmationEmail } = useAuthStore();
+	const { resendConfirmationEmail, unconfirmedEmail, resetUnconfirmedEmail } =
+		useAuthStore();
 	const [emailSent, setEmailSent] = useState(false);
 
 	const handleResendEmail = async () => {
@@ -29,13 +31,27 @@ export function UnconfirmedEmail() {
 				</h1>
 
 				<p className="leading-6 md:text-xl md:leading-7 max-w-[170rem] mt-4 md:mt-8">
-					{Content["unconfirmedEmail.text"]}
+					{Content["unconfirmedEmail.text.beforeEmail"]}{" "}
+					<strong>{unconfirmedEmail}</strong>
+					<br />
+					{Content["unconfirmedEmail.text.afterEmail"]}
 				</p>
+
 				<div className="mt-10 md:mt-16 w-full">
 					<span className="text-lg leading-7 font-semibold">
 						{Content["unconfirmedEmail.p"]}
 					</span>
 					<ul className="list-disc leading-6 md:text-lg md:leading-7 font-normal max-w-[170rem] ml-5 mt-2 md:mt-2">
+						<li>
+							{Content["unconfirmedEmail.wrongEmail.question"]}{" "}
+							<Link
+								to="/register/"
+								onClick={resetUnconfirmedEmail}
+								className="font-semibold underline hover:no-underline"
+							>
+								{Content["unconfirmedEmail.wrongEmail.link"]}
+							</Link>
+						</li>
 						<li>{Content["unconfirmedEmail.list1.li1"]}</li>
 						<li>{Content["unconfirmedEmail.list1.li2"]}</li>
 					</ul>

--- a/apps/frontend/src/content.ts
+++ b/apps/frontend/src/content.ts
@@ -1231,12 +1231,9 @@ export const Content = {
 	"resetPasswordSuccessful.buttonLink": "Zum Login",
 
 	/* ---------------------- Unconfirmed Email ---------------------- */
-	"unconfirmedEmail.h1": "Registrierung fast abgeschlossen",
-	"unconfirmedEmail.h2": "Sie erhalten in Kürze eine E-Mail",
-	"unconfirmedEmail.list.li.1":
-		"Prüfen Sie den Posteingang Ihres E-Mail-Postfaches",
-	"unconfirmedEmail.list.li.2":
-		"Klicken Sie auf den Link in der E-Mail, um die Registrierung abzuschließen",
+	"unconfirmedEmail.h2": "Fast geschafft!",
+	"unconfirmedEmail.text":
+		"Sie erhalten in Kürze eine E-Mail. Prüfen Sie den Posteingang Ihres E-Mail-Postfaches und klicken Sie auf den Link.",
 	"unconfirmedEmail.p": "Keine E-Mail bekommen?",
 	"unconfirmedEmail.list1.li1": "Bitte prüfen Sie auch Ihren Spam-Ordner",
 	"unconfirmedEmail.list1.li2":
@@ -1285,8 +1282,6 @@ export const Content = {
 		"Bitte stimmen Sie den Datenschutz- und Nutzungsbedingungen zu.",
 	"form.validation.invalidCredentials.error":
 		"Benutzername oder Passwort inkorrekt",
-	"form.validation.userAlreadyRegistered.error":
-		"Benutzer ist bereits registriert.",
 	"form.validation.password.shouldBeDifferent.error":
 		"Das neue Passwort muss sich vom alten Passwort unterscheiden.",
 	"form.validation.userBanned.error": "Der Benutzeraccount wurde gesperrt.",

--- a/apps/frontend/src/content.ts
+++ b/apps/frontend/src/content.ts
@@ -1232,14 +1232,18 @@ export const Content = {
 
 	/* ---------------------- Unconfirmed Email ---------------------- */
 	"unconfirmedEmail.h2": "Fast geschafft!",
-	"unconfirmedEmail.text":
-		"Sie erhalten in Kürze eine E-Mail. Prüfen Sie den Posteingang Ihres E-Mail-Postfaches und klicken Sie auf den Link.",
+	"unconfirmedEmail.text.beforeEmail":
+		"Sie erhalten in Kürze eine E-Mail an die folgende Adresse:",
+	"unconfirmedEmail.text.afterEmail":
+		"Prüfen Sie den Posteingang Ihres Postfaches und klicken Sie auf den Link in der E-Mail.",
 	"unconfirmedEmail.p": "Keine E-Mail bekommen?",
 	"unconfirmedEmail.list1.li1": "Bitte prüfen Sie auch Ihren Spam-Ordner",
 	"unconfirmedEmail.list1.li2":
 		"Falls nach fünf Minuten keine E-Mail angekommen ist, können Sie sie erneut senden",
 	"unconfirmedEmail.resendButton": "E-Mail erneut senden",
 	"unconfirmedEmail.resend.success": "E-Mail wurde versendet",
+	"unconfirmedEmail.wrongEmail.question": "Falsche E-Mail-Adresse?",
+	"unconfirmedEmail.wrongEmail.link": "Erneut registrieren",
 	"unconfirmedEmail.otp.resend":
 		"Falls der Code nicht mehr gültig ist, können Sie einen neuen anfordern:",
 

--- a/apps/frontend/src/store/auth-error-store.ts
+++ b/apps/frontend/src/store/auth-error-store.ts
@@ -10,8 +10,6 @@ interface AuthErrorStore {
 
 const errorMessages: { [key: string]: string } = {
 	wrong_password: content["form.validation.password.wrong.error"],
-	"User already registered":
-		content["form.validation.userAlreadyRegistered.error"],
 	"Invalid login credentials":
 		content["form.validation.invalidCredentials.error"],
 	privacy_not_accepted: content["form.validation.privacy.required.error"],

--- a/apps/frontend/src/store/auth-store.ts
+++ b/apps/frontend/src/store/auth-store.ts
@@ -9,12 +9,13 @@ import { getAdminStatus } from "../api/user/get-admin-status.ts";
 import { updateEmail } from "../api/auth/update-email.ts";
 import { captureError } from "../monitoring/capture-error.ts";
 import { registerUser } from "../api/auth/register-user.ts";
-import { resendEmailConfirmation } from "../api/auth/resend-email-confirmation.ts";
 import { resendOtpEmail } from "../api/auth/resend-otp-email.ts";
 import type { Span } from "@sentry/react";
 import { getIsUserBanned } from "../api/auth/get-is-user-banned.ts";
 
 let resendTime: number | null = null;
+
+const UNCONFIRMED_EMAIL_STORAGE_KEY = "baergpt:unconfirmedEmail";
 
 type EmailConfirmationStatus = "unknown" | "confirmed" | "unconfirmed";
 
@@ -96,6 +97,10 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 				newUnconfirmedEmail = null;
 			}
 
+			if (newEmailConfirmationStatus !== "unconfirmed") {
+				sessionStorage.removeItem(UNCONFIRMED_EMAIL_STORAGE_KEY);
+			}
+
 			const newState: Partial<AuthStore> = {
 				unconfirmedEmail: newUnconfirmedEmail,
 				emailConfirmationStatus: newEmailConfirmationStatus,
@@ -143,9 +148,15 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 		}
 	});
 
+	const storedUnconfirmedEmail = sessionStorage.getItem(
+		UNCONFIRMED_EMAIL_STORAGE_KEY,
+	);
+
 	return {
-		unconfirmedEmail: null,
-		emailConfirmationStatus: "unknown" as EmailConfirmationStatus,
+		unconfirmedEmail: storedUnconfirmedEmail,
+		emailConfirmationStatus: (storedUnconfirmedEmail
+			? "unconfirmed"
+			: "unknown") as EmailConfirmationStatus,
 		session: undefined,
 		isInitialized: false,
 		isPasswordResetEmailSent: false,
@@ -157,26 +168,24 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 		isBanned: null,
 
 		async register({ firstName, lastName, email, password, span }) {
-			const { data, error } = await registerUser({
-				email,
-				password,
-				firstName,
-				lastName,
-			});
-
-			if (error) {
+			try {
+				await registerUser({ email, password, firstName, lastName });
+			} catch (error) {
 				useAuthErrorStore.getState().handleError(error, span);
 				return;
 			}
 
-			if (data.user && !data.user.email_confirmed_at) {
-				// Explicitly set the unconfirmed email here in addition to relying on onAuthStateChange
-				// This helps if there's any delay in the event firing.
-				set({
-					unconfirmedEmail: email,
-					emailConfirmationStatus: "unconfirmed",
-				});
-			}
+			/**
+			 * The backend always returns the same generic response regardless of
+			 * whether it created a new account, resent a confirmation email, or
+			 * sent a password reset email, so we always show the same
+			 * "check your email" screen here.
+			 */
+			sessionStorage.setItem(UNCONFIRMED_EMAIL_STORAGE_KEY, email);
+			set({
+				unconfirmedEmail: email,
+				emailConfirmationStatus: "unconfirmed",
+			});
 		},
 		async updatePassword(newPassword) {
 			try {
@@ -233,9 +242,9 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 
 			resendTime = Date.now();
 
-			const { error } = await resendEmailConfirmation(unconfirmedEmail);
-
-			if (error) {
+			try {
+				await registerUser({ email: unconfirmedEmail });
+			} catch (error) {
 				useAuthErrorStore.getState().handleError(error);
 			}
 		},

--- a/apps/frontend/src/store/auth-store.ts
+++ b/apps/frontend/src/store/auth-store.ts
@@ -73,6 +73,7 @@ interface AuthStore {
 	updateEmail: (newEmail: string) => Promise<{ error: Error | null }>;
 	updatePassword: (newPassword: string) => Promise<void>;
 	resendConfirmationEmail: () => Promise<void>;
+	resetUnconfirmedEmail: () => void;
 	resendOtpEmail: (args: {
 		email: string;
 		otpType: "email" | "email_change" | "recovery";
@@ -234,6 +235,11 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 		async updateEmail(newEmail: string) {
 			const { error } = await updateEmail(newEmail);
 			return { error };
+		},
+
+		resetUnconfirmedEmail: () => {
+			clearUnconfirmedEmail();
+			set({ unconfirmedEmail: null, emailConfirmationStatus: "unknown" });
 		},
 
 		/**

--- a/apps/frontend/src/store/auth-store.ts
+++ b/apps/frontend/src/store/auth-store.ts
@@ -8,46 +8,12 @@ import { requestPasswordResetByEmail } from "../api/auth/request-password-reset-
 import { getAdminStatus } from "../api/user/get-admin-status.ts";
 import { updateEmail } from "../api/auth/update-email.ts";
 import { captureError } from "../monitoring/capture-error.ts";
-import { registerUser } from "../api/auth/register-user.ts";
+import { registerOrRecoverUser } from "../api/auth/register-user.ts";
 import { resendOtpEmail } from "../api/auth/resend-otp-email.ts";
 import type { Span } from "@sentry/react";
 import { getIsUserBanned } from "../api/auth/get-is-user-banned.ts";
 
 let resendTime: number | null = null;
-
-const UNCONFIRMED_EMAIL_STORAGE_KEY = "baergpt:unconfirmedEmail";
-
-/**
- * sessionStorage isn't defined in every environment this module gets
- * imported into (e.g. Vitest's default "node" test environment), and can
- * also throw even when defined (e.g. Safari private browsing), why every
- * access needs to be guarded, not just checked for existence.
- */
-function readUnconfirmedEmail(): string | null {
-	try {
-		return typeof sessionStorage !== "undefined"
-			? sessionStorage.getItem(UNCONFIRMED_EMAIL_STORAGE_KEY)
-			: null;
-	} catch {
-		return null;
-	}
-}
-
-function writeUnconfirmedEmail(email: string): void {
-	try {
-		sessionStorage?.setItem(UNCONFIRMED_EMAIL_STORAGE_KEY, email);
-	} catch {
-		// sessionStorage unavailable or blocked, ignore.
-	}
-}
-
-function clearUnconfirmedEmail(): void {
-	try {
-		sessionStorage?.removeItem(UNCONFIRMED_EMAIL_STORAGE_KEY);
-	} catch {
-		// sessionStorage unavailable or blocked, ignore.
-	}
-}
 
 type EmailConfirmationStatus = "unknown" | "confirmed" | "unconfirmed";
 
@@ -130,10 +96,6 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 				newUnconfirmedEmail = null;
 			}
 
-			if (newEmailConfirmationStatus !== "unconfirmed") {
-				clearUnconfirmedEmail();
-			}
-
 			const newState: Partial<AuthStore> = {
 				unconfirmedEmail: newUnconfirmedEmail,
 				emailConfirmationStatus: newEmailConfirmationStatus,
@@ -181,13 +143,9 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 		}
 	});
 
-	const storedUnconfirmedEmail = readUnconfirmedEmail();
-
 	return {
-		unconfirmedEmail: storedUnconfirmedEmail,
-		emailConfirmationStatus: (storedUnconfirmedEmail
-			? "unconfirmed"
-			: "unknown") as EmailConfirmationStatus,
+		unconfirmedEmail: null,
+		emailConfirmationStatus: "unknown" as EmailConfirmationStatus,
 		session: undefined,
 		isInitialized: false,
 		isPasswordResetEmailSent: false,
@@ -200,7 +158,7 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 
 		async register({ firstName, lastName, email, password, span }) {
 			try {
-				await registerUser({ email, password, firstName, lastName });
+				await registerOrRecoverUser({ email, password, firstName, lastName });
 			} catch (error) {
 				useAuthErrorStore.getState().handleError(error, span);
 				return;
@@ -212,7 +170,6 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 			 * sent a password reset email, so we always show the same
 			 * "check your email" screen here.
 			 */
-			writeUnconfirmedEmail(email);
 			set({
 				unconfirmedEmail: email,
 				emailConfirmationStatus: "unconfirmed",
@@ -238,7 +195,6 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 		},
 
 		resetUnconfirmedEmail: () => {
-			clearUnconfirmedEmail();
 			set({ unconfirmedEmail: null, emailConfirmationStatus: "unknown" });
 		},
 
@@ -279,7 +235,7 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 			resendTime = Date.now();
 
 			try {
-				await registerUser({ email: unconfirmedEmail });
+				await registerOrRecoverUser({ email: unconfirmedEmail });
 			} catch (error) {
 				useAuthErrorStore.getState().handleError(error);
 			}

--- a/apps/frontend/src/store/auth-store.ts
+++ b/apps/frontend/src/store/auth-store.ts
@@ -17,6 +17,38 @@ let resendTime: number | null = null;
 
 const UNCONFIRMED_EMAIL_STORAGE_KEY = "baergpt:unconfirmedEmail";
 
+/**
+ * sessionStorage isn't defined in every environment this module gets
+ * imported into (e.g. Vitest's default "node" test environment), and can
+ * also throw even when defined (e.g. Safari private browsing), why every
+ * access needs to be guarded, not just checked for existence.
+ */
+function readUnconfirmedEmail(): string | null {
+	try {
+		return typeof sessionStorage !== "undefined"
+			? sessionStorage.getItem(UNCONFIRMED_EMAIL_STORAGE_KEY)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function writeUnconfirmedEmail(email: string): void {
+	try {
+		sessionStorage?.setItem(UNCONFIRMED_EMAIL_STORAGE_KEY, email);
+	} catch {
+		// sessionStorage unavailable or blocked, ignore.
+	}
+}
+
+function clearUnconfirmedEmail(): void {
+	try {
+		sessionStorage?.removeItem(UNCONFIRMED_EMAIL_STORAGE_KEY);
+	} catch {
+		// sessionStorage unavailable or blocked, ignore.
+	}
+}
+
 type EmailConfirmationStatus = "unknown" | "confirmed" | "unconfirmed";
 
 interface AuthStore {
@@ -98,7 +130,7 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 			}
 
 			if (newEmailConfirmationStatus !== "unconfirmed") {
-				sessionStorage.removeItem(UNCONFIRMED_EMAIL_STORAGE_KEY);
+				clearUnconfirmedEmail();
 			}
 
 			const newState: Partial<AuthStore> = {
@@ -148,9 +180,7 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 		}
 	});
 
-	const storedUnconfirmedEmail = sessionStorage.getItem(
-		UNCONFIRMED_EMAIL_STORAGE_KEY,
-	);
+	const storedUnconfirmedEmail = readUnconfirmedEmail();
 
 	return {
 		unconfirmedEmail: storedUnconfirmedEmail,
@@ -181,7 +211,7 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 			 * sent a password reset email, so we always show the same
 			 * "check your email" screen here.
 			 */
-			sessionStorage.setItem(UNCONFIRMED_EMAIL_STORAGE_KEY, email);
+			writeUnconfirmedEmail(email);
 			set({
 				unconfirmedEmail: email,
 				emailConfirmationStatus: "unconfirmed",

--- a/apps/frontend/src/store/auth-store.ts
+++ b/apps/frontend/src/store/auth-store.ts
@@ -237,7 +237,9 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 			try {
 				await registerOrRecoverUser({ email: unconfirmedEmail });
 			} catch (error) {
+				resendTime = null;
 				useAuthErrorStore.getState().handleError(error);
+				throw error;
 			}
 		},
 

--- a/apps/frontend/tests/e2e/auth.spec.ts
+++ b/apps/frontend/tests/e2e/auth.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import {
 	confirmOtp,
@@ -7,6 +8,7 @@ import { supabaseAdminClient } from "../supabase.ts";
 import { defaultUserFirstName, defaultUserLastName } from "../constants.ts";
 import { testWithLoggedInUser } from "../fixtures/test-with-logged-in-user.ts";
 import { testWithoutSplashScreen } from "../fixtures/test-without-splash-screen.ts";
+import Content from "../../src/content.ts";
 
 test.describe("Login", () => {
 	testWithRegisteredUser("User Login and Logout", async ({ page, account }) => {
@@ -232,6 +234,60 @@ test.describe("Password Reset", () => {
 	});
 });
 
+async function fillAndSubmitRegistrationForm(
+	page: Page,
+	{
+		email,
+		password,
+		firstName,
+		lastName,
+	}: { email: string; password: string; firstName: string; lastName: string },
+) {
+	await page.goto("/register/");
+
+	const firstNameInput = page.getByRole("textbox", { name: "Vorname" });
+	await firstNameInput.fill(firstName);
+
+	const lastNameInput = page.getByRole("textbox", { name: "Nachname" });
+	await lastNameInput.fill(lastName);
+
+	const emailInput = page.getByRole("textbox", {
+		name: "E-Mail-Adresse Nur",
+	});
+	await emailInput.fill(email);
+
+	// Wait for check email allowed to be loaded before proceeding
+	await page
+		.waitForResponse((resp) => resp.url().includes("check_email_allowed"), {
+			timeout: 10_000,
+		})
+		.catch(() => {}); // Ignore if already completed
+
+	const passwordInput = page.getByRole("textbox", {
+		name: "Passwort",
+		exact: true,
+	});
+	await passwordInput.fill(password);
+
+	const passwordRepeatInput = page.getByRole("textbox", {
+		name: "Passwort wiederholen",
+	});
+	await passwordRepeatInput.fill(password);
+
+	const privacyCheckboxInput = page.locator(
+		'[data-testid="label-has-accepted-privacy-checkbox"]',
+	);
+	await privacyCheckboxInput.check();
+
+	// Wait for the registration request to complete
+	await Promise.all([
+		page.waitForResponse(
+			(resp) => resp.url().includes("/auth/register") && resp.status() === 200,
+		),
+		page.getByRole("button", { name: "Registrieren" }).click(),
+	]);
+}
+
 test.describe("User Registration (uses different user to prevent side-effects on other tests)", () => {
 	const givenUserEmail = "user.registration@ts.berlin";
 	const givenUserPassword = "123456789!";
@@ -262,58 +318,16 @@ test.describe("User Registration (uses different user to prevent side-effects on
 	});
 
 	testWithoutSplashScreen("Default Registration Flow", async ({ page }) => {
-		// Go to the registration page
-		await page.goto("/register/");
-
-		// Fill in the registration form
-		const firstNameInput = page.getByRole("textbox", {
-			name: "Vorname",
+		await fillAndSubmitRegistrationForm(page, {
+			email: givenUserEmail,
+			password: givenUserPassword,
+			firstName: givenUserFirstName,
+			lastName: givenUserLastName,
 		});
-		await firstNameInput.fill(givenUserFirstName);
-
-		const lastNameInput = page.getByRole("textbox", { name: "Nachname" });
-		await lastNameInput.fill(givenUserLastName);
-
-		const emailInput = page.getByRole("textbox", {
-			name: "E-Mail-Adresse Nur",
-		});
-		await emailInput.fill(givenUserEmail);
-
-		// Wait for check email allowed to be loaded before proceeding
-		await page
-			.waitForResponse((resp) => resp.url().includes("check_email_allowed"), {
-				timeout: 10_000,
-			})
-			.catch(() => {}); // Ignore if already completed
-
-		const passwordInput = page.getByRole("textbox", {
-			name: "Passwort",
-			exact: true,
-		});
-		await passwordInput.fill(givenUserPassword);
-
-		const passwordRepeatInput = page.getByRole("textbox", {
-			name: "Passwort wiederholen",
-		});
-		await passwordRepeatInput.fill(givenUserPassword);
-
-		const privacyCheckboxInput = page.locator(
-			'[data-testid="label-has-accepted-privacy-checkbox"]',
-		);
-		await privacyCheckboxInput.check();
-
-		// Wait for the registration request to complete
-		await Promise.all([
-			page.waitForResponse(
-				(resp) =>
-					resp.url().includes("/auth/v1/signup") && resp.status() === 200,
-			),
-			page.getByRole("button", { name: "Registrieren" }).click(),
-		]);
 
 		// Info message about confirmation mail should be visible
 		await expect(
-			page.getByRole("heading", { name: "Registrierung fast abgeschlossen" }),
+			page.getByRole("heading", { name: "Fast geschafft!" }),
 		).toBeVisible({ timeout: 10_000 });
 
 		const page1 = await confirmOtp({
@@ -333,6 +347,107 @@ test.describe("User Registration (uses different user to prevent side-effects on
 			}),
 		).toBeVisible();
 	});
+
+	testWithoutSplashScreen(
+		"Registering with an existing confirmed email shows the same generic screen",
+		async ({ page }) => {
+			const { error: createUserError } =
+				await supabaseAdminClient.auth.admin.createUser({
+					email: givenUserEmail,
+					password: givenUserPassword,
+					email_confirm: true,
+				});
+
+			expect(createUserError).toBeNull();
+
+			await fillAndSubmitRegistrationForm(page, {
+				email: givenUserEmail,
+				password: givenUserPassword,
+				firstName: givenUserFirstName,
+				lastName: givenUserLastName,
+			});
+
+			// The uniform "check your email" screen must be shown -
+			// never an error revealing that the account already exists.
+			await expect(
+				page.getByRole("heading", {
+					name: "Fast geschafft!",
+				}),
+			).toBeVisible({ timeout: 10_000 });
+			await expect(
+				page.getByText("Benutzer ist bereits registriert."),
+			).not.toBeVisible();
+		},
+	);
+
+	testWithoutSplashScreen(
+		"Registering with an existing unconfirmed email shows the same generic screen",
+		async ({ page }) => {
+			const { error: createUserError } =
+				await supabaseAdminClient.auth.admin.createUser({
+					email: givenUserEmail,
+					password: givenUserPassword,
+					email_confirm: false,
+				});
+
+			expect(createUserError).toBeNull();
+
+			await fillAndSubmitRegistrationForm(page, {
+				email: givenUserEmail,
+				password: givenUserPassword,
+				firstName: givenUserFirstName,
+				lastName: givenUserLastName,
+			});
+
+			// Behaviorally indistinguishable from the "new user" case from the UI -
+			// that's expected, the whole point is uniformity.
+			await expect(
+				page.getByRole("heading", {
+					name: "Fast geschafft!",
+				}),
+			).toBeVisible({ timeout: 10_000 });
+			await expect(
+				page.getByText("Benutzer ist bereits registriert."),
+			).not.toBeVisible();
+		},
+	);
+
+	testWithoutSplashScreen(
+		"Resend button re-submits the registration endpoint with just the email",
+		async ({ page }) => {
+			await fillAndSubmitRegistrationForm(page, {
+				email: givenUserEmail,
+				password: givenUserPassword,
+				firstName: givenUserFirstName,
+				lastName: givenUserLastName,
+			});
+
+			await expect(
+				page.getByRole("heading", {
+					name: "Fast geschafft!",
+				}),
+			).toBeVisible({ timeout: 10_000 });
+
+			const resendButton = page.getByRole("button", {
+				name: "E-Mail erneut senden",
+			});
+
+			const [resendRequest] = await Promise.all([
+				page.waitForRequest(
+					(request) =>
+						request.url().includes("/auth/register") &&
+						request.method() === "POST",
+				),
+				resendButton.click(),
+			]);
+
+			expect(resendRequest.postDataJSON()).toEqual({ email: givenUserEmail });
+
+			await expect(
+				page.getByText(Content["unconfirmedEmail.resend.success"]),
+			).toBeVisible();
+		},
+	);
 });
 
 testWithoutSplashScreen(

--- a/libs/db-schema/index.ts
+++ b/libs/db-schema/index.ts
@@ -246,7 +246,7 @@ export type Database = {
 					content: string;
 					document_id: number | null;
 					folder_id: number | null;
-					full_text_search: unknown;
+					full_text_search: unknown | null;
 					id: number;
 					owned_by_user_id: string | null;
 					page: number;
@@ -258,7 +258,7 @@ export type Database = {
 					content: string;
 					document_id?: number | null;
 					folder_id?: number | null;
-					full_text_search?: unknown;
+					full_text_search?: unknown | null;
 					id?: number;
 					owned_by_user_id?: string | null;
 					page: number;
@@ -270,7 +270,7 @@ export type Database = {
 					content?: string;
 					document_id?: number | null;
 					folder_id?: number | null;
-					full_text_search?: unknown;
+					full_text_search?: unknown | null;
 					id?: number;
 					owned_by_user_id?: string | null;
 					page?: number;
@@ -537,7 +537,10 @@ export type Database = {
 				Args: { p_domain: string };
 				Returns: undefined;
 			};
-			add_allowed_domain: { Args: { p_domain: string }; Returns: undefined };
+			add_allowed_domain: {
+				Args: { p_domain: string };
+				Returns: undefined;
+			};
 			add_allowed_individual_email: {
 				Args: { p_email: string };
 				Returns: undefined;
@@ -550,14 +553,27 @@ export type Database = {
 				};
 				Returns: undefined;
 			};
-			check_email_allowed: { Args: { p_email: string }; Returns: boolean };
+			check_email_allowed: {
+				Args: { p_email: string };
+				Returns: boolean;
+			};
+			check_email_registration_status: {
+				Args: { p_email: string };
+				Returns: {
+					is_confirmed: boolean;
+					user_exists: boolean;
+				}[];
+			};
 			deactivate_allowed_domain: {
 				Args: { p_domain: string };
 				Returns: number;
 			};
-			delete_user: { Args: never; Returns: undefined };
+			delete_user: {
+				Args: Record<PropertyKey, never>;
+				Returns: undefined;
+			};
 			find_unprocessed_documents: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: {
 					created_at: string;
 					file_checksum: string;
@@ -573,14 +589,14 @@ export type Database = {
 				}[];
 			};
 			get_allowed_email_domains: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: {
 					domain: string;
 					id: number;
 				}[];
 			};
 			get_allowed_email_domains_admin: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: {
 					created_at: string;
 					created_by: string;
@@ -593,7 +609,7 @@ export type Database = {
 				}[];
 			};
 			get_allowed_individual_emails: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: {
 					created_at: string;
 					created_by: string;
@@ -643,10 +659,16 @@ export type Database = {
 					storage_version: string;
 				}[];
 			};
-			get_maintenance_mode_status: { Args: never; Returns: boolean };
-			get_product_dashboard_stats: { Args: never; Returns: Json };
+			get_maintenance_mode_status: {
+				Args: Record<PropertyKey, never>;
+				Returns: boolean;
+			};
+			get_product_dashboard_stats: {
+				Args: Record<PropertyKey, never>;
+				Returns: Json;
+			};
 			get_users: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: {
 					academic_title: string;
 					banned_until: string;
@@ -690,8 +712,14 @@ export type Database = {
 					source_url: string;
 				}[];
 			};
-			is_application_admin: { Args: never; Returns: boolean };
-			is_current_user_banned: { Args: never; Returns: boolean };
+			is_application_admin: {
+				Args: Record<PropertyKey, never>;
+				Returns: boolean;
+			};
+			is_current_user_banned: {
+				Args: Record<PropertyKey, never>;
+				Returns: boolean;
+			};
 			match_jina_document_chunks: {
 				Args: {
 					allowed_document_ids: number[];
@@ -752,11 +780,11 @@ export type Database = {
 				}[];
 			};
 			regenerate_embedding_indices_for_chunks: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: undefined;
 			};
 			regenerate_embedding_indices_for_summaries: {
-				Args: never;
+				Args: Record<PropertyKey, never>;
 				Returns: undefined;
 			};
 			remove_allowed_individual_email: {


### PR DESCRIPTION
## Summary
- Fixes registration for already-registered emails: previously, submitting the registration form again with an existing email showed the same generic "registrationn early done, check your email" success screen, but nothing actually happened, no email was ever sent, regardless of whether the existing account was confirmed or not. Users had no way to realize they'd already registered.
- New `POST /auth/register` backend endpoint owns the full registration flow: new email -> create account, existing + confirmed -> send a password reset email, existing + unconfirmed -> resend the confirmation email. The response is identical in all cases, so, as a deliberate side effect of fixing this properly, it also never reveals to the caller which branch fired.
- Frontend registration + resend now go through this endpoint instead of calling Supabase directly.

## Why backend-owned
Deciding what should actually happen (send a reset vs. resend a confirmation) requires knowing whether the email is already registered and confirmed. That lookup requires the service-role client, which only exists server-side. The frontend calling Supabase directly had no way to make that distinction, which is why it silently did nothing useful before.

## Also included
The "check your email" screen now shows the actual address the message was sent to, and (main frontend only) a "Falsche E-Mail-Adresse? Erneut registrieren" link to go back and re-register. Previously, once this screen appeared there was no way back to the form at all, a pre-existing gap in `AuthLayout`'s gating that this PR happens to make fixable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a unified registration and account-recovery flow for new, confirmed, and unconfirmed email addresses.
  - Users can reset passwords or resend confirmation emails through the same flow.
- **Bug Fixes**
  - Kept messaging generic for existing accounts to avoid revealing account status.
- **Content**
  - Improved unconfirmed-email guidance and wrong-email navigation.
  - Expanded German password-recovery email instructions.
- **Tests**
  - Expanded coverage for registration, recovery, confirmation resending, and the unified success screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215791302655155