### PR TITLE
draft: fix: remove auto-login link from magic-link email template

### DIFF
--- a/apps/backend/supabase/config.toml
+++ b/apps/backend/supabase/config.toml
@@ -138,6 +138,10 @@ content_path = "./supabase/templates/invite.html"
 subject = "Neue E-Mail-Adresse bestätigen"
 content_path = "./supabase/templates/email_change.html"
 
+[auth.email.template.magic_link]
+subject = "Ihr Anmeldecode für BärGPT"
+content_path = "./supabase/templates/magic_link.html"
+
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.

--- a/apps/backend/supabase/templates/magic_link.html
+++ b/apps/backend/supabase/templates/magic_link.html
@@ -1,0 +1,189 @@
+<!--
+  We don't offer "magic link" passwordless sign-in as a product feature, but Supabase's 
+  public /auth/v1/otp endpoint exists regardless and can be called directly by anyone with the anon key, 
+  for any email address, without owning that inbox. Without this template, GoTrue falls back to its own
+  default email, which contains a real one-click auto-login link. This template exists only
+  to remove that link: it sends a code the recipient must manually enter, same as our
+  confirmation/recovery/email-change emails, so the endpoint being publicly callable can't
+  by itself hand out a working session to anyone but the actual inbox owner.
+-->
+<!doctype html>
+<html lang="de">
+	<head>
+		<meta charset="UTF-8" />
+	</head>
+	<body
+		style="
+			font-family: Arial, Helvetica, sans-serif;
+			background-color: #f2f4f6;
+			margin: 0;
+			padding: 0;
+		"
+	>
+		<table
+			width="100%"
+			cellpadding="0"
+			cellspacing="0"
+			style="background-color: #f2f4f6"
+			class="email-wrapper"
+		>
+			<tr>
+				<td align="center">
+					<table
+						width="570"
+						cellpadding="0"
+						cellspacing="0"
+						style="
+							background-color: #ffffff;
+							margin: 20px auto;
+							padding: 35px;
+							border-radius: 4px;
+						"
+						class="email-content"
+					>
+						<tr>
+							<td
+								width="100%"
+								style="padding: 25px 0; text-align: center"
+								align="center"
+							>
+								<a
+									style="
+										font-family:
+											Arial, &quot;Helvetica Neue&quot;, Helvetica, sans-serif;
+										-webkit-box-sizing: border-box;
+										box-sizing: border-box;
+										font-size: 16px;
+										font-weight: bold;
+										color: #2f3133;
+										text-decoration: none;
+										text-shadow: 0 1px 0 white;
+									"
+									href="https://www.baergpt.berlin/"
+									class="email-masthead_name"
+								>
+									<img
+										style="
+											font-family:
+												Arial, &quot;Helvetica Neue&quot;, Helvetica, sans-serif;
+											-webkit-box-sizing: border-box;
+											box-sizing: border-box;
+											max-height: 50px;
+										"
+										src="https://www.baergpt.berlin/logos/baergpt-logo.svg"
+										alt="BärGPT Logo"
+									/>
+								</a>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<h1 style="font-size: 16px; color: #000000; line-height: 1.5">
+									Hallo {{ .Data.first_name }} {{ .Data.last_name }},
+								</h1>
+
+								<p style="font-size: 16px; color: #000000; line-height: 1.5">
+									Für Ihre Anmeldung bei BärGPT wurde dieser Sicherheitscode
+									angefordert.
+								</p>
+
+								<p style="font-size: 14px; color: #000000; line-height: 1.5">
+									Ihr Sicherheitscode (bitte im Formular eingeben):
+								</p>
+
+								<div
+									style="
+										background-color: #ffffff;
+										border: 1px solid #0c2753;
+										color: #0c2753;
+										font-size: 20px;
+										letter-spacing: 0.2em;
+										text-align: center;
+										word-break: break-word;
+										font-family: &quot;Courier New&quot;, Courier, monospace;
+										border-radius: 6px;
+										padding: 16px;
+										margin: 24px 0;
+									"
+								>
+									<p style="margin: 0">{{ .Token }}</p>
+								</div>
+
+								<!-- Trailing "&" prevents Brevo click tracking from corrupting the email param -->
+								<table
+									cellpadding="0"
+									cellspacing="0"
+									width="100%"
+									style="text-align: left; margin: 30px 0"
+								>
+									<tr>
+										<td align="left">
+											<a
+												href="{{ .SiteURL }}/confirm-otp/?type=email&email={{ .Email }}&"
+												target="_blank"
+												rel="noopener noreferrer"
+												style="
+													background-color: #0c2753;
+													color: #ffffff;
+													padding: 14px 24px;
+													font-size: 16px;
+													text-decoration: none;
+													border-radius: 6px;
+													display: inline-block;
+												"
+											>
+												Anmeldung fortsetzen
+											</a>
+										</td>
+									</tr>
+								</table>
+
+								<p
+									style="
+										font-size: 14px;
+										color: #666666;
+										line-height: 1.5;
+										margin-top: 30px;
+									"
+								>
+									Der Code ist aus Sicherheitsgründen 60 Minuten gültig. Wenn
+									Sie diese Anmeldung nicht angefordert haben, können Sie diese
+									Nachricht ignorieren.
+								</p>
+
+								<p style="font-size: 14px; color: #666666; line-height: 1.5">
+									Funktioniert der Button nicht? Öffnen Sie folgenden Link
+									manuell:
+									<br />
+									<a
+										href="{{ .SiteURL }}/confirm-otp/?type=email&email={{ .Email }}&"
+										target="_blank"
+										rel="noopener noreferrer"
+										style="color: #0c2753; word-break: break-word"
+									>
+										{{ .SiteURL }}/confirm-otp/?type=email&email={{ .Email }}&
+									</a>
+									<br /><br />
+									Ihr Code (bitte im Formular eingeben):
+									<strong>{{ .Token }}</strong>
+								</p>
+
+								<p style="font-size: 14px; color: #666666; line-height: 1.5">
+									Bei Fragen stehen wir Ihnen gerne zur Verfügung: <br />
+									<a href="mailto:support@baergpt.berlin"
+										>support@baergpt.berlin</a
+									>
+								</p>
+
+								<p style="font-size: 14px; color: #666666; line-height: 1.5">
+									Viele Grüße <br />
+									Ihr <strong>BärGPT-Team</strong>
+								</p>
+							</td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+	</body>
+</html>

--- a/infra/supabase/docker-compose.yml
+++ b/infra/supabase/docker-compose.yml
@@ -135,6 +135,10 @@ services:
       GOTRUE_MAILER_TEMPLATES_RECOVERY: ${MAILER_TEMPLATES_RECOVERY_URL}
       # Email change - provide a URL to a HTML or Text template
       GOTRUE_MAILER_TEMPLATES_EMAIL_CHANGE: ${MAILER_TEMPLATES_EMAIL_CHANGE_URL}
+
+      # Without this, GoTrue falls back to its built-in default magic link template, which contains
+      # a real one-click auto-login link instead of a code the user must enter manually.
+      GOTRUE_MAILER_TEMPLATES_MAGIC_LINK: ${MAILER_TEMPLATES_MAGIC_LINK_URL}
       # Subjects
       GOTRUE_MAILER_SUBJECTS_CONFIRMATION: ${MAILER_SUBJECTS_CONFIRMATION}
       GOTRUE_MAILER_SUBJECTS_RECOVERY: ${MAILER_SUBJECTS_RECOVERY}
@@ -447,8 +451,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXP: ${JWT_EXPIRY}
-    command:
-      [
+    command: [
         "postgres",
         "-c",
         "config_file=/etc/postgresql/postgresql.conf",


### PR DESCRIPTION
## Some background from what I understood in my research and from trying out:
Supabase bundles "magic link" (passwordless login via email) as a core part of its email-auth system, it's not an optional add-on. We never use it (our app only does password login + OTP codes for signup/reset), but the feature is active anyway, and there's no setting anywhere to switch it off. The endpoint behind it (/auth/v1/otp) is public by design, needs no login, and works for any email address, because that's also how our legitimate signup/reset emails get triggered under the hood, same shared mechanism. It can only be made harmless (which is what was did here by overriding its default template) or gated with extra checks (CAPTCHA/rate-limit, still open).

In general it seems not super dangerous overall. The attacker never has the target's mailbox, and it only works for allowed domains. But a link logs you in the instant anything opens it, even an automated scanner with no human involved. A code can't do that, it's useless until a person actually reads and types it in.

## What this PR fixes:
The magic-link email used to send a real, clickable "log in instantly" link (Supabase's default). Now it sends a code instead, same as all our other emails: code, no click-to-login link. So even if someone triggers this, they don't hand out a working session anymore.

## What we could also do:
1. Rate limit is basically unlimited right now (GOTRUE_RATE_LIMIT_EMAIL_SENT: 10000 in the docker-compose file). We should probably lower this, would be a quick fix
2. Add CAPTCHA: would be the actual fix for "random script can spam this endpoint at all." Without it, anyone (scanner, bot, whatever) can still hit the endpoint over and over for any email, they just won't get anything dangerous back anymore. But this would be a bigger task and is probably out of scope.