### PR TITLE
feat: add cf/ci service accounts

### DIFF
--- a/infra/terraform/cloud-foundry/README.md
+++ b/infra/terraform/cloud-foundry/README.md
@@ -5,14 +5,15 @@ Provisions one CF org (`baergpt`) with `staging` and `prod` spaces in the
 
 ## Layout
 
-| File           | Manages                                                              |
-| -------------- | -------------------------------------------------------------------- |
-| `versions.tf`  | Terraform + provider pins; S3 remote-state backend                   |
-| `provider.tf`  | `stackit` + `cloudfoundry` providers (CF wired from the org-manager) |
-| `variables.tf` | project id, org name, region, operators, per-space quota + ssh       |
-| `org.tf`       | CF org + technical org-manager + platform data source                |
-| `spaces.tf`    | spaces, space quotas, org/space roles                                |
-| `outputs.tf`   | api_url                                                              |
+| File                  | Manages                                                              |
+| --------------------- | -------------------------------------------------------------------- |
+| `versions.tf`         | Terraform + provider pins; S3 remote-state backend                   |
+| `provider.tf`         | `stackit` + `cloudfoundry` providers (CF wired from the org-manager) |
+| `variables.tf`        | project id, org name, region, operators, per-space quota + ssh       |
+| `org.tf`              | CF org + technical org-manager + platform data source                |
+| `spaces.tf`           | spaces, space quotas, org/space roles                                |
+| `service-accounts.tf` | per-space CI service accounts + their keys                           |
+| `outputs.tf`          | api_url, CI credentials                                              |
 
 ## Quotas
 
@@ -64,6 +65,15 @@ Every later change is a plain `$OP terraform apply` — no `-target`.
 > concurrent applies against this state.
 
 [stackitcloud/terraform-provider-stackit#1534]: https://github.com/stackitcloud/terraform-provider-stackit/issues/1534
+
+## CI credentials
+
+Each space has a `space-deployer` service account for CI pipelines (SpaceDeveloper) in that
+space only. Read a login out and put it in the pipeline's secret store:
+
+```sh
+$OP terraform output -json deployer_credentials | jq '.prod'
+```
 
 ## SSH access
 

--- a/infra/terraform/cloud-foundry/outputs.tf
+++ b/infra/terraform/cloud-foundry/outputs.tf
@@ -2,3 +2,9 @@ output "api_url" {
   value       = data.stackit_scf_platform.platform.api_url
   description = "Cloud Foundry API URL (use with `cf api`)."
 }
+
+output "deployer_credentials" {
+  value       = { for space, binding in cloudfoundry_service_credential_binding.deployer : space => binding.credential_binding }
+  sensitive   = true
+  description = "Per-space CI login, keyed by space name."
+}

--- a/infra/terraform/cloud-foundry/service-accounts.tf
+++ b/infra/terraform/cloud-foundry/service-accounts.tf
@@ -1,0 +1,39 @@
+# Broker-managed technical users for CI. Creating the instance provisions a user, adds it
+# to that one space and grants it SpaceDeveloper, so a prod credential cannot reach staging.
+data "cloudfoundry_service_plans" "space_deployer" {
+  service_offering_name = "space-scoped-service-account"
+  name                  = "space-deployer"
+}
+
+# Org-manager rights stop at the org boundary, and creating a service instance is a
+# space-level action, so Terraform's own identity needs a role inside each space via
+# org membership first.
+resource "cloudfoundry_org_role" "manager" {
+  username = stackit_scf_organization_manager.manager.username
+  type     = "organization_user"
+  org      = stackit_scf_organization.org.org_id
+}
+
+resource "cloudfoundry_space_role" "manager" {
+  for_each = cloudfoundry_space.this
+  user     = cloudfoundry_org_role.manager.user
+  type     = "space_developer"
+  space    = each.value.id
+}
+
+resource "cloudfoundry_service_instance" "deployer" {
+  for_each     = cloudfoundry_space.this
+  name         = "${each.key}-deployer"
+  type         = "managed"
+  space        = each.value.id
+  service_plan = data.cloudfoundry_service_plans.space_deployer.service_plans[0].id
+
+  depends_on = [cloudfoundry_space_role.manager]
+}
+
+resource "cloudfoundry_service_credential_binding" "deployer" {
+  for_each         = cloudfoundry_service_instance.deployer
+  type             = "key"
+  name             = "ci"
+  service_instance = each.value.id
+}


### PR DESCRIPTION
This branch adds the TF for the different username/pw for the prod/staging CLI. 

Background Info: 

We have 4 Identities we are working with: 
1. STACKIT API credential: TF uses it to create the org, org quota and `stackit_scf_organization_manager.manager`
2. stackit_scf_organization_manager.manager: A machine user who's password lives in TF state. Terraform's cloudfoundry provider logs in as this account to create spaces, quotas and role grants.
3. var.operators: This is the SSO account we use when logging into the CF CLI. TF doesn't create it. STACKIT does. 
4. Staging Deployer / Prod Deployer: TF doesn't create these directly. CF Marketplace offers a service called space-scoped-service-account with a plan called space-deployer.  Ordering one into a space causes the broker to invent a fresh user and grant it SpaceDeveloper in that space only. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated CI service accounts for each Cloud Foundry space.
  - Added secure credential bindings for CI deployments.
  - Terraform now exposes sensitive deployer credentials for configured spaces.

- **Documentation**
  - Expanded the Cloud Foundry Terraform documentation with a module layout overview.
  - Added instructions for retrieving CI deployment credentials, including production credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->