### PR TITLE
Feat/add autoscaling

### DIFF
--- a/.github/workflows/backend-deploy-stackit-cf.yml
+++ b/.github/workflows/backend-deploy-stackit-cf.yml
@@ -209,6 +209,7 @@ jobs:
       - name: Attach autoscaling policy 📈
         working-directory: apps/backend
         run: |
+          set -euo pipefail
           service="${CF_SPACE}-autoscaler"
           policy="autoscaler-policy-${{ github.ref_name == 'main' && 'production' || 'staging' }}.json"
           cf unbind-service "${{ env.APP_NAME }}" "$service" --wait 2>/dev/null || true

--- a/.github/workflows/backend-deploy-stackit-cf.yml
+++ b/.github/workflows/backend-deploy-stackit-cf.yml
@@ -199,6 +199,21 @@ jobs:
             --var disk_quota="$CF_DISK_QUOTA" \
           || { cf cancel-deployment "${{ env.APP_NAME }}" 2>/dev/null || true; exit 1; }
 
+      # Autoscaling: re-attach the committed policy on every deploy so the repo
+      # stays the single source of truth (same philosophy as the env-var sync
+      # above). The autoscaler *service instance* ("<space>-autoscaler") is
+      # provisioned once by Terraform — see infra/terraform/cloud-foundry. cf v8
+      # has no update-binding, so we unbind + rebind, passing the policy as the
+      # binding's config (-c). Unbind is best-effort: on the first attach there's
+      # nothing bound yet.
+      - name: Attach autoscaling policy 📈
+        working-directory: apps/backend
+        run: |
+          service="${CF_SPACE}-autoscaler"
+          policy="autoscaler-policy-${{ github.ref_name == 'main' && 'production' || 'staging' }}.json"
+          cf unbind-service "${{ env.APP_NAME }}" "$service" --wait 2>/dev/null || true
+          cf bind-service "${{ env.APP_NAME }}" "$service" --wait -c "$policy"
+
       - name: Dump recent app logs on failure 🪵
         if: ${{ failure() && !cancelled() }}
         run: cf logs "${{ env.APP_NAME }}" --recent

--- a/.github/workflows/gotenberg-deploy-stackit-cf.yml
+++ b/.github/workflows/gotenberg-deploy-stackit-cf.yml
@@ -133,6 +133,32 @@ jobs:
             ${{ steps.sync.outputs.bootstrapped != 'true' && '--strategy rolling' || '' }} \
           || { cf cancel-deployment "${{ env.APP_NAME }}" 2>/dev/null || true; exit 1; }
 
+      # Prod only: autoscale gotenberg 1→3 instances (conversions are CPU-bound).
+      # Staging stays at the manifest's fixed single instance, so no policy there.
+      # Binds to the shared "<space>-autoscaler" service instance provisioned by
+      # Terraform (infra/terraform/cloud-foundry) — one instance, many apps. cf v8
+      # has no update-binding, so unbind + rebind with the committed policy (-c).
+      - name: Attach autoscaling policy 📈
+        if: ${{ github.ref_name == 'main' }}
+        working-directory: infra/gotenberg
+        run: |
+          service="${CF_SPACE}-autoscaler"
+          policy="autoscaler-policy-production.json"
+          cf unbind-service "${{ env.APP_NAME }}" "$service" --wait 2>/dev/null || true
+          # The unbind above detached the previous policy, so a failed rebind
+          # would leave the app with no autoscaling. Retry with backoff; the
+          # committed policy file is the source of truth, so re-binding it is
+          # the recovery path. Fail the deploy if it never attaches.
+          for attempt in 1 2 3; do
+            cf bind-service "${{ env.APP_NAME }}" "$service" --wait -c "$policy" && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Failed to attach autoscaling policy after $attempt attempts; app left without a policy" >&2
+              exit 1
+            fi
+            echo "bind-service failed (attempt $attempt), retrying in $((attempt * 10))s…" >&2
+            sleep $((attempt * 10))
+          done
+
       - name: Dump recent app logs on failure 🪵
         if: ${{ failure() && !cancelled() }}
         run: cf logs "${{ env.APP_NAME }}" --recent

--- a/.github/workflows/gotenberg-deploy-stackit-cf.yml
+++ b/.github/workflows/gotenberg-deploy-stackit-cf.yml
@@ -8,6 +8,7 @@ on:
     # (or manually via workflow_dispatch)
     paths:
       - "infra/gotenberg/manifest.yml"
+      - "infra/gotenberg/autoscaler-policy-production.json"
       - ".github/workflows/gotenberg-deploy-stackit-cf.yml"
   workflow_dispatch:
 

--- a/.github/workflows/gotenberg-deploy-stackit-cf.yml
+++ b/.github/workflows/gotenberg-deploy-stackit-cf.yml
@@ -143,6 +143,7 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         working-directory: infra/gotenberg
         run: |
+          set -euo pipefail
           service="${CF_SPACE}-autoscaler"
           policy="autoscaler-policy-production.json"
           cf unbind-service "${{ env.APP_NAME }}" "$service" --wait 2>/dev/null || true

--- a/apps/backend/autoscaler-policy-production.json
+++ b/apps/backend/autoscaler-policy-production.json
@@ -1,0 +1,22 @@
+{
+	"instance_min_count": 2,
+	"instance_max_count": 6,
+	"scaling_rules": [
+		{
+			"metric_type": "memoryutil",
+			"breach_duration_secs": 300,
+			"threshold": 40,
+			"operator": ">=",
+			"cool_down_secs": 300,
+			"adjustment": "+1"
+		},
+		{
+			"metric_type": "memoryutil",
+			"breach_duration_secs": 300,
+			"threshold": 20,
+			"operator": "<",
+			"cool_down_secs": 300,
+			"adjustment": "-1"
+		}
+	]
+}

--- a/apps/backend/autoscaler-policy-staging.json
+++ b/apps/backend/autoscaler-policy-staging.json
@@ -1,0 +1,22 @@
+{
+	"instance_min_count": 1,
+	"instance_max_count": 2,
+	"scaling_rules": [
+		{
+			"metric_type": "memoryutil",
+			"breach_duration_secs": 300,
+			"threshold": 40,
+			"operator": ">=",
+			"cool_down_secs": 300,
+			"adjustment": "+1"
+		},
+		{
+			"metric_type": "memoryutil",
+			"breach_duration_secs": 300,
+			"threshold": 20,
+			"operator": "<",
+			"cool_down_secs": 300,
+			"adjustment": "-1"
+		}
+	]
+}

--- a/infra/gotenberg/autoscaler-policy-production.json
+++ b/infra/gotenberg/autoscaler-policy-production.json
@@ -1,0 +1,22 @@
+{
+	"instance_min_count": 1,
+	"instance_max_count": 3,
+	"scaling_rules": [
+		{
+			"metric_type": "cpu",
+			"operator": ">=",
+			"threshold": 80,
+			"adjustment": "+1",
+			"breach_duration_secs": 120,
+			"cool_down_secs": 120
+		},
+		{
+			"metric_type": "cpu",
+			"operator": "<=",
+			"threshold": 25,
+			"adjustment": "-1",
+			"breach_duration_secs": 300,
+			"cool_down_secs": 300
+		}
+	]
+}

--- a/infra/terraform/cloud-foundry/README.md
+++ b/infra/terraform/cloud-foundry/README.md
@@ -13,6 +13,7 @@ Provisions one CF org (`baergpt`) with `staging` and `prod` spaces in the
 | `org.tf`              | CF org + technical org-manager + platform data source                |
 | `spaces.tf`           | spaces, space quotas, org/space roles                                |
 | `service-accounts.tf` | per-space CI service accounts + their keys                           |
+| `autoscaler.tf`       | per-space App-Autoscaler service instance (`<space>-autoscaler`)     |
 | `outputs.tf`          | api_url, CI credentials                                              |
 
 ## Quotas
@@ -28,6 +29,23 @@ cf curl /v3/organization_quotas | jq '.resources[] | {name, guid, memory_mb: .ap
 ```
 
 Switch plans in the portal, then update `quota_id` to match.
+
+## Autoscaling
+
+`autoscaler.tf` provisions **one App-Autoscaler service instance per space**
+(`<space>-autoscaler`, e.g. `staging-autoscaler`, `prod-autoscaler`) from the free
+`autoscaler-free-plan` in the STACKIT marketplace. This is deliberately split from the
+scaling policy:
+
+- **The service instance** is the durable half — provisioned once by Terraform, it lives
+  independently of any app deploy. One instance is shared by every app in the space.
+- **The policy** (min/max instances + scaling rules) is _not_ in Terraform. The apps
+  themselves are created by `cf push` in CI, not here, so each deploy workflow attaches a
+  committed policy JSON to its app by binding it to the space's autoscaler instance. See
+  `autoscaler-policy-*.json` and the "Attach autoscaling policy" step in
+  `backend-deploy-stackit-cf.yml` / `gotenberg-deploy-stackit-cf.yml`.
+
+Because the plan is free, `allow_paid_service_plans` stays `false` on the space quota.
 
 ## Auth
 

--- a/infra/terraform/cloud-foundry/autoscaler.tf
+++ b/infra/terraform/cloud-foundry/autoscaler.tf
@@ -1,0 +1,24 @@
+# App-Autoscaler service instance, one per space. This is the durable half of
+# autoscaling: the managed service instance is provisioned once and lives
+# independently of any app deploy. The *policy* (min/max instances + scaling
+# rules) is NOT set here — it's attached per-app by the deploy workflow from a
+# committed JSON file, because the apps themselves are created by `cf push` in
+# CI, not by Terraform (see backend-deploy-stackit-cf.yml and the repo-root
+# autoscaler-policy-*.json files).
+
+# The free autoscaler plan offered by the STACKIT marketplace ("autoscaler"
+# broker). allow_paid_service_plans stays false on the space quota because this
+# plan is free.
+data "cloudfoundry_service_plans" "autoscaler" {
+  name                  = "autoscaler-free-plan"
+  service_offering_name = "autoscaler"
+}
+
+resource "cloudfoundry_service_instance" "autoscaler" {
+  for_each     = var.spaces
+  name         = "${each.key}-autoscaler"
+  space        = cloudfoundry_space.this[each.key].id
+  type         = "managed"
+  service_plan = data.cloudfoundry_service_plans.autoscaler.service_plans[0].id
+  depends_on   = [cloudfoundry_space_role.manager]
+}

--- a/infra/terraform/cloud-foundry/autoscaler.tf
+++ b/infra/terraform/cloud-foundry/autoscaler.tf
@@ -3,8 +3,7 @@
 # independently of any app deploy. The *policy* (min/max instances + scaling
 # rules) is NOT set here — it's attached per-app by the deploy workflow from a
 # committed JSON file, because the apps themselves are created by `cf push` in
-# CI, not by Terraform (see backend-deploy-stackit-cf.yml and the repo-root
-# autoscaler-policy-*.json files).
+# CI, not by Terraform (see backend-deploy-stackit-cf.yml and gotenberg-deploy-stackit-cf.yml).
 
 # The free autoscaler plan offered by the STACKIT marketplace ("autoscaler"
 # broker). allow_paid_service_plans stays false on the space quota because this


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic backend autoscaling for staging and production environments.
  * Added production autoscaling for the Gotenberg service.
  * Backend scaling adjusts between 1–2 instances in staging and 2–6 in production based on memory usage.
  * Gotenberg scales based on CPU utilization.
  * Added infrastructure support for provisioning autoscaler services per environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215648063343464