### PR TITLE
Increase staging total_memory to 8192

### DIFF
--- a/infra/terraform/cloud-foundry/terraform.tfvars.example
+++ b/infra/terraform/cloud-foundry/terraform.tfvars.example
@@ -9,6 +9,6 @@ operators = ["you@example.org"]
 
 # Override per-space caps to fit the org quota if needed:
 # spaces = {
-#   staging = { allow_ssh = true,  total_memory = 4096,  total_app_instances = 10, total_routes = 10 }
+#   staging = { allow_ssh = true,  total_memory = 8192,  total_app_instances = 10, total_routes = 10 }
 #   prod    = { allow_ssh = false, total_memory = 18432, total_app_instances = 20, total_routes = 20 }
 # }

--- a/infra/terraform/cloud-foundry/variables.tf
+++ b/infra/terraform/cloud-foundry/variables.tf
@@ -35,7 +35,7 @@ variable "spaces" {
     total_routes        = number
   }))
   default = {
-    staging = { allow_ssh = true, total_memory = 4096, total_app_instances = 10, total_routes = 10 }
+    staging = { allow_ssh = true, total_memory = 8192, total_app_instances = 10, total_routes = 10 }
     prod    = { allow_ssh = false, total_memory = 18432, total_app_instances = 20, total_routes = 20 }
   }
 


### PR DESCRIPTION
`cf push --strategy rolling` needs double the space since both versions of the app are running at the same time during handover. CF starts the new instance, waits for it to pass the health check, and only then stops the old one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Increased the default memory allocation for the staging environment from 4 GB to 8 GB.
  * Updated the example configuration to reflect the new staging capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->