### PR TITLE
fix: re-add data: to img-src CSP

### DIFF
--- a/apps/frontend/vercel.json
+++ b/apps/frontend/vercel.json
@@ -7,7 +7,7 @@
 				{ "key": "X-Frame-Options", "value": "DENY" },
 				{
 					"key": "Content-Security-Policy",
-					"value": "frame-ancestors 'none'; img-src 'self' blob: https://logos.citylab-berlin.org"
+					"value": "frame-ancestors 'none'; img-src 'self' data: blob: https://logos.citylab-berlin.org"
 				}
 			]
 		}


### PR DESCRIPTION
data: URIs can't exfiltrate anything (no network fetch, bytes are inline), and react-dnd's document drag-and-drop hardcodes a data: URI for its drag-ghost image. Removing it broke that feature for no security benefit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled images embedded as data URIs to load correctly while preserving existing image source permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->