### PR TITLE
feat: add UUID-based preview source URL handling for document uploads

### DIFF
--- a/apps/backend/src/integration/routes/documents-preview-collision.integration.test.ts
+++ b/apps/backend/src/integration/routes/documents-preview-collision.integration.test.ts
@@ -1,0 +1,176 @@
+import {
+	describe,
+	it,
+	expect,
+	vi,
+	beforeAll,
+	afterAll,
+	beforeEach,
+} from "vitest";
+import { readFileSync } from "node:fs";
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "@repo/db-schema";
+import app from "../../index";
+import { serviceRoleDbClient } from "../../supabase";
+import { config } from "../../config";
+import { WordDocumentExtractionService } from "../../services/document-extraction-service";
+import { GenerationService } from "../../services/generation-service";
+import { defaultDocumentPath } from "../fixtures/constants";
+
+const supabaseAnonClient = createClient<Database>(
+	config.supabaseUrl,
+	config.supabaseAnonKey,
+);
+
+const UUID_PDF_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.pdf$/;
+
+describe("Documents Route Integration, preview naming collision", () => {
+	const givenUserId = "6e8e6e2b-6f0a-4c3d-9c1a-2f7a2b7e5c11";
+	const givenUserEmail = "docs-preview-collision-user@ts.berlin";
+	const givenUserPassword = "SecurePassword123!";
+	const preexistingPdfName = "report.pdf";
+	const docxName = "report.docx";
+	let accessToken: string;
+
+	beforeAll(async () => {
+		await serviceRoleDbClient.auth.admin.createUser({
+			id: givenUserId,
+			email: givenUserEmail,
+			password: givenUserPassword,
+			email_confirm: true,
+		});
+	}, 20_000);
+
+	afterAll(async () => {
+		await serviceRoleDbClient.auth.admin.deleteUser(givenUserId);
+	});
+
+	beforeEach(async () => {
+		const { data } = await supabaseAnonClient.auth.signInWithPassword({
+			email: givenUserEmail,
+			password: givenUserPassword,
+		});
+		accessToken = data.session?.access_token || "";
+
+		vi.spyOn(
+			WordDocumentExtractionService.prototype,
+			"extractWordDocument",
+		).mockResolvedValue("mock extracted text");
+	});
+
+	async function uploadFixtureAs(fileName: string) {
+		const sourceUrl = `${givenUserId}/${fileName}`;
+		const file = readFileSync(defaultDocumentPath);
+		const { error } = await supabaseAnonClient.storage
+			.from("documents")
+			.upload(sourceUrl, file, {
+				contentType: "application/pdf",
+				upsert: true,
+			});
+		expect(error).toBeNull();
+		return sourceUrl;
+	}
+
+	async function processDocument(sourceUrl: string) {
+		const req = new Request("http://localhost/documents/process", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${accessToken}`,
+			},
+			body: JSON.stringify({
+				document: {
+					source_url: sourceUrl,
+					source_type: "personal_document",
+					folder_id: null,
+					owned_by_user_id: givenUserId,
+					created_at: new Date().toISOString(),
+				},
+				llm_model: config.defaultDocumentProcessingModel,
+			}),
+		});
+		return app.fetch(req);
+	}
+
+	it("does not collide with, and does not delete, a pre-existing pdf with the same base name", async () => {
+		// 1. An unrelated pdf already exists at the base name the docx preview would have used.
+		await uploadFixtureAs(preexistingPdfName);
+
+		// 2. Upload and process a docx whose preview would legacy-collide with that pdf.
+		const docxSourceUrl = await uploadFixtureAs(docxName);
+		const res = await processDocument(docxSourceUrl);
+
+		expect(res.status).toBe(204);
+
+		// 3. The new document row got a UUID-named preview, not "report.pdf".
+		const { data: documentRow, error: documentRowError } =
+			await serviceRoleDbClient
+				.from("documents")
+				.select("preview_source_url")
+				.eq("source_url", docxSourceUrl)
+				.single();
+		expect(documentRowError).toBeNull();
+		expect(documentRow?.preview_source_url).toBeTruthy();
+		const previewFileName = documentRow?.preview_source_url?.split("/").pop();
+		expect(previewFileName).toMatch(UUID_PDF_PATTERN);
+
+		// 4. The pre-existing, unrelated pdf is untouched.
+		const { data: filesAfter } = await serviceRoleDbClient.storage
+			.from("documents")
+			.list(givenUserId);
+		expect(
+			filesAfter?.find((f) => f.name === preexistingPdfName),
+		).toBeDefined();
+
+		// Cleanup
+		await serviceRoleDbClient
+			.from("documents")
+			.delete()
+			.eq("source_url", docxSourceUrl);
+		await serviceRoleDbClient.storage
+			.from("documents")
+			.remove([
+				`${givenUserId}/${preexistingPdfName}`,
+				`${givenUserId}/${docxName}`,
+				documentRow?.preview_source_url as string,
+			]);
+	}, 30_000);
+
+	it("only cleans up the preview it just created when processing fails, leaving a pre-existing same-named pdf alone", async () => {
+		await uploadFixtureAs(preexistingPdfName);
+		const docxSourceUrl = await uploadFixtureAs(docxName);
+
+		const summarizeSpy = vi
+			.spyOn(GenerationService.prototype, "summarize")
+			.mockRejectedValue(new Error("Forced Failure"));
+
+		const res = await processDocument(docxSourceUrl);
+		expect(res.status).toBe(500);
+
+		const { data: filesAfter } = await serviceRoleDbClient.storage
+			.from("documents")
+			.list(givenUserId);
+
+		// Cleanup-on-failure removes the docx itself (processing never
+		// completed, so it never became a real document) and its freshly
+		// generated UUID preview...
+		expect(filesAfter?.find((f) => f.name === docxName)).toBeUndefined();
+		const remainingNames = new Set(filesAfter?.map((f) => f.name));
+		const leftoverPreview = [...remainingNames].find((name) =>
+			UUID_PDF_PATTERN.test(name),
+		);
+		expect(leftoverPreview).toBeUndefined();
+		// ...but must not touch the pre-existing, unrelated pdf.
+		expect(
+			filesAfter?.find((f) => f.name === preexistingPdfName),
+		).toBeDefined();
+
+		summarizeSpy.mockRestore();
+
+		// Cleanup
+		await serviceRoleDbClient.storage
+			.from("documents")
+			.remove([`${givenUserId}/${preexistingPdfName}`]);
+	}, 30_000);
+});

--- a/apps/backend/src/routes/documents.ts
+++ b/apps/backend/src/routes/documents.ts
@@ -27,6 +27,7 @@ documents.post("/process", async (c: Context) => {
 
 	let sourceUrl: string | null = null;
 	let bucket: string | null = null;
+	let previewSourceUrl: string | null = null;
 	const authenticatedUserId = c.get("authenticatedUserId");
 	const reqId =
 		config.nodeEnv === "production"
@@ -62,6 +63,7 @@ documents.post("/process", async (c: Context) => {
 		const extractionResult = await userScopedDbService.extractDocument(
 			documentForExtraction,
 		);
+		previewSourceUrl = extractionResult.previewSourceUrl ?? null;
 		logMemory(
 			`doc:after-extract (pages=${extractionResult.numPages}, size=${extractionResult.fileSize})`,
 			reqId,
@@ -82,6 +84,7 @@ documents.post("/process", async (c: Context) => {
 					? authenticatedUserId
 					: undefined,
 			source_url: sourceUrl,
+			preview_source_url: previewSourceUrl,
 			source_type: inputDocument.source_type,
 			file_checksum: extractionResult.checksum,
 			file_size: extractionResult.fileSize,
@@ -123,7 +126,11 @@ documents.post("/process", async (c: Context) => {
 		// If processing failed, clean up the storage file
 		if (sourceUrl !== null && bucket !== null) {
 			try {
-				await userScopedDbService.deleteFileFromStorage(sourceUrl, bucket);
+				await userScopedDbService.deleteFileFromStorage(
+					sourceUrl,
+					bucket,
+					previewSourceUrl,
+				);
 			} catch (cleanupError) {
 				captureError(cleanupError);
 			}

--- a/apps/backend/src/services/build-preview-source-url.test.ts
+++ b/apps/backend/src/services/build-preview-source-url.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { buildPreviewSourceUrl } from "./build-preview-source-url";
+
+const UUID_PDF_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.pdf$/;
+
+describe("buildPreviewSourceUrl", () => {
+	it("keeps the original directory but replaces the filename with a UUID-based .pdf name", () => {
+		const result = buildPreviewSourceUrl("user-123/folder-456/report.docx");
+
+		const segments = result.split("/");
+		const fileName = segments.pop() as string;
+		expect(segments.join("/")).toBe("user-123/folder-456");
+		expect(fileName).toMatch(UUID_PDF_PATTERN);
+	});
+
+	it("does not derive the name from the original filename", () => {
+		const result = buildPreviewSourceUrl("user-123/report.docx");
+
+		expect(result).not.toContain("report");
+	});
+
+	it("generates a different name on each call, so repeated conversions of the same document never collide", () => {
+		const first = buildPreviewSourceUrl("user-123/report.docx");
+		const second = buildPreviewSourceUrl("user-123/report.docx");
+
+		expect(first).not.toBe(second);
+	});
+
+	it("handles a source_url with no directory prefix", () => {
+		const result = buildPreviewSourceUrl("report.docx");
+
+		expect(result).toMatch(UUID_PDF_PATTERN);
+	});
+});

--- a/apps/backend/src/services/build-preview-source-url.ts
+++ b/apps/backend/src/services/build-preview-source-url.ts
@@ -1,0 +1,7 @@
+import { randomUUID } from "crypto";
+
+export function buildPreviewSourceUrl(sourceUrl: string): string {
+	const segments = sourceUrl.split("/");
+	segments[segments.length - 1] = `${randomUUID()}.pdf`;
+	return segments.join("/");
+}

--- a/apps/backend/src/services/db-service/base-db-service.ts
+++ b/apps/backend/src/services/db-service/base-db-service.ts
@@ -18,6 +18,7 @@ import {
 	WordDocumentExtractionService,
 } from "../document-extraction-service";
 import { captureError } from "../../monitoring/capture-error";
+import { buildPreviewSourceUrl } from "../build-preview-source-url";
 const documentExtraction = new DocumentExtractionService();
 const wordExtractionService = new WordDocumentExtractionService();
 
@@ -105,10 +106,11 @@ export abstract class BaseContentDbService {
 	async deleteFileFromStorage(
 		source_url: string,
 		bucket: string,
+		previewSourceUrl?: string | null,
 	): Promise<void> {
 		const pathsToRemove = [source_url];
-		if (/\.(docx?)$/i.test(source_url)) {
-			pathsToRemove.push(source_url.replace(/\.(docx?)$/i, ".pdf"));
+		if (previewSourceUrl) {
+			pathsToRemove.push(previewSourceUrl);
 		}
 		const { error: deletionError } = await this.client.storage
 			.from(bucket)
@@ -170,6 +172,7 @@ export abstract class BaseContentDbService {
 				processing_finished_at: new Date().toISOString(),
 				folder_id: document.folder_id || null,
 				source_url: document.source_url,
+				preview_source_url: document.preview_source_url ?? null,
 				source_type: document.source_type,
 				file_name: document.source_url?.split("/").pop(),
 				created_at: document.created_at || new Date().toISOString(),
@@ -214,9 +217,9 @@ export abstract class BaseContentDbService {
 	 * Only logs errors rather than throwing them to avoid masking the original error.
 	 */
 	async deleteDocumentById(documentId: number): Promise<void> {
-		const { bucket, sourceUrl } =
+		const { bucket, sourceUrl, previewSourceUrl } =
 			await this.getStorageInformationForDocumentId(documentId);
-		await this.deleteFileFromStorage(sourceUrl, bucket);
+		await this.deleteFileFromStorage(sourceUrl, bucket, previewSourceUrl);
 
 		const { error } = await this.client
 			.from("documents")
@@ -266,8 +269,13 @@ export abstract class BaseContentDbService {
 			document.source_url,
 		);
 
+		let previewSourceUrl: string | undefined;
 		if (/\.(docx?)$/i.test(document.source_url)) {
-			await this.savePdfPreview({ fileBytes, bucket, document });
+			previewSourceUrl = await this.savePdfPreview({
+				fileBytes,
+				bucket,
+				document,
+			});
 		}
 
 		const extractionResult = await documentExtraction.extractDocument(
@@ -275,7 +283,7 @@ export abstract class BaseContentDbService {
 			document,
 		);
 
-		return extractionResult;
+		return { ...extractionResult, previewSourceUrl };
 	}
 
 	async savePdfPreview({
@@ -286,8 +294,8 @@ export abstract class BaseContentDbService {
 		fileBytes: Uint8Array;
 		bucket: string;
 		document: Document;
-	}) {
-		const pdfPreviewUrl = document.source_url.replace(/\.(docx?)$/i, ".pdf");
+	}): Promise<string> {
+		const previewSourceUrl = buildPreviewSourceUrl(document.source_url);
 		const fileName = document.source_url.split("/").pop();
 
 		const pdfBuffer = await wordExtractionService.convertWordToPdf({
@@ -296,12 +304,14 @@ export abstract class BaseContentDbService {
 		});
 
 		await this.uploadFileToStorage(
-			pdfPreviewUrl,
+			previewSourceUrl,
 			new File([pdfBuffer], fileName, {
 				type: "application/pdf",
 			}),
 			bucket,
 		);
+
+		return previewSourceUrl;
 	}
 
 	/**
@@ -371,7 +381,7 @@ export abstract class BaseContentDbService {
 
 		let selectQuery = this.client
 			.from("documents")
-			.select("source_url, source_type, owned_by_user_id")
+			.select("source_url, source_type, owned_by_user_id, preview_source_url")
 			.eq("id", documentId);
 
 		// This security check is added in addition to an existing RLS policy which enforces this as well to make the logic more explicit
@@ -432,7 +442,11 @@ export abstract class BaseContentDbService {
 			: "documents";
 
 		if ((isAdmin && bucket === "public_documents") || bucket === "documents") {
-			await this.deleteFileFromStorage(documentData.source_url, bucket);
+			await this.deleteFileFromStorage(
+				documentData.source_url,
+				bucket,
+				documentData.preview_source_url,
+			);
 		}
 
 		// Update the user's document count
@@ -539,12 +553,14 @@ export abstract class BaseContentDbService {
 		return data?.some((file) => file.name === fileName) ?? false;
 	}
 
-	async getStorageInformationForDocumentId(
-		documentId: number,
-	): Promise<{ bucket: string; sourceUrl: string }> {
+	async getStorageInformationForDocumentId(documentId: number): Promise<{
+		bucket: string;
+		sourceUrl: string;
+		previewSourceUrl: string | null;
+	}> {
 		const { data, error } = await this.client
 			.from("documents")
-			.select("source_url, source_type")
+			.select("source_url, source_type, preview_source_url")
 			.eq("id", documentId)
 			.single();
 		if (error) {
@@ -557,6 +573,10 @@ export abstract class BaseContentDbService {
 			? "public_documents"
 			: "documents";
 
-		return { bucket, sourceUrl: data.source_url };
+		return {
+			bucket,
+			sourceUrl: data.source_url,
+			previewSourceUrl: data.preview_source_url,
+		};
 	}
 }

--- a/apps/backend/src/services/db-service/privileged-db-service.ts
+++ b/apps/backend/src/services/db-service/privileged-db-service.ts
@@ -157,7 +157,7 @@ export class PrivilegedDbService extends BaseContentDbService {
 		// Get all documents for the user with storage info
 		const { data: documents, error: documentsError } = await this.client
 			.from("documents")
-			.select("source_url, source_type")
+			.select("source_url, source_type, preview_source_url")
 			.eq("owned_by_user_id", userId);
 
 		if (documentsError) {
@@ -182,7 +182,11 @@ export class PrivilegedDbService extends BaseContentDbService {
 					: "documents";
 
 				try {
-					await this.deleteFileFromStorage(doc.source_url, bucket);
+					await this.deleteFileFromStorage(
+						doc.source_url,
+						bucket,
+						doc.preview_source_url,
+					);
 				} catch (storageError) {
 					captureError(storageError);
 				}

--- a/apps/backend/src/types/common.ts
+++ b/apps/backend/src/types/common.ts
@@ -13,6 +13,7 @@ export type Document = {
 	processing_finished_at?: string;
 	created_at: string;
 	uploaded_by_user_id?: string;
+	preview_source_url?: string | null;
 };
 
 export type DocumentSummary = {
@@ -123,6 +124,7 @@ export type ExtractionResult = {
 	numPages: number;
 	checksum: string;
 	parsedPages: ParsedPage[];
+	previewSourceUrl?: string;
 };
 
 export type SummarizeResult = {

--- a/apps/backend/supabase/migrations/20260803120000_add_preview_source_url_to_documents.sql
+++ b/apps/backend/supabase/migrations/20260803120000_add_preview_source_url_to_documents.sql
@@ -1,0 +1,5 @@
+-- Add a column to persist the UUID-based preview file path, generated at
+-- upload time instead of derived from the original filename (which could
+-- collide with an unrelated pre-existing file of the same base name).
+ALTER TABLE public.documents
+ADD COLUMN IF NOT EXISTS preview_source_url TEXT;

--- a/apps/frontend/src/api/documents/get-document-object-url.test.ts
+++ b/apps/frontend/src/api/documents/get-document-object-url.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { deriveLegacyPreviewSourceUrl } from "./get-document-object-url";
+
+describe("deriveLegacyPreviewSourceUrl", () => {
+	it("swaps a .docx suffix for .pdf", () => {
+		expect(deriveLegacyPreviewSourceUrl("user-1/report.docx")).toBe(
+			"user-1/report.pdf",
+		);
+	});
+
+	it("leaves non-docx source urls unchanged", () => {
+		expect(deriveLegacyPreviewSourceUrl("user-1/report.pdf")).toBe(
+			"user-1/report.pdf",
+		);
+	});
+
+	it("is case-insensitive on the .docx suffix", () => {
+		expect(deriveLegacyPreviewSourceUrl("user-1/report.DOCX")).toBe(
+			"user-1/report.pdf",
+		);
+	});
+});

--- a/apps/frontend/src/api/documents/get-document-object-url.ts
+++ b/apps/frontend/src/api/documents/get-document-object-url.ts
@@ -5,19 +5,22 @@ import type { SourceType } from "../../common.ts";
 export async function getDocumentObjectUrl({
 	sourceUrl,
 	sourceType,
+	previewSourceUrl,
 }: {
 	sourceUrl: string;
 	sourceType: SourceType;
+	previewSourceUrl?: string | null;
 }): Promise<string | undefined> {
 	const bucket = ["public_document", "default_document"].includes(sourceType)
 		? "public_documents"
 		: "documents";
 
-	const previewSourceUrl = getPreviewSourceUrl(sourceUrl);
+	const resolvedPreviewSourceUrl =
+		previewSourceUrl ?? deriveLegacyPreviewSourceUrl(sourceUrl);
 
 	const { data: previewBlob, error: previewError } = await supabase.storage
 		.from(bucket)
-		.download(previewSourceUrl);
+		.download(resolvedPreviewSourceUrl);
 
 	if (previewError) {
 		useErrorStore.getState().handleError(previewError);
@@ -27,11 +30,12 @@ export async function getDocumentObjectUrl({
 	return URL.createObjectURL(previewBlob);
 }
 
-function getPreviewSourceUrl(sourceUrl: string) {
-	/**
-	 * For docx files, use the PDF preview version instead,
-	 * to ensure it is viewable with the browser PDF viewer.
-	 */
+/**
+ * Only used for documents processed before UUID-named previews existed
+ * (preview_source_url is null on their row): for docx files, the PDF
+ * preview lives at the same path with the extension swapped.
+ */
+export function deriveLegacyPreviewSourceUrl(sourceUrl: string) {
 	if (sourceUrl.toLowerCase().endsWith(".docx")) {
 		return sourceUrl.replace(/\.docx$/i, ".pdf");
 	}

--- a/apps/frontend/src/common.ts
+++ b/apps/frontend/src/common.ts
@@ -82,6 +82,7 @@ export type UserDocument = {
 	id: number;
 	num_pages: number | null;
 	owned_by_user_id: string | null;
+	preview_source_url: string | null;
 	processing_finished_at: string | null;
 	source_type: "personal_document" | "default_document";
 	source_url: string;
@@ -96,6 +97,7 @@ export type PublicDocument = {
 	id: number;
 	num_pages: number | null;
 	owned_by_user_id: string | null;
+	preview_source_url: string | null;
 	processing_finished_at: string | null;
 	source_type: "public_document";
 	source_url: string;

--- a/apps/frontend/src/store/use-preview-document-store.ts
+++ b/apps/frontend/src/store/use-preview-document-store.ts
@@ -42,6 +42,7 @@ export const usePreviewDocumentStore = create<PreviewDocumentStore>((set) => ({
 		const previewUrl = await getDocumentObjectUrl({
 			sourceUrl: document.source_url,
 			sourceType: document.source_type,
+			previewSourceUrl: document.preview_source_url,
 		});
 
 		set({ selectedPreviewDocumentPreviewUrl: previewUrl });

--- a/libs/db-schema/index.ts
+++ b/libs/db-schema/index.ts
@@ -375,6 +375,7 @@ export type Database = {
 					id: number;
 					num_pages: number | null;
 					owned_by_user_id: string | null;
+					preview_source_url: string | null;
 					processing_finished_at: string | null;
 					source_type: string;
 					source_url: string;
@@ -390,6 +391,7 @@ export type Database = {
 					id?: number;
 					num_pages?: number | null;
 					owned_by_user_id?: string | null;
+					preview_source_url?: string | null;
 					processing_finished_at?: string | null;
 					source_type: string;
 					source_url: string;
@@ -405,6 +407,7 @@ export type Database = {
 					id?: number;
 					num_pages?: number | null;
 					owned_by_user_id?: string | null;
+					preview_source_url?: string | null;
 					processing_finished_at?: string | null;
 					source_type?: string;
 					source_url?: string;


### PR DESCRIPTION
Current workflow:
- User uploads doc
- Frontend stores doc under source_url: <userId or accessGroupId>/<originalFileName>
- Backend takes this url, downloads the file, and if it's a .docx/.doc, additionally generates a PDF preview via Gotenberg, naming it by swapping the suffix on the original filename (same folder, X.docx -> X.pdf)
- Problem: if a file named X.pdf already exists in that same folder (unrelated to this upload), the preview upload collides with it (409 from Supabase Storage, no upsert), processing fails, and the error-cleanup step can end up deleting that pre-existing, unrelated pdf

This ticket introduces an additional column in the document table for the path to its preview, consisting of the same folder prefix as the original file, plus a freshly generated UUID, plus ".pdf".
This solves the problem of potential naming conflicts where the same preview name already exists, leading to a 409 error and in the worst case removing the existing, unrelated preview file in a cleanup step. So for every action on a doc's preview, the correct url to it needs to be read from the column instead of derived. This affects the deletion paths (single-document deletion, account deletion, and processing-failure cleanup) as well as the frontend read path when displaying the preview.

The ticket says "Preview files are named using the UUID of the original document not a suffix-swapped version of the original filename.", but 1. each doc only has a sequential id it gets from supabase, no uuid, and more importantly, 2. the preview gets generated before the document is stored at all. That's why we can't use any document id for the preview name; at generation time there is no row yet. Only after the preview is generated, and everything else needed for the doc (summary, embeddings) is ready, does the document row get written all at once, and only then does it become visible to the user in the frontend. If we instead stored the doc row first just to get an id to name the preview with, users would see a half-done upload state in the meantime. Also, right now, if extraction fails, nothing has been written to the db yet. If we switched the order, we'd need a new failure-cleanup path for that partial row too.

Alternative, a bit out of scope for this ticket: if we want one consistent naming scheme throughout, we could also give the document itself a UUID-based name instead of the original filename (now or as a follow-up), so original and preview share one identifier. This is more contained than it sounds: the storage path is already built client-side, and the frontend already treats the display filename as its own field, separate from the storage path. Pro: no collision possible by construction, matches the ticket's literal wording more closely. Con: renames every upload, not just docx ones..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document previews now use a dedicated preview file path, helping keep preview files separate from the original upload.
  * Preview URLs are now stored and reused across the app for more reliable document viewing.

* **Bug Fixes**
  * Fixed preview generation so new previews no longer overwrite existing files with the same base name.
  * When document processing fails, only newly created files are removed, preserving any existing preview files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->