### PR TITLE
feat: add UUID for docs to prevent doc preview naming collisions

### DIFF
--- a/apps/backend/src/routes/documents.ts
+++ b/apps/backend/src/routes/documents.ts
@@ -82,6 +82,7 @@ documents.post("/process", async (c: Context) => {
 					? authenticatedUserId
 					: undefined,
 			source_url: sourceUrl,
+			file_name: inputDocument.file_name,
 			source_type: inputDocument.source_type,
 			file_checksum: extractionResult.checksum,
 			file_size: extractionResult.fileSize,

--- a/apps/backend/src/services/db-service/base-db-service.ts
+++ b/apps/backend/src/services/db-service/base-db-service.ts
@@ -171,7 +171,7 @@ export abstract class BaseContentDbService {
 				folder_id: document.folder_id || null,
 				source_url: document.source_url,
 				source_type: document.source_type,
-				file_name: document.source_url?.split("/").pop(),
+				file_name: document.file_name ?? document.source_url?.split("/").pop(),
 				created_at: document.created_at || new Date().toISOString(),
 				access_group_id: document.access_group_id || null,
 				uploaded_by_user_id: document.uploaded_by_user_id || null,

--- a/apps/backend/src/services/db-service/privileged-db-service.ts
+++ b/apps/backend/src/services/db-service/privileged-db-service.ts
@@ -2,7 +2,6 @@ import { captureError } from "../../monitoring/capture-error";
 import type { ServiceRoleDbClient } from "../../supabase";
 import type { TablesUpdate } from "@repo/db-schema";
 import { BaseContentDbService } from "./base-db-service";
-import { TablesUpdate } from "@repo/db-schema";
 /**
  * AdminService handles operations that require the Supabase service role key.
  *
@@ -63,7 +62,6 @@ export class PrivilegedDbService extends BaseContentDbService {
 				userId,
 				authUpdateData,
 			);
-
 			if (authError) {
 				throw authError;
 			}

--- a/apps/backend/src/services/db-service/privileged-db-service.ts
+++ b/apps/backend/src/services/db-service/privileged-db-service.ts
@@ -1,5 +1,6 @@
 import { captureError } from "../../monitoring/capture-error";
 import type { ServiceRoleDbClient } from "../../supabase";
+import type { TablesUpdate } from "@repo/db-schema";
 import { BaseContentDbService } from "./base-db-service";
 import { TablesUpdate } from "@repo/db-schema";
 /**

--- a/apps/backend/src/types/common.ts
+++ b/apps/backend/src/types/common.ts
@@ -6,6 +6,7 @@ export type Document = {
 	access_group_id?: string;
 	source_url: string;
 	source_type: string;
+	file_name?: string;
 	file_checksum?: string;
 	file_size?: number;
 	num_pages?: number;

--- a/apps/frontend/src/api/documents/upload-file.ts
+++ b/apps/frontend/src/api/documents/upload-file.ts
@@ -46,6 +46,7 @@ export async function processDocument(
 			created_at: new Date().toISOString(),
 			source_type: "personal_document",
 			source_url: filePath,
+			file_name: file.name,
 			metadata: {
 				mimeType: file.type,
 				size: file.size,

--- a/apps/frontend/src/store/use-file-uploads-store.ts
+++ b/apps/frontend/src/store/use-file-uploads-store.ts
@@ -1,7 +1,6 @@
 import { create } from "zustand";
 import { useUserDocumentStore } from "./use-user-document-store.ts";
 import { useAuthStore } from "./auth-store.ts";
-import slugify from "slugify";
 import {
 	uploadFileToDb,
 	processDocument,
@@ -65,15 +64,15 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 			useUserDocumentStore.getState();
 
 		const uploadFileSizeLimit = import.meta.env.VITE_UPLOAD_FILE_SIZE_LIMIT_MB;
-		const slugifiedFilename = slugify(file.name, { lower: true });
-		const filePath = `${session?.user.id}/${slugifiedFilename}`;
+		const fileExtension = file.name.split(".").pop();
+		const filePath = `${session?.user.id}/${crypto.randomUUID()}.${fileExtension}`;
 		try {
 			if (file.size > uploadFileSizeLimit * 1024 * 1024) {
 				throw new Error("failed.size");
 			}
 
 			const fileExists = userDocuments.some(
-				(doc) => doc.source_url === filePath,
+				(doc) => doc.file_name === file.name,
 			);
 			if (fileExists) {
 				throw new Error("failed.duplicate");

--- a/apps/frontend/src/store/use-file-uploads-store.ts
+++ b/apps/frontend/src/store/use-file-uploads-store.ts
@@ -9,6 +9,7 @@ import { useErrorStore } from "./error-store.ts";
 import * as Sentry from "@sentry/react";
 import type { Span } from "@sentry/react";
 import { deleteFileFromStorage } from "../api/documents/delete-file-from-storage.ts";
+import { isDocumentInDatabase } from "../api/documents/is-document-in-database.ts";
 
 export const UPLOAD_STATUS_MAP = {
 	waiting: "Warte",
@@ -119,14 +120,23 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 		} catch (error) {
 			useErrorStore.getState().handleError(error, span);
 
-			// The upload reached storage but never finished being processed into
-			// a document — clean up the file we just wrote, since no document
-			// row for it will ever be created.
+			// Storage succeeded, but /documents/process failed or its response
+			// never arrived. That doesn't guarantee no document was created,
+			// so confirm with the server before deleting the file.
 			if (storageUploadSucceeded && !documentCreated) {
-				const { error: deleteFileError } =
-					await deleteFileFromStorage(filePath);
-				if (deleteFileError) {
-					useErrorStore.getState().handleError(deleteFileError, span);
+				const { data: documentExists, error: checkError } =
+					await isDocumentInDatabase(filePath);
+
+				if (checkError) {
+					useErrorStore.getState().handleError(checkError, span);
+				}
+
+				if (!documentExists) {
+					const { error: deleteFileError } =
+						await deleteFileFromStorage(filePath);
+					if (deleteFileError) {
+						useErrorStore.getState().handleError(deleteFileError, span);
+					}
 				}
 			}
 

--- a/apps/frontend/src/store/use-file-uploads-store.ts
+++ b/apps/frontend/src/store/use-file-uploads-store.ts
@@ -131,7 +131,7 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 					useErrorStore.getState().handleError(checkError, span);
 				}
 
-				if (!documentExists) {
+				if (!checkError && documentExists === false) {
 					const { error: deleteFileError } =
 						await deleteFileFromStorage(filePath);
 					if (deleteFileError) {

--- a/apps/frontend/src/store/use-file-uploads-store.ts
+++ b/apps/frontend/src/store/use-file-uploads-store.ts
@@ -8,9 +8,7 @@ import {
 import { useErrorStore } from "./error-store.ts";
 import * as Sentry from "@sentry/react";
 import type { Span } from "@sentry/react";
-import { isFileInStorage } from "../api/documents/is-file-in-storage.ts";
 import { deleteFileFromStorage } from "../api/documents/delete-file-from-storage.ts";
-import { isDocumentInDatabase } from "../api/documents/is-document-in-database.ts";
 
 export const UPLOAD_STATUS_MAP = {
 	waiting: "Warte",
@@ -66,6 +64,8 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 		const uploadFileSizeLimit = import.meta.env.VITE_UPLOAD_FILE_SIZE_LIMIT_MB;
 		const fileExtension = file.name.split(".").pop();
 		const filePath = `${session?.user.id}/${crypto.randomUUID()}.${fileExtension}`;
+		let storageUploadSucceeded = false;
+		let documentCreated = false;
 		try {
 			if (file.size > uploadFileSizeLimit * 1024 * 1024) {
 				throw new Error("failed.size");
@@ -93,10 +93,12 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 
 			updateFileUploadStatus(file, "uploading");
 			await uploadFileToDb(file, filePath);
+			storageUploadSucceeded = true;
 			updateFileUploadStatus(file, "uploaded");
 
 			updateFileUploadStatus(file, "processing");
 			await processDocument(file, filePath);
+			documentCreated = true;
 			updateFileUploadStatus(file, "successful");
 
 			setTimeout(() => {
@@ -117,7 +119,16 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 		} catch (error) {
 			useErrorStore.getState().handleError(error, span);
 
-			await cleanupIfNecessary(filePath, span);
+			// The upload reached storage but never finished being processed into
+			// a document — clean up the file we just wrote, since no document
+			// row for it will ever be created.
+			if (storageUploadSucceeded && !documentCreated) {
+				const { error: deleteFileError } =
+					await deleteFileFromStorage(filePath);
+				if (deleteFileError) {
+					useErrorStore.getState().handleError(deleteFileError, span);
+				}
+			}
 
 			if (isKnownError(error)) {
 				updateFileUploadStatus(file, error.message);
@@ -267,89 +278,4 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 
 function isKnownError(error: unknown): error is { message: UploadStatusKeys } {
 	return error instanceof Error && error.message in UPLOAD_STATUS_MAP;
-}
-
-async function cleanupIfNecessary(filePath: string, span: Span) {
-	const { data: isFileInStorageData, error: isFileInStorageError } =
-		await isFileInStorage(filePath);
-
-	/**
-	 * If the file does not exist, supabase returns false + an error:
-	 * https://github.com/supabase/supabase-js/issues/1363
-	 * So we only log the error without returning early.
-	 */
-	if (isFileInStorageError) {
-		useErrorStore.getState().handleError(isFileInStorageError, span);
-	}
-
-	const { data: isDocumentInDbData, error: isDocumentInDbError } =
-		await isDocumentInDatabase(filePath);
-
-	if (isDocumentInDbError) {
-		useErrorStore.getState().handleError(isDocumentInDbError, span);
-		return;
-	}
-
-	/**
-	 * If the file exists in the storage AND in the db,
-	 * it means the upload was successful but something else failed
-	 * (e.g. user tried to upload a file twice)
-	 */
-	if (isFileInStorageData && isDocumentInDbData) {
-		return;
-	}
-
-	/**
-	 * If the file does NEITHER exist in the storage NOR in the db,
-	 * there is nothing to clean up.
-	 */
-	if (!isFileInStorageData && !isDocumentInDbData) {
-		return;
-	}
-
-	/**
-	 * If the file exists in the storage but does not exist in the db,
-	 * just remove the file from the storage.
-	 * This can happen e.g. when the API is unavailable.
-	 */
-	if (isFileInStorageData && !isDocumentInDbData) {
-		await cleanupStorage(filePath, span);
-		return;
-	}
-
-	/**
-	 * If the file does not exist in the storage but does exist in the db,
-	 * just remove the file from the store and the db.
-	 * This can happen e.g. when a DB deletion failed.
-	 */
-	await cleanupStoreAndDatabase(filePath, span);
-}
-async function cleanupStorage(filePath: string, span: Span) {
-	const { error: deleteFileError } = await deleteFileFromStorage(filePath);
-
-	if (!deleteFileError) {
-		return;
-	}
-
-	useErrorStore.getState().handleError(deleteFileError, span);
-}
-
-async function cleanupStoreAndDatabase(filePath: string, span: Span) {
-	const { userDocuments, deleteUserDocument } = useUserDocumentStore.getState();
-
-	const documentToDelete = userDocuments.find(
-		(doc) => doc.source_url === filePath,
-	);
-
-	if (!documentToDelete) {
-		return;
-	}
-
-	const deleteError = await deleteUserDocument(documentToDelete.id);
-
-	if (!deleteError) {
-		return;
-	}
-
-	useErrorStore.getState().handleError(deleteError, span);
 }

--- a/apps/frontend/tests/e2e/document.spec.ts
+++ b/apps/frontend/tests/e2e/document.spec.ts
@@ -29,9 +29,6 @@ import {
 	seedDefaultDocumentName,
 } from "../constants.ts";
 import { supabaseAdminClient } from "../supabase.ts";
-import { createClient } from "@supabase/supabase-js";
-import { Database } from "@repo/db-schema";
-import { config } from "../config.ts";
 
 test.describe("Documents", () => {
 	testDesktopOnly(
@@ -152,42 +149,23 @@ test.describe("Documents", () => {
 
 	testDesktopOnly(
 		"Should delete the file from storage when the processing fails",
-		async ({ page, account, browserName, session }) => {
-			const givenStoragePath = `${account.id}/${secondaryDocumentName}`;
-
-			const givenFile = new File(["test content"], secondaryDocumentName, {
-				type: secondaryDocumentType,
+		async ({ page, browserName }) => {
+			// Force the process step to fail after the file has already reached
+			// storage, so we can verify the frontend cleans up the now-orphaned
+			// storage object.
+			await page.route("**/documents/process", async (route) => {
+				return route.fulfill({ status: 500 });
 			});
 
-			const localAnonClient = createClient<Database>(
-				config.supabaseUrl,
-				config.supabaseAnonKey,
+			// Storage paths are UUID-based now, so we need to capture the path
+			// from the actual upload request instead of predicting it. Both
+			// listeners are set up before triggering the upload so neither can
+			// fire and resolve before we start waiting for it.
+			const waitForUpload = page.waitForResponse(
+				(response) =>
+					response.url().includes("/storage/v1/object/documents/") &&
+					response.request().method() === "POST",
 			);
-
-			const { error: sessionError } = await localAnonClient.auth.setSession({
-				access_token: session.access_token,
-				refresh_token: session.refresh_token,
-			});
-
-			expect(sessionError).toBeNull();
-
-			const { error: uploadError } = await localAnonClient.storage
-				.from("documents")
-				.upload(givenStoragePath, givenFile);
-
-			// Use scope local to avoid revoking the current access_token globally
-			await localAnonClient.auth.signOut({ scope: "local" });
-
-			expect(uploadError).toBeNull();
-
-			const { data: exists1, error: existsError1 } =
-				await supabaseAdminClient.storage
-					.from(defaultBucketName)
-					.exists(givenStoragePath);
-
-			expect(existsError1).toBeNull();
-			expect(exists1).toBe(true);
-
 			const waitForDeletion = page.waitForResponse(
 				(response) =>
 					response.url().includes("/storage/v1/object/documents") &&
@@ -201,20 +179,55 @@ test.describe("Documents", () => {
 				uploadButtonName: "Datei hochladen",
 			});
 
+			const uploadResponse = await waitForUpload;
+			const uploadedPath = decodeURIComponent(
+				uploadResponse.url().split("/storage/v1/object/documents/")[1],
+			);
+
 			await waitForDeletion;
 
-			const { data: exists2, error: existsError2 } =
+			const { data: exists, error: existsError } =
 				await supabaseAdminClient.storage
 					.from(defaultBucketName)
-					.exists(givenStoragePath);
+					.exists(uploadedPath);
 
 			/**
 			 * If the file does not exist, supabase returns false + an error:
 			 * https://github.com/supabase/supabase-js/issues/1363
 			 * So we expect an error to be defined, but we also expect exists to be false.
 			 */
-			expect(existsError2).toBeDefined();
-			expect(exists2).toBe(false);
+			expect(existsError).toBeDefined();
+			expect(exists).toBe(false);
+		},
+	);
+
+	testDesktopOnly(
+		"Should reject uploading a file with a name that already exists",
+		async ({ page, browserName }) => {
+			await uploadFileViaFileChooserAndWait({
+				page,
+				fileName: secondaryDocumentName,
+				filePath: secondaryDocumentPath,
+				browserName,
+				uploadButtonName: "Datei hochladen",
+			});
+
+			await attemptFileUploadViaFileChooser({
+				page,
+				filePath: secondaryDocumentPath,
+				browserName,
+				uploadButtonName: "Datei hochladen",
+			});
+
+			await expect(
+				page
+					.locator("#desktop-documents-panel")
+					.getByText(`${secondaryDocumentName}Datei existiert bereits`, {
+						exact: true,
+					}),
+			).toBeVisible();
+
+			await deleteFileViaUI({ page, fileName: secondaryDocumentName });
 		},
 	);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Document processing now preserves the original uploaded filename for clearer document records.
  * File uploads use safer unique storage names while retaining the original file extension.
  * Upload status handling provides more reliable results when storage or document creation encounters an error.

* **Bug Fixes**
  * Duplicate filenames are detected and rejected with a clear message.
  * Failed processing no longer leaves behind uploaded files when cleanup is appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216523425320959