### PR TITLE
fix: block chat submit while an attached document is still processing

### DIFF
--- a/apps/frontend/src/components/chat/chat-form/chat-form.tsx
+++ b/apps/frontend/src/components/chat/chat-form/chat-form.tsx
@@ -12,6 +12,7 @@ import { ChatStopGeneratingIcon } from "../../primitives/icons/chat-stop-generat
 import { useChatStreamingStore } from "../../../store/use-chat-streaming-store.ts";
 import { useUserFolderStore } from "../../../store/use-user-folder-store.ts";
 import { useUserDocumentStore } from "../../../store/use-user-document-store.ts";
+import { useFileUploadsStore } from "../../../store/use-file-uploads-store.ts";
 import Content from "../../../content.ts";
 import type { NewChatMessage } from "../../../common.ts";
 import { getCompletion } from "../../../api/chat/get-completion.ts";
@@ -38,6 +39,7 @@ export const ChatForm: React.FC = () => {
 		useChatsStore();
 	const { showInfoMessage } = useChatsStore.getState();
 	const { abortStreaming } = useChatStreamingStore.getState();
+	const { isUploadingOver } = useFileUploadsStore();
 
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const [textareaContent, setTextareaContent] = useState("");
@@ -60,7 +62,9 @@ export const ChatForm: React.FC = () => {
 		}
 
 		const isSubmitEnabled =
-			!isLoading() && event.currentTarget.value.trim().length > 0;
+			!isLoading() &&
+			isUploadingOver() &&
+			event.currentTarget.value.trim().length > 0;
 		if (isEnterWithoutShiftPressed && isSubmitEnabled) {
 			event.currentTarget.form?.requestSubmit();
 		}
@@ -223,7 +227,7 @@ export const ChatForm: React.FC = () => {
 						) : (
 							<button
 								type="submit"
-								disabled={!textareaContent.trim()}
+								disabled={!textareaContent.trim() || !isUploadingOver()}
 								aria-label={Content["chat.sendButton.ariaLabel"]}
 								className={`rounded-3px size-8 bg-dunkelblau-100 disabled:bg-dunkelblau-30 p-1.5 hover:bg-dunkelblau-90 focus-visible:outline-2px`}
 							>

--- a/apps/frontend/src/store/use-file-uploads-store.ts
+++ b/apps/frontend/src/store/use-file-uploads-store.ts
@@ -63,8 +63,10 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 			useUserDocumentStore.getState();
 
 		const uploadFileSizeLimit = import.meta.env.VITE_UPLOAD_FILE_SIZE_LIMIT_MB;
-		const slugifiedFilename = slugify(file.name, { lower: true });
-		const filePath = `${session?.user.id}/${slugifiedFilename}`;
+		const fileExtension = file.name.split(".").pop();
+		const filePath = `${session?.user.id}/${crypto.randomUUID()}.${fileExtension}`;
+		let storageUploadSucceeded = false;
+		let documentCreated = false;
 		try {
 			if (file.size > uploadFileSizeLimit * 1024 * 1024) {
 				throw new Error("failed.size");
@@ -97,6 +99,7 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 
 			updateFileUploadStatus(file, "processing");
 			await processDocument(file, filePath);
+			documentCreated = true;
 
 			await getUserDocuments(new AbortController().signal);
 

--- a/apps/frontend/src/store/use-file-uploads-store.ts
+++ b/apps/frontend/src/store/use-file-uploads-store.ts
@@ -63,10 +63,8 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 			useUserDocumentStore.getState();
 
 		const uploadFileSizeLimit = import.meta.env.VITE_UPLOAD_FILE_SIZE_LIMIT_MB;
-		const fileExtension = file.name.split(".").pop();
-		const filePath = `${session?.user.id}/${crypto.randomUUID()}.${fileExtension}`;
-		let storageUploadSucceeded = false;
-		let documentCreated = false;
+		const slugifiedFilename = slugify(file.name, { lower: true });
+		const filePath = `${session?.user.id}/${slugifiedFilename}`;
 		try {
 			if (file.size > uploadFileSizeLimit * 1024 * 1024) {
 				throw new Error("failed.size");
@@ -99,12 +97,6 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 
 			updateFileUploadStatus(file, "processing");
 			await processDocument(file, filePath);
-			documentCreated = true;
-			updateFileUploadStatus(file, "successful");
-
-			setTimeout(() => {
-				get().removeFileUpload(file.name);
-			}, SUCCESSFUL_UPLOAD_REMOVAL_DELAY_MS);
 
 			await getUserDocuments(new AbortController().signal);
 
@@ -117,6 +109,12 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 					selectUserChatDocument(uploadedDocument);
 				}
 			}
+
+			updateFileUploadStatus(file, "successful");
+
+			setTimeout(() => {
+				get().removeFileUpload(file.name);
+			}, SUCCESSFUL_UPLOAD_REMOVAL_DELAY_MS);
 		} catch (error) {
 			useErrorStore.getState().handleError(error, span);
 

--- a/apps/frontend/tests/e2e/chat.spec.ts
+++ b/apps/frontend/tests/e2e/chat.spec.ts
@@ -1,5 +1,6 @@
 import { Readable } from "node:stream";
 import {
+	mockDocumentProcessing,
 	mockDocumentUpload,
 	uploadFileViaDragAndDropAndWait,
 } from "../fixtures/test-with-documents.ts";
@@ -177,6 +178,81 @@ test.describe("Chat", () => {
 		const answer = page.getByTestId("assistant-message-markdown-container");
 		await expect(answer).not.toBeEmpty();
 	});
+
+	testDesktopOnly(
+		"Chat submit is disabled while a newly attached document is still processing",
+		async ({ page, account }) => {
+			await page.goto("/");
+			await page.waitForLoadState("networkidle");
+
+			// Hold /documents/process open so we can control exactly when processing "finishes",
+			// and capture the real (randomUUID-based) source_url the client generated for this upload.
+			let releaseProcessing: (() => void) | undefined;
+			let capturedSourceUrl: string | undefined;
+			await page.route("**/documents/process", async (route) => {
+				const body = route.request().postDataJSON();
+				capturedSourceUrl = body.document.source_url;
+				await new Promise<void>((resolve) => {
+					releaseProcessing = resolve;
+				});
+				await route.fulfill({ status: 204 });
+			});
+
+			// Attach a brand-new file via the chat input's own "+" menu,
+			// the same path a user takes when attaching a document directly to a message.
+			await page
+				.getByRole("button", { name: "Weitere Funktionen aktivieren" })
+				.click();
+			await page
+				.locator("#chat-form input[type='file']")
+				.setInputFiles(secondaryDocumentPath);
+
+			// Wait until the upload is in flight (storage upload done, /documents/process held)
+			await expect
+				.poll(() => releaseProcessing !== undefined, { timeout: 15_000 })
+				.toBe(true);
+
+			const chatInput = page.getByPlaceholder("Stellen Sie eine Frage");
+			await chatInput.fill("Worum geht es?");
+
+			const sendButton = page.getByRole("button", { name: "Nachricht senden" });
+
+			// Submit must be blocked while the document is still processing
+			await expect(sendButton).toBeDisabled();
+
+			await chatInput.press("Enter");
+			await expect(
+				page.getByTestId("user-message-markdown-container"),
+			).not.toBeVisible();
+
+			// Simulate the backend finishing processing (insert matching document rows),
+			// then let the held /documents/process request resolve.
+			if (!capturedSourceUrl) {
+				throw new Error("capturedSourceUrl was not set by the route handler");
+			}
+			await mockDocumentProcessing({
+				userId: account.id,
+				sourceUrl: capturedSourceUrl,
+				accessGroupId: null,
+				fileName: secondaryDocumentName,
+				sourceType: "personal_document",
+			});
+			releaseProcessing?.();
+
+			// Once processing settles, the document is auto-selected into the chat
+			await expect(
+				page.getByTestId(`remove-item-${secondaryDocumentName}`),
+			).toBeVisible();
+
+			// Submit is unblocked again
+			await expect(sendButton).toBeEnabled();
+
+			await sendAndWaitForLLMResponse(page);
+			await expect(
+				page.getByTestId("user-message-markdown-container"),
+			).toBeVisible();
+		},
+	);
 
 	testDesktopOnly(
 		"Add document and user folder to chat via dropdown",


### PR DESCRIPTION
Users could hit send before a freshly attached file finished uploading/processing, so the message went out with an empty allowed_document_ids and the LLM had no document context. Gate the submit button and Enter-to-submit on isUploadingOver() so sending is blocked until any in-flight upload settles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat messages can no longer be submitted while attached documents are processing.
  * Enter-key submission and the send button remain disabled until uploads finish and a non-empty message is entered.
  * Completed documents are automatically selected after processing, allowing chat submission to proceed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217233037774236