### PR TITLE
feat: add local target assertions for scripts and tests

### DIFF
--- a/apps/admin-panel/tests/config.ts
+++ b/apps/admin-panel/tests/config.ts
@@ -14,6 +14,28 @@ export function verifyConfig() {
 	if (!process.env.VITE_SUPABASE_ANON_KEY) {
 		throw new Error("VITE_SUPABASE_ANON_KEY must be defined");
 	}
+
+	assertLocalTarget();
+}
+
+function assertLocalTarget() {
+	const supabaseUrl = process.env.VITE_SUPABASE_URL || "";
+
+	let host: string;
+	try {
+		host = new URL(supabaseUrl).hostname;
+	} catch {
+		throw new Error(`VITE_SUPABASE_URL is not a valid URL: "${supabaseUrl}"`);
+	}
+
+	const localHosts = ["localhost", "127.0.0.1", "0.0.0.0", "::1"];
+	if (!localHosts.includes(host)) {
+		throw new Error(
+			`Refusing to run e2e tests: VITE_SUPABASE_URL points to a non-local target ("${supabaseUrl}"). ` +
+				`These tests seed and mutate data and are only meant to run against a local Supabase instance. ` +
+				`Check your environment variables — they may be pointing at staging/production.`,
+		);
+	}
 }
 
 export const config: Config = {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -17,7 +17,7 @@
 		"prettier:write": "prettier --write src supabase",
 		"db:reset": "supabase db reset && npm run db:typegen && npm run db:upload-default-documents && npm run db:localseed",
 		"db:typegen": "supabase gen types --lang typescript --local > ../../libs/db-schema/index.ts && prettier --write ../../libs/db-schema/index.ts && ESLINT_USE_FLAT_CONFIG=true eslint --fix ../../libs/db-schema/index.ts",
-		"db:localseed": "tsx ./supabase/local-seed.ts",
+		"db:localseed": "tsx supabase/scripts/local-seed.ts",
 		"db:upload-default-documents": "tsx ./supabase/scripts/upload-default-documents.ts",
 		"db:backfill-mistral": "tsx ./supabase/backfill-mistral-embeddings.ts",
 		"db:up": "supabase migration up --local && npm run db:typegen",

--- a/apps/backend/src/integration/setup.ts
+++ b/apps/backend/src/integration/setup.ts
@@ -1,9 +1,35 @@
 import { serve, type ServerType } from "@hono/node-server";
 import app from "../index";
+import { config } from "../config";
 
 let server: ServerType | null = null;
 
+function assertLocalTarget() {
+	let host: string;
+	try {
+		host = new URL(config.supabaseUrl).hostname;
+	} catch {
+		throw new Error(`SUPABASE_URL is not a valid URL: "${config.supabaseUrl}"`);
+	}
+
+	const localHosts = ["localhost", "127.0.0.1", "0.0.0.0", "::1"];
+	if (!localHosts.includes(host)) {
+		throw new Error(
+			`Refusing to run integration tests: SUPABASE_URL points to a non-local target ("${config.supabaseUrl}"). ` +
+				`These tests seed and mutate data and are only meant to run against a local Supabase instance. ` +
+				`Check your environment variables — they may be pointing at staging/production.`,
+		);
+	}
+
+	/* eslint-disable-next-line no-console */
+	console.log(
+		`Running integration tests against local Supabase at ${config.supabaseUrl}`,
+	);
+}
+
 export async function setup() {
+	assertLocalTarget();
+
 	if (server) {
 		return;
 	}

--- a/apps/backend/supabase/scripts/local-seed.ts
+++ b/apps/backend/supabase/scripts/local-seed.ts
@@ -1,7 +1,31 @@
-import { serviceRoleDbClient as supabase } from "../src/supabase";
+import { serviceRoleDbClient as supabase } from "../../src/supabase";
 import type { User } from "@supabase/supabase-js";
+import { config } from "../../src/config";
+
+function assertLocalTarget() {
+	let host: string;
+	try {
+		host = new URL(config.supabaseUrl).hostname;
+	} catch {
+		throw new Error(`SUPABASE_URL is not a valid URL: "${config.supabaseUrl}"`);
+	}
+
+	const localHosts = ["localhost", "127.0.0.1", "0.0.0.0", "::1"];
+	if (!localHosts.includes(host)) {
+		throw new Error(
+			`Refusing to seed: SUPABASE_URL points to a non-local target ("${config.supabaseUrl}"). ` +
+				`This script is only meant to run against a local Supabase instance. ` +
+				`Check your environment variables — they may be pointing at staging/production.`,
+		);
+	}
+
+	/* eslint-disable-next-line no-console */
+	console.log(`Seeding admin for local Supabase at ${config.supabaseUrl}`);
+}
 
 export async function seedLocalAdmin() {
+	assertLocalTarget();
+
 	const id = crypto.randomUUID();
 	const email = "local.admin@ts.berlin";
 	const password = "123456789!";

--- a/apps/backend/supabase/scripts/upload-default-documents.ts
+++ b/apps/backend/supabase/scripts/upload-default-documents.ts
@@ -13,6 +13,36 @@ const sourceType = "default_document";
 const bucketName = "public_documents";
 const defaultDocumentsDir = resolve(process.cwd(), "./src/default_documents");
 
+function assertTargetAllowed(): void {
+	let host: string;
+	try {
+		host = new URL(config.supabaseUrl).hostname;
+	} catch {
+		throw new Error(`SUPABASE_URL is not a valid URL: "${config.supabaseUrl}"`);
+	}
+
+	const localHosts = ["localhost", "127.0.0.1", "0.0.0.0", "::1"];
+	if (localHosts.includes(host)) {
+		console.log(
+			`Uploading default documents to local Supabase at ${config.supabaseUrl}`,
+		);
+		return;
+	}
+
+	if (process.env.ALLOW_REMOTE_UPLOAD !== "true") {
+		throw new Error(
+			`Refusing to upload: SUPABASE_URL points to a non-local target ("${config.supabaseUrl}"). ` +
+				`Your environment variables may be pointing at staging/production. ` +
+				`If this is intentional, re-run with ALLOW_REMOTE_UPLOAD=true.`,
+		);
+	}
+
+	console.warn(
+		`⚠️  Uploading default documents to a NON-LOCAL target ("${config.supabaseUrl}") ` +
+			`because ALLOW_REMOTE_UPLOAD=true was set.`,
+	);
+}
+
 // eslint-disable-next-line consistent-return
 async function getPdfFiles(): Promise<string[]> {
 	try {
@@ -163,6 +193,8 @@ async function processDocument(
 
 async function uploadDefaultDocument() {
 	try {
+		assertTargetAllowed();
+
 		const pdfFiles = await getPdfFiles();
 
 		if (pdfFiles.length === 0) {

--- a/apps/frontend/tests/config.ts
+++ b/apps/frontend/tests/config.ts
@@ -14,6 +14,28 @@ export function verifyConfig() {
 	if (!process.env.VITE_SUPABASE_ANON_KEY) {
 		throw new Error("VITE_SUPABASE_ANON_KEY must be defined");
 	}
+
+	assertLocalTarget();
+}
+
+function assertLocalTarget() {
+	const supabaseUrl = process.env.VITE_SUPABASE_URL || "";
+
+	let host: string;
+	try {
+		host = new URL(supabaseUrl).hostname;
+	} catch {
+		throw new Error(`VITE_SUPABASE_URL is not a valid URL: "${supabaseUrl}"`);
+	}
+
+	const localHosts = ["localhost", "127.0.0.1", "0.0.0.0", "::1"];
+	if (!localHosts.includes(host)) {
+		throw new Error(
+			`Refusing to run e2e tests: VITE_SUPABASE_URL points to a non-local target ("${supabaseUrl}"). ` +
+				`These tests seed and mutate data and are only meant to run against a local Supabase instance. ` +
+				`Check your environment variables — they may be pointing at staging/production.`,
+		);
+	}
 }
 
 export const config: Config = {


### PR DESCRIPTION
I ran the scripts with the wrong env variable by accident which created admins in staging/prod. I deleted those users. But I think it would be safer to add target assertions for the future. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety for local database seeding by validating the configured Supabase target.
  * Prevented default document uploads to remote environments unless explicitly enabled.
  * Added warnings when remote uploads are intentionally permitted.
  * Added configuration checks to prevent tests and integration setup from running against non-local or invalid Supabase targets.
  * Updated the local seed command to use the correct script location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->