### PR TITLE
fix: stop storing GITHUB_TOKEN as the CF registry credential

### DIFF
--- a/.github/workflows/backend-deploy-stackit-cf.yml
+++ b/.github/workflows/backend-deploy-stackit-cf.yml
@@ -147,8 +147,6 @@ jobs:
       - name: Sync backend env vars 🔄
         id: sync
         working-directory: apps/backend
-        env:
-          CF_DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           if ! cf app "${{ env.APP_NAME }}" >/dev/null 2>&1; then
@@ -160,7 +158,6 @@ jobs:
               -f manifest.yml \
               --no-start \
               --var image="${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}" \
-              --var docker_username="${{ github.actor }}" \
               --var instances="$CF_INSTANCES" \
               --var memory="$CF_MEMORY" \
               --var disk_quota="$CF_DISK_QUOTA"
@@ -185,15 +182,12 @@ jobs:
       # step flags it, and we do a plain cold start instead (empty = no flag).
       - name: Push image to Cloud Foundry 🚀
         working-directory: apps/backend
-        env:
-          CF_DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           cf push \
             -f manifest.yml \
             ${{ steps.sync.outputs.bootstrapped != 'true' && '--strategy rolling' || '' }} \
             --var image="${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}" \
-            --var docker_username="${{ github.actor }}" \
             --var instances="$CF_INSTANCES" \
             --var memory="$CF_MEMORY" \
             --var disk_quota="$CF_DISK_QUOTA" \

--- a/apps/backend/manifest.yml
+++ b/apps/backend/manifest.yml
@@ -8,7 +8,6 @@ applications:
   - name: baergpt-backend
     docker:
       image: ((image))
-      username: ((docker_username))
     instances: ((instances))
     memory: ((memory))
     disk_quota: ((disk_quota))


### PR DESCRIPTION
Heres a theory:
1. The baergpt-backend GHCR package is publicly pullable. No credential is needed to fetch it.
2. The deploy passed secrets.GITHUB_TOKEN as the CF registry password. CF stores that on the app and replays it on every later image pull.
3. That token is revoked when the workflow job ends, so every pull after the run presents a dead credential.
4. GHCR returns 403 for invalid credentials where it returns 200 for none. So the pull failed, the container was never created, and CF reported it as app.crash.

This would explain the autoscaling issues. But I don't yet see if this would impact our CI issues. Either way its good to remove the creds here as they are not necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified backend deployment configuration by removing redundant container registry credentials.
  * Preserved existing deployment behavior, including rolling and cold-start options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->