### PR TITLE
fix: remove seeded 'init.de' domain from allowed email domains

### DIFF
--- a/apps/backend/supabase/migrations/20260729120000_remove_init_de_domain.sql
+++ b/apps/backend/supabase/migrations/20260729120000_remove_init_de_domain.sql
@@ -1,0 +1,4 @@
+-- Remove the seeded 'init.de' domain from the allowed email domains.
+DELETE FROM public.allowed_email_domains
+WHERE
+    domain = 'init.de';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the seeded `init.de` email domain from the list of allowed domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216901633741591