### PR TITLE
fix: add otp rate limit

### DIFF
--- a/apps/backend/src/integration/product-dashboard.test.ts
+++ b/apps/backend/src/integration/product-dashboard.test.ts
@@ -303,6 +303,86 @@ describe("get_product_dashboard_stats", () => {
 	});
 });
 
+// These SECURITY DEFINER helpers write directly to auth.users and have no
+// internal authorization guard, so their only protection is that EXECUTE is
+// revoked from every role except service_role.
+describe("auth.users helper functions are restricted to the service role", () => {
+	const givenUserId = crypto.randomUUID();
+	const givenUserEmail = "user-test-suite-auth-helpers@ts.berlin";
+	const givenUserPassword = "SecurePassword123!";
+	const givenTimestamp = subDays(new Date(), 5).toISOString();
+
+	const anonDbClient = createClient<Database>(
+		config.supabaseUrl,
+		config.supabaseAnonKey,
+	);
+	const authenticatedDbClient = createClient<Database>(
+		config.supabaseUrl,
+		config.supabaseAnonKey,
+	);
+
+	const helperFunctions = [
+		{
+			name: "update_user_email_confirmed_at",
+			args: {
+				user_id: givenUserId,
+				new_email_confirmed_at: givenTimestamp,
+			},
+		},
+		{
+			name: "update_user_last_sign_in_at",
+			args: {
+				user_id: givenUserId,
+				new_last_sign_in_at: givenTimestamp,
+			},
+		},
+	] as const;
+
+	beforeAll(async () => {
+		await registerNonAdminUser({
+			id: givenUserId,
+			email: givenUserEmail,
+			password: givenUserPassword,
+		});
+
+		const { error } = await authenticatedDbClient.auth.signInWithPassword({
+			email: givenUserEmail,
+			password: givenUserPassword,
+		});
+		expect(error).toBeNull();
+	}, TIMEOUT);
+
+	afterAll(async () => {
+		const { error } =
+			await serviceRoleDbClient.auth.admin.deleteUser(givenUserId);
+		expect(error).toBeNull();
+	}, TIMEOUT);
+
+	describe.each(helperFunctions)("$name", ({ name, args }) => {
+		it("rejects the anonymous role with permission denied", async () => {
+			const { error } = await anonDbClient.rpc(name, args);
+
+			expect(error).not.toBeNull();
+			expect(error?.code).toBe("42501");
+			expect(error?.message).toContain("permission denied");
+		});
+
+		it("rejects the authenticated role with permission denied", async () => {
+			const { error } = await authenticatedDbClient.rpc(name, args);
+
+			expect(error).not.toBeNull();
+			expect(error?.code).toBe("42501");
+			expect(error?.message).toContain("permission denied");
+		});
+
+		it("allows the service role to execute the function", async () => {
+			const { error } = await serviceRoleDbClient.rpc(name, args);
+
+			expect(error).toBeNull();
+		});
+	});
+});
+
 async function registerAdmin(params: {
 	id: string;
 	email: string;

--- a/apps/backend/supabase/migrations/20260813120949_revoke_execute.sql
+++ b/apps/backend/supabase/migrations/20260813120949_revoke_execute.sql
@@ -1,0 +1,9 @@
+REVOKE
+EXECUTE ON FUNCTION update_user_email_confirmed_at (UUID, TIMESTAMPTZ)
+FROM
+    anon;
+
+REVOKE
+EXECUTE ON FUNCTION update_user_last_sign_in_at (UUID, TIMESTAMPTZ)
+FROM
+    anon;

--- a/infra/ansible/roles/supabase/tasks/main.yml
+++ b/infra/ansible/roles/supabase/tasks/main.yml
@@ -49,6 +49,22 @@
       delegate_to: localhost
       become: false
 
+# The .env is rendered fresh from 1Password on every run, so these GoTrue
+# hardening overrides are (re)applied here to guarantee they are present.
+# docker-compose.yml already carries safe defaults (:-5 / :-3600); these lines
+# make the intended values explicit and tunable without a code change.
+- name: Ensure GoTrue OTP hardening vars in .env
+  ansible.builtin.lineinfile:
+    path: "{{ supabase_dir }}/.env"
+    regexp: "^{{ item.key }}="
+    line: "{{ item.key }}={{ item.value }}"
+    state: present
+  loop:
+    - { key: "GOTRUE_MAILER_OTP_EXP", value: "3600" } # 60 min instead of 24h
+    - { key: "GOTRUE_RATE_LIMIT_VERIFY", value: "5" } # low; only meaningful once RATE_LIMIT_HEADER is set
+  loop_control:
+    label: "{{ item.key }}"
+
 - name: Upload otel-collector config
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/../supabase/otel-config.yml"

--- a/infra/supabase/docker-compose.yml
+++ b/infra/supabase/docker-compose.yml
@@ -163,6 +163,11 @@ services:
       GOTRUE_EXTERNAL_PHONE_ENABLED: ${ENABLE_PHONE_SIGNUP}
       GOTRUE_SMS_AUTOCONFIRM: ${ENABLE_PHONE_AUTOCONFIRM}
       GOTRUE_RATE_LIMIT_EMAIL_SENT: 10000
+      # Rate-limit the OTP/verify endpoint. GoTrue only enforces the verify
+      # limiter when it can identify the client, which requires RATE_LIMIT_HEADER.
+      GOTRUE_RATE_LIMIT_HEADER: X-Forwarded-For
+      GOTRUE_RATE_LIMIT_VERIFY: ${GOTRUE_RATE_LIMIT_VERIFY}
+      GOTRUE_MAILER_OTP_EXP: ${GOTRUE_MAILER_OTP_EXP}
       # Uncomment to enable custom access token hook. Please see: https://supabase.com/docs/guides/auth/auth-hooks for full list of hooks and additional details about custom_access_token_hook
 
       # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED: "true"
@@ -447,8 +452,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXP: ${JWT_EXPIRY}
-    command:
-      [
+    command: [
         "postgres",
         "-c",
         "config_file=/etc/postgresql/postgresql.conf",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Improved one-time password verification protection with configurable rate limiting.
  * Added support for proxy-aware request tracking when applying verification limits.
  * Configured OTP codes to expire after a defined period, defaulting to one hour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->