### PR TITLE
feat: move upload to storage to backend and use SSE to update status

### DIFF
--- a/apps/admin-panel/src/api/documents/upload-file.ts
+++ b/apps/admin-panel/src/api/documents/upload-file.ts
@@ -95,8 +95,6 @@ export async function uploadAndProcessDocument(
 				if (status.startsWith("failed")) {
 					throw new Error(status);
 				}
-
-				updateFileUploadStatusCallback(event.status);
 			}
 		}
 	} finally {

--- a/apps/admin-panel/src/api/documents/upload-file.ts
+++ b/apps/admin-panel/src/api/documents/upload-file.ts
@@ -64,14 +64,15 @@ export async function uploadAndProcessDocument(
 
 			buffer += decoder.decode(value, { stream: true });
 			const lines = buffer.split("\n");
-			buffer = lines.pop() ?? ""; // last line may be incomplete — keep i
+			buffer = lines.pop() ?? "";
 
 			for (const line of lines) {
-				if (!line.startsWith("data: ")) {
+				const prefix = "data: ";
+				if (!line.startsWith(prefix)) {
 					continue;
 				}
 
-				const payload = line.slice(6).trim();
+				const payload = line.slice(prefix.length).trim();
 				if (!payload) {
 					continue;
 				}

--- a/apps/admin-panel/src/api/documents/upload-file.ts
+++ b/apps/admin-panel/src/api/documents/upload-file.ts
@@ -1,72 +1,39 @@
-import { useAuthStore } from "../../store/use-auth-store";
+import { useAuthStore } from "@/store/use-auth-store";
 import { useAccessGroupStore } from "@/store/use-access-group-store";
-import { supabase } from "../../../supabase-client";
-import { StorageApiError } from "@supabase/storage-js";
+import type { UploadStatusKeys } from "@/store/use-upload-document-store.ts";
+import { UPLOAD_STATUS_MAP } from "baergpt-frontend/src/store/use-file-uploads-store.ts";
 
-/**
- * Uploads the provided file directly to Supabase Storage in the "public_documents" bucket.
- * @param file The file to upload.
- * @param filePath The path (including filename) where the file will be stored in Supabase Storage.
- */
-export async function uploadFileToDb(
+export async function uploadAndProcessDocument(
 	file: File,
-	filePath: string,
-): Promise<void> {
-	try {
-		const { error: uploadError } = await supabase.storage
-			.from("public_documents")
-			.upload(filePath, file);
-
-		if (uploadError) {
-			console.error("Storage upload error:", uploadError);
-			throw uploadError;
-		}
-	} catch (error) {
-		if (error instanceof StorageApiError && error.status === 409) {
-			throw new Error("failed.duplicate");
-		} else {
-			throw new Error("failed.generic");
-		}
-	}
-}
-
-/**
- * Processes the uploaded document via the /documents/process endpoint.
- */
-export async function processDocument(
-	file: File,
-	filePath: string,
+	updateFileUploadStatusCallback: (status: UploadStatusKeys) => void,
 ): Promise<void> {
 	const { session } = useAuthStore.getState();
-	const access_group_id = useAccessGroupStore.getState().accessGroupId;
+	const { accessGroupId } = useAccessGroupStore.getState();
+
 	// Create document metadata
 	const documentData = {
 		document: {
-			id: null,
-			folder_id: null,
-			owned_by_user_id: null,
-			created_at: new Date().toISOString(),
-			source_type: "public_document",
-			source_url: filePath,
-			access_group_id: access_group_id,
-			uploaded_by_user_id: session?.user.id,
-			metadata: {
-				mimeType: file.type,
-				size: file.size,
-			},
+			folderId: null,
+			sourceType: "public_document",
+			accessGroupId,
 		},
-		llm_model: import.meta.env.VITE_DEFAULT_DOCUMENT_PROCESSING_MODEL,
+		llmModel: import.meta.env.VITE_DEFAULT_DOCUMENT_PROCESSING_MODEL,
 	};
+
+	const form = new FormData();
+	form.append("file", file);
+	form.append("metadata", JSON.stringify(documentData));
+
+	updateFileUploadStatusCallback("uploading");
 
 	const url = `${import.meta.env.VITE_API_URL}/documents/process`;
 
 	const response = await fetch(url, {
 		method: "POST",
 		headers: {
-			"Content-Type": "application/json",
 			Authorization: `Bearer ${session?.access_token}`,
 		},
-		body: JSON.stringify(documentData),
+		body: form,
 	});
 
 	if (!response.ok) {
@@ -74,11 +41,64 @@ export async function processDocument(
 			.json()
 			.catch(() => ({ message: "Unknown error" }));
 
-		if (response.status === 409) {
-			throw new Error("failed.duplicate");
-		}
+		throw new Error(
+			`Document processing failed: ${JSON.stringify(errorResponse)}`,
+		);
+	}
 
-		console.error("Document processing failed:", errorResponse);
-		throw new Error("failed.generic");
+	if (!response.body) {
+		throw new Error("Document processing response has no body");
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+
+			if (done) {
+				break;
+			}
+
+			buffer += decoder.decode(value, { stream: true });
+			const lines = buffer.split("\n");
+			buffer = lines.pop() ?? ""; // last line may be incomplete — keep i
+
+			for (const line of lines) {
+				if (!line.startsWith("data: ")) {
+					continue;
+				}
+
+				const payload = line.slice(6).trim();
+				if (!payload) {
+					continue;
+				}
+
+				let event;
+				try {
+					event = JSON.parse(payload);
+				} catch {
+					continue; // ignore anything unparseable
+				}
+
+				const status: unknown = event?.status;
+
+				if (typeof status !== "string" || !(status in UPLOAD_STATUS_MAP)) {
+					continue;
+				}
+
+				updateFileUploadStatusCallback(status as UploadStatusKeys);
+
+				if (status.startsWith("failed")) {
+					throw new Error(status);
+				}
+
+				updateFileUploadStatusCallback(event.status);
+			}
+		}
+	} finally {
+		reader.cancel().catch((error) => console.error(error));
 	}
 }

--- a/apps/admin-panel/src/store/use-upload-document-store.ts
+++ b/apps/admin-panel/src/store/use-upload-document-store.ts
@@ -1,22 +1,16 @@
 import { create } from "zustand";
 import { useDocumentStore } from "./use-document-store.ts";
-import slugify from "slugify";
-
-import {
-	uploadFileToDb,
-	processDocument,
-} from "../api/documents/upload-file.ts";
-import { useAccessGroupStore } from "./use-access-group-store.ts";
+import { uploadAndProcessDocument } from "@/api/documents/upload-file.ts";
 
 export const UPLOAD_STATUS_MAP = {
 	uploading: "wird hochgeladen",
 	uploaded: "erfolgreich hochgeladen",
 	processing: "wird verarbeitet",
-	successful: "erfolgreich verarbeitet",
+	successful: "bereit zur Nutzung",
 	canceled: "hochladen abgebrochen",
 	"failed.generic": "hochladen fehlgeschlagen",
 	"failed.duplicate": "Datei existiert bereits",
-	"failed.format": "Ungültiges Dateiformat (nur PDF, Word oder Excel)",
+	"failed.format": "Ungültiges Dateiformat (nur PDF, Word, Excel oder CSV)",
 	"failed.size": `Datei zu groß (max. ${import.meta.env.VITE_UPLOAD_FILE_SIZE_LIMIT_MB} MB)`,
 } as const;
 
@@ -46,35 +40,37 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 
 	async uploadFile({ file }: FileUpload) {
 		const { updateFileUploadStatus } = get();
-		const access_group_id = useAccessGroupStore.getState().accessGroupId;
 		const { documents, getDocuments, deleteDocument } =
 			useDocumentStore.getState();
 
 		const uploadFileSizeLimit = import.meta.env.VITE_UPLOAD_FILE_SIZE_LIMIT_MB;
-		const slugifiedFilename = slugify(file.name, { lower: true });
-		const filePath = `${access_group_id}/${slugifiedFilename}`;
 
 		try {
 			if (file.size > uploadFileSizeLimit * 1024 * 1024) {
 				throw new Error("failed.size");
 			}
 
-			const fileExists = documents.some((doc) => doc.source_url === filePath);
+			const fileExists = documents.some((doc) => doc.file_name === file.name);
 			if (fileExists) {
 				throw new Error("failed.duplicate");
 			}
 
-			if (!file.type.includes("pdf")) {
+			if (
+				!file.type.includes("pdf") &&
+				!file.type.includes(
+					"vnd.openxmlformats-officedocument.wordprocessingml.document",
+				) &&
+				!file.type.includes(
+					"vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+				) &&
+				!file.type.includes("csv")
+			) {
 				throw new Error("failed.format");
 			}
 
-			updateFileUploadStatus(file, "uploading");
-			await uploadFileToDb(file, filePath);
-			updateFileUploadStatus(file, "uploaded");
-
-			updateFileUploadStatus(file, "processing");
-			await processDocument(file, filePath);
-			updateFileUploadStatus(file, "successful");
+			await uploadAndProcessDocument(file, (status) =>
+				updateFileUploadStatus(file, status),
+			);
 
 			getDocuments(new AbortController().signal).catch(console.error);
 		} catch (error) {
@@ -87,7 +83,7 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 			updateFileUploadStatus(file, "failed.generic");
 			// If the document processing fails, remove the document from the store
 			const documentToDelete = documents.find(
-				(doc) => doc.source_url === filePath,
+				(doc) => doc.file_name === file.name,
 			);
 			if (documentToDelete) {
 				await deleteDocument(documentToDelete.id);

--- a/apps/admin-panel/src/store/use-upload-document-store.ts
+++ b/apps/admin-panel/src/store/use-upload-document-store.ts
@@ -4,7 +4,6 @@ import { uploadAndProcessDocument } from "@/api/documents/upload-file.ts";
 
 export const UPLOAD_STATUS_MAP = {
 	uploading: "wird hochgeladen",
-	uploaded: "erfolgreich hochgeladen",
 	processing: "wird verarbeitet",
 	successful: "bereit zur Nutzung",
 	canceled: "hochladen abgebrochen",
@@ -111,9 +110,7 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 		const { fileUploads } = get();
 		return fileUploads.every(
 			(fileUpload) =>
-				fileUpload.status !== "uploading" &&
-				fileUpload.status !== "processing" &&
-				fileUpload.status !== "uploaded",
+				fileUpload.status !== "uploading" && fileUpload.status !== "processing",
 		);
 	},
 

--- a/apps/backend/src/integration/default-document.integration.test.ts
+++ b/apps/backend/src/integration/default-document.integration.test.ts
@@ -13,7 +13,7 @@ const DEFAULT_DOCUMENT_SOURCE_TYPE = "default_document";
 const PUBLIC_DOCUMENTS_BUCKET = "public_documents";
 
 // Mocked processing outputs so the test exercises real storage + DB writes
-// without hitting the (flaky) Mistral OCR / summary / embedding APIs. The chunk
+// without hitting the (flaky) API OCR / LLM / embedding APIs. The chunk
 // embedding must match the vector(1024) column, or the real insert fails.
 const MOCK_EXTRACTION_RESULT = {
 	parsedPages: [{ content: "page content", tokenCount: 10, pageNumber: 1 }],

--- a/apps/backend/src/integration/default-document.integration.test.ts
+++ b/apps/backend/src/integration/default-document.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { config } from "../config";
@@ -11,6 +11,29 @@ import { serviceRoleDbClient } from "../supabase";
 const DEFAULT_DOCUMENT_FILE_NAME = "BaerGPT-Handbuch.pdf";
 const DEFAULT_DOCUMENT_SOURCE_TYPE = "default_document";
 const PUBLIC_DOCUMENTS_BUCKET = "public_documents";
+
+// Mocked processing outputs so the test exercises real storage + DB writes
+// without hitting the (flaky) Mistral OCR / summary / embedding APIs. The chunk
+// embedding must match the vector(1024) column, or the real insert fails.
+const MOCK_EXTRACTION_RESULT = {
+	parsedPages: [{ content: "page content", tokenCount: 10, pageNumber: 1 }],
+	checksum: "test-checksum",
+	fileSize: 1234,
+	numPages: 1,
+};
+const MOCK_SUMMARY_DATA = {
+	summary: "A summary",
+	shortSummary: "Short",
+	tags: ["tag"],
+};
+const MOCK_EMBEDDINGS = [
+	{
+		content: "chunk",
+		embedding: new Array(config.mistralEmbeddingDimensions).fill(0),
+		chunkIndex: 0,
+		page: 1,
+	},
+];
 
 const cleanupDefaultDocuments = async (accessGroupId: string) => {
 	try {
@@ -92,11 +115,25 @@ describe("Default Document Integration Tests", () => {
 	});
 
 	afterAll(async () => {
+		vi.restoreAllMocks();
 		// Run cleanup after all tests
 		await cleanupDefaultDocuments(accessGroupId);
 	});
 
 	it("should upload and process default document with correct properties", async () => {
+		// Mock the expensive/flaky processing steps; logProcessedDocument still
+		// runs for real so the DB assertions below (and in the next test) hold.
+		vi.spyOn(
+			PrivilegedDbService.prototype,
+			"extractDocument",
+		).mockResolvedValue(MOCK_EXTRACTION_RESULT as never);
+		vi.spyOn(GenerationService.prototype, "summarize").mockResolvedValue(
+			MOCK_SUMMARY_DATA as never,
+		);
+		vi.spyOn(EmbeddingService.prototype, "batchEmbed").mockResolvedValue(
+			MOCK_EMBEDDINGS as never,
+		);
+
 		// Read file from disk
 		const filePath = resolve(
 			process.cwd(),
@@ -135,7 +172,7 @@ describe("Default Document Integration Tests", () => {
 			access_group_id: accessGroupId,
 		};
 
-		const extractionResult = await dbService.extractDocument(document);
+		const extractionResult = await dbService.extractDocument(document, file);
 
 		const documentForProcessing: Document = {
 			...document,
@@ -196,7 +233,7 @@ describe("Default Document Integration Tests", () => {
 		// Verify it's associated with the default access group
 		expect(verifiedDoc?.access_group_id).toBe(accessGroupId);
 		expect(verifiedDoc?.owned_by_user_id).toBeNull(); // Default documents are not owned by users
-	}, 400_000);
+	}, 20_000);
 
 	it("should create document summary and chunks after processing", async () => {
 		// Verify summary was created
@@ -220,7 +257,7 @@ describe("Default Document Integration Tests", () => {
 		expect(chunksError).toBeNull();
 		expect(chunks).toBeDefined();
 		expect(chunks?.length).toBeGreaterThan(0);
-	}, 400_000);
+	}, 20_000);
 
 	it("should have file available in storage", async () => {
 		// Read file from disk
@@ -273,5 +310,5 @@ describe("Default Document Integration Tests", () => {
 
 		expect(downloadError).toBeNull();
 		expect(downloadedFile).toBeDefined();
-	}, 60_000);
+	}, 20_000);
 });

--- a/apps/backend/src/integration/routes/documents-process-error-handling.test.ts
+++ b/apps/backend/src/integration/routes/documents-process-error-handling.test.ts
@@ -302,20 +302,6 @@ describe("POST /documents/process – captureError is called for every error cas
 			extractDocumentSpy.mockRestore();
 		});
 
-		it("calls captureError when savePdfPreview throws", async () => {
-			const givenError = new Error("Some Error");
-			vi.spyOn(
-				UserScopedDbService.prototype,
-				"savePdfPreview",
-			).mockRejectedValue(givenError);
-
-			const res = await app.fetch(givenWordRequest);
-
-			expect(await getStatuses(res)).toContain("failed.generic");
-			expect(captureErrorMock).toHaveBeenCalledOnce();
-			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
-		});
-
 		it("calls captureError when extractWordDocument throws", async () => {
 			const givenError = new Error("Some Error");
 			vi.spyOn(

--- a/apps/backend/src/integration/routes/documents-process-error-handling.test.ts
+++ b/apps/backend/src/integration/routes/documents-process-error-handling.test.ts
@@ -39,42 +39,73 @@ import { config } from "../../config";
 
 const BASE_URL = "http://localhost/documents/process";
 
-const VALID_PDF_BODY = {
+// The route now derives the file extension / source_url server-side from the
+// uploaded file's mime type, so the metadata no longer carries a source_url.
+const VALID_METADATA = {
 	document: {
-		source_url: "test-user-id/some-document.pdf",
-		source_type: "personal_document",
-		folder_id: null,
+		folderId: null,
+		sourceType: "personal_document",
 	},
-	llm_model: config.defaultDocumentProcessingModel,
+	llmModel: config.defaultDocumentProcessingModel,
 };
 
-const VALID_WORD_BODY = {
-	document: {
-		source_url: "test-user-id/some-document.docx",
-		source_type: "personal_document",
-		folder_id: null,
-	},
-	llm_model: config.defaultDocumentProcessingModel,
-};
+// Kept as aliases so existing tests read the same; the file (not the metadata)
+// now decides pdf/docx/xlsx.
+const VALID_PDF_BODY = VALID_METADATA;
+const VALID_WORD_BODY = VALID_METADATA;
+const VALID_EXCEL_BODY = VALID_METADATA;
 
-const VALID_EXCEL_BODY = {
-	document: {
-		source_url: "test-user-id/some-document.xlsx",
-		source_type: "personal_document",
-		folder_id: null,
-	},
-	llm_model: config.defaultDocumentProcessingModel,
-};
+const DUMMY_BYTES = new Uint8Array([1, 2, 3]);
 
-function createRequest(body: unknown): Request {
+function pdfFile(): File {
+	return new File([DUMMY_BYTES], "some-document.pdf", {
+		type: "application/pdf",
+	});
+}
+
+function wordFile(): File {
+	return new File([DUMMY_BYTES], "some-document.docx", {
+		type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	});
+}
+
+function excelFile(): File {
+	return new File([DUMMY_BYTES], "some-document.xlsx", {
+		type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	});
+}
+
+function createRequest(metadata: unknown, file: File = pdfFile()): Request {
+	const form = new FormData();
+	form.append("file", file);
+	form.append(
+		"metadata",
+		typeof metadata === "string" ? metadata : JSON.stringify(metadata),
+	);
+
+	// No Content-Type header: FormData sets the multipart boundary itself.
 	return new Request(BASE_URL, {
 		method: "POST",
 		headers: {
-			"Content-Type": "application/json",
 			Authorization: "Bearer mock-token",
 		},
-		body: JSON.stringify(body),
+		body: form,
 	});
+}
+
+/**
+ * The route always responds 200 with an SSE stream; failures are delivered
+ * in-band as `{ status: "failed.*" }` events. This reads the whole stream and
+ * returns the emitted status strings (heartbeat pings are empty and skipped).
+ */
+async function getStatuses(response: Response): Promise<string[]> {
+	const text = await response.text();
+	return text
+		.split("\n")
+		.filter((line) => line.startsWith("data: "))
+		.map((line) => line.slice(6).trim())
+		.filter((payload) => payload.length > 0)
+		.map((payload) => JSON.parse(payload).status as string);
 }
 
 /** A minimal extraction result so the happy-path stubs pass validation */
@@ -99,23 +130,22 @@ const MOCK_EMBEDDINGS = [
 describe("POST /documents/process – captureError is called for every error case", () => {
 	const captureErrorMock = captureError as ReturnType<typeof vi.fn>;
 
-	// Spies that represent the happy-path baseline; individual tests override them
-	let validateDocumentRequestSpy: ReturnType<typeof vi.spyOn>;
+	// Spies that represent the happy-path baseline; individual tests override them.
+	// NOTE: validateDocumentRequest is intentionally NOT mocked — it parses
+	// and validates the whole multipart request (file/size/format/metadata/path)
+	// and returns { sourceUrl, file, bucket, ... }. The real implementation works
+	// for the happy-path request built by createRequest(), and the request-level
+	// tests rely on it actually throwing.
 	let extractDocumentSpy: ReturnType<typeof vi.spyOn>;
 	let extractWordDocumentSpy: ReturnType<typeof vi.spyOn>;
 	let summarizeSpy: ReturnType<typeof vi.spyOn>;
 	let batchEmbedSpy: ReturnType<typeof vi.spyOn>;
 	let logProcessedDocumentSpy: ReturnType<typeof vi.spyOn>;
-	let deleteFileFromStorageSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 
 		// Default: happy-path stubs for all service methods
-		validateDocumentRequestSpy = vi
-			.spyOn(ValidationService.prototype, "validateDocumentRequest")
-			.mockResolvedValue({ success: true, bucket: "documents" });
-
 		extractDocumentSpy = vi
 			.spyOn(UserScopedDbService.prototype, "extractDocument")
 			.mockResolvedValue(MOCK_EXTRACTION_RESULT as never);
@@ -134,30 +164,95 @@ describe("POST /documents/process – captureError is called for every error cas
 
 		logProcessedDocumentSpy = vi
 			.spyOn(UserScopedDbService.prototype, "logProcessedDocument")
-			.mockResolvedValue(undefined);
+			.mockResolvedValue(123);
 
-		deleteFileFromStorageSpy = vi
-			.spyOn(UserScopedDbService.prototype, "deleteFileFromStorage")
-			.mockResolvedValue(undefined);
+		// Stub the cleanup calls so the route's cleanup() (deleteDocument +
+		// deleteFileFromStorage) is a no-op by default and doesn't add spurious
+		// captureError calls. Individual tests override these when they assert on
+		// cleanup behaviour.
+		vi.spyOn(UserScopedDbService.prototype, "deleteDocument").mockResolvedValue(
+			undefined,
+		);
+		vi.spyOn(
+			UserScopedDbService.prototype,
+			"deleteFileFromStorage",
+		).mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
 
-	it("calls captureError when request body is not valid JSON", async () => {
+	it("calls captureError when the metadata is not valid JSON", async () => {
+		// Valid file, but metadata is a malformed JSON string → JSON.parse throws.
+		const givenRequest = createRequest("{ not json !!!");
+
+		const actualResponse = await app.fetch(givenRequest);
+
+		expect(await getStatuses(actualResponse)).toContain("failed.generic");
+		expect(captureErrorMock).toHaveBeenCalledOnce();
+	});
+
+	it("emits failed.format when the file part is missing", async () => {
+		// validateDocumentRequest throws Error("failed.format") when the `file`
+		// part is not a File, so a missing file surfaces as failed.format.
+		const form = new FormData();
+		form.append("metadata", JSON.stringify(VALID_METADATA));
 		const givenRequest = new Request(BASE_URL, {
 			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: "Bearer mock-token",
-			},
-			body: "{ not json !!!",
+			headers: { Authorization: "Bearer mock-token" },
+			body: form,
 		});
 
 		const actualResponse = await app.fetch(givenRequest);
 
-		expect(actualResponse.status).toBe(500);
+		expect(await getStatuses(actualResponse)).toContain("failed.format");
+		expect(captureErrorMock).toHaveBeenCalledOnce();
+	});
+
+	it("emits failed.generic when the metadata part is missing", async () => {
+		const form = new FormData();
+		form.append("file", pdfFile());
+		const givenRequest = new Request(BASE_URL, {
+			method: "POST",
+			headers: { Authorization: "Bearer mock-token" },
+			body: form,
+		});
+
+		const actualResponse = await app.fetch(givenRequest);
+
+		expect(await getStatuses(actualResponse)).toContain("failed.generic");
+		expect(captureErrorMock).toHaveBeenCalledOnce();
+	});
+
+	it("emits failed.size when the file exceeds the size limit", async () => {
+		// The route reads the size off the File that parseBody() reconstructs, so
+		// shrink the limit instead of trying to send an oversized file.
+		const originalLimit = config.fileUploadLimitMb;
+		config.fileUploadLimitMb = 0;
+
+		try {
+			const actualResponse = await app.fetch(
+				createRequest(VALID_PDF_BODY, pdfFile()),
+			);
+
+			expect(await getStatuses(actualResponse)).toContain("failed.size");
+			expect(captureErrorMock).toHaveBeenCalledOnce();
+		} finally {
+			config.fileUploadLimitMb = originalLimit;
+		}
+	});
+
+	it("emits failed.format for an unsupported mime type", async () => {
+		const pngFile = new File([DUMMY_BYTES], "some-image.png", {
+			type: "image/png",
+		});
+
+		const actualResponse = await app.fetch(
+			createRequest(VALID_PDF_BODY, pngFile),
+		);
+
+		expect(await getStatuses(actualResponse)).toContain("failed.format");
 		expect(captureErrorMock).toHaveBeenCalledOnce();
 	});
 
@@ -172,35 +267,23 @@ describe("POST /documents/process – captureError is called for every error cas
 
 		const actualResponse = await app.fetch(givenRequest);
 
-		expect(actualResponse.status).toBe(400);
+		expect(await getStatuses(actualResponse)).toContain("failed.generic");
 		expect(captureErrorMock).toHaveBeenCalledOnce();
 		const [capturedArg] = captureErrorMock.mock.calls[0];
 		expect(capturedArg.name).toBe("ZodError");
 	});
 
-	it("calls captureError when validateDocumentRequest returns a failure result", async () => {
-		validateDocumentRequestSpy.mockResolvedValue({
-			success: false,
-			error: "File not found in storage at the specified source_url",
-			status: 404,
-		});
-
-		const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
-
-		expect(actualResponse.status).toBe(404);
-		expect(captureErrorMock).toHaveBeenCalledOnce();
-		const [capturedArg] = captureErrorMock.mock.calls[0];
-		expect(capturedArg).toBeInstanceOf(Error);
-		expect(capturedArg.message).toContain("File not found");
-	});
-
 	it("calls captureError when validateDocumentRequest throws", async () => {
+		// validateDocumentRequest no longer returns failure results — it throws.
 		const givenError = new Error("Unexpected DB error during validation");
-		validateDocumentRequestSpy.mockRejectedValue(givenError);
+		vi.spyOn(
+			ValidationService.prototype,
+			"validateDocumentRequest",
+		).mockRejectedValue(givenError);
 
 		const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-		expect(actualResponse.status).toBe(500);
+		expect(await getStatuses(actualResponse)).toContain("failed.generic");
 		expect(captureErrorMock).toHaveBeenCalledOnce();
 		expect(captureErrorMock).toHaveBeenCalledWith(givenError);
 	});
@@ -211,26 +294,12 @@ describe("POST /documents/process – captureError is called for every error cas
 		let givenExcelRequest: Request;
 
 		beforeEach(() => {
-			givenPdfRequest = createRequest(VALID_PDF_BODY);
-			givenWordRequest = createRequest(VALID_WORD_BODY);
-			givenExcelRequest = createRequest(VALID_EXCEL_BODY);
+			givenPdfRequest = createRequest(VALID_PDF_BODY, pdfFile());
+			givenWordRequest = createRequest(VALID_WORD_BODY, wordFile());
+			givenExcelRequest = createRequest(VALID_EXCEL_BODY, excelFile());
 			// For these tests, we want to test sub-functions of extractDocument,
 			// so we restore the original implementation of extractDocument
 			extractDocumentSpy.mockRestore();
-		});
-
-		it("calls captureError when getDocumentBufferFromSupabase throws", async () => {
-			const givenError = new Error("Some Error");
-			vi.spyOn(
-				UserScopedDbService.prototype,
-				"getDocumentBufferFromSupabase",
-			).mockRejectedValueOnce(givenError);
-
-			const actualResponse = await app.fetch(givenPdfRequest);
-
-			expect(actualResponse.status).toBe(500);
-			expect(captureErrorMock).toHaveBeenCalledOnce();
-			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
 		});
 
 		it("calls captureError when savePdfPreview throws", async () => {
@@ -239,14 +308,10 @@ describe("POST /documents/process – captureError is called for every error cas
 				UserScopedDbService.prototype,
 				"savePdfPreview",
 			).mockRejectedValue(givenError);
-			vi.spyOn(
-				UserScopedDbService.prototype,
-				"getDocumentBufferFromSupabase",
-			).mockResolvedValueOnce(new Uint8Array() as never);
 
 			const res = await app.fetch(givenWordRequest);
 
-			expect(res.status).toBe(500);
+			expect(await getStatuses(res)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledOnce();
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
 		});
@@ -255,17 +320,13 @@ describe("POST /documents/process – captureError is called for every error cas
 			const givenError = new Error("Some Error");
 			vi.spyOn(
 				UserScopedDbService.prototype,
-				"getDocumentBufferFromSupabase",
-			).mockResolvedValueOnce(new Uint8Array() as never);
-			vi.spyOn(
-				UserScopedDbService.prototype,
 				"savePdfPreview",
 			).mockResolvedValueOnce();
 			extractWordDocumentSpy.mockRejectedValueOnce(givenError);
 
 			const actualResponse = await app.fetch(givenWordRequest);
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledOnce();
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
 		});
@@ -273,17 +334,13 @@ describe("POST /documents/process – captureError is called for every error cas
 		it("calls captureError when extractExcelDocument throws", async () => {
 			const givenError = new Error("Some Error");
 			vi.spyOn(
-				UserScopedDbService.prototype,
-				"getDocumentBufferFromSupabase",
-			).mockResolvedValueOnce(new Uint8Array() as never);
-			vi.spyOn(
 				ExcelExtractionService.prototype,
 				"extractExcelDocument",
 			).mockRejectedValueOnce(givenError);
 
 			const actualResponse = await app.fetch(givenExcelRequest);
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledOnce();
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
 		});
@@ -291,27 +348,19 @@ describe("POST /documents/process – captureError is called for every error cas
 		it("calls captureError when getPdfPageCount throws", async () => {
 			const givenError = new Error("Some Error");
 			vi.spyOn(
-				UserScopedDbService.prototype,
-				"getDocumentBufferFromSupabase",
-			).mockResolvedValueOnce(new Uint8Array() as never);
-			vi.spyOn(
 				DocumentExtractionService.prototype,
 				"getPdfPageCount",
 			).mockRejectedValueOnce(givenError);
 
 			const actualResponse = await app.fetch(givenPdfRequest);
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledOnce();
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
 		});
 
 		it("calls captureError when extractPdfAsMarkdownPages throws", async () => {
 			const givenError = new Error("Some Error");
-			vi.spyOn(
-				UserScopedDbService.prototype,
-				"getDocumentBufferFromSupabase",
-			).mockResolvedValueOnce(new Uint8Array() as never);
 			vi.spyOn(
 				DocumentExtractionService.prototype,
 				"getPdfPageCount",
@@ -323,7 +372,7 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(givenPdfRequest);
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledOnce();
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
 		});
@@ -361,9 +410,8 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
-			expect(deleteFileFromStorageSpy).toHaveBeenCalledOnce();
 		});
 
 		it("calls captureError when generateSummary throws", async () => {
@@ -373,9 +421,8 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
-			expect(deleteFileFromStorageSpy).toHaveBeenCalledOnce();
 		});
 
 		it("calls captureError when generateOneSentenceSummary throws", async () => {
@@ -386,9 +433,8 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
-			expect(deleteFileFromStorageSpy).toHaveBeenCalledOnce();
 		});
 
 		it("calls captureError when generateTags throws", async () => {
@@ -400,9 +446,8 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
-			expect(deleteFileFromStorageSpy).toHaveBeenCalledOnce();
 		});
 	});
 
@@ -432,9 +477,8 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
-			expect(deleteFileFromStorageSpy).toHaveBeenCalledOnce();
 		});
 
 		it("calls captureError when generateMistralBatchEmbeddings throws", async () => {
@@ -443,9 +487,8 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
-			expect(deleteFileFromStorageSpy).toHaveBeenCalledOnce();
 		});
 	});
 
@@ -495,9 +538,8 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
-			expect(deleteFileFromStorageSpy).toHaveBeenCalledOnce();
 		});
 
 		it("calls captureError when logSummarizedDocument throws", async () => {
@@ -511,9 +553,8 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
-			expect(deleteFileFromStorageSpy).toHaveBeenCalledOnce();
 		});
 
 		it("calls captureError when logEmbeddings throws", async () => {
@@ -528,9 +569,8 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
-			expect(deleteFileFromStorageSpy).toHaveBeenCalledOnce();
 		});
 
 		it("calls captureError when updateUserDocumentCount throws", async () => {
@@ -546,9 +586,8 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
-			expect(deleteFileFromStorageSpy).toHaveBeenCalledOnce();
 		});
 
 		it("calls captureError when deleteDocumentById throws", async () => {
@@ -565,22 +604,60 @@ describe("POST /documents/process – captureError is called for every error cas
 
 			const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-			expect(actualResponse.status).toBe(500);
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError2);
-			expect(deleteFileFromStorageSpy).toHaveBeenCalledOnce();
 		});
+	});
+
+	it("emits canceled and cleans up when the request is aborted after upload", async () => {
+		const controller = new AbortController();
+
+		// Abort right after the document is logged and the file is uploaded, so
+		// the post-upload `signal.aborted` check fires.
+		vi.spyOn(
+			UserScopedDbService.prototype,
+			"uploadFileToStorage",
+		).mockImplementation(async () => {
+			controller.abort();
+		});
+		const deleteDocumentSpy = vi
+			.spyOn(UserScopedDbService.prototype, "deleteDocument")
+			.mockResolvedValue(undefined);
+
+		const form = new FormData();
+		form.append("file", pdfFile());
+		form.append("metadata", JSON.stringify(VALID_METADATA));
+		const givenRequest = new Request(BASE_URL, {
+			method: "POST",
+			headers: { Authorization: "Bearer mock-token" },
+			body: form,
+			signal: controller.signal,
+		});
+
+		const actualResponse = await app.fetch(givenRequest);
+
+		expect(await getStatuses(actualResponse)).toContain("canceled");
+		expect(deleteDocumentSpy).toHaveBeenCalledWith(123, "test-user-id");
 	});
 
 	it("calls captureError twice when both processing and cleanup fail", async () => {
 		const givenProcessingError = new Error("Given Processing Error");
 		const givenCleanupError = new Error("Given Cleanup Error");
 
-		summarizeSpy.mockRejectedValue(givenProcessingError);
-		deleteFileFromStorageSpy.mockRejectedValue(givenCleanupError);
+		// Cleanup (deleteDocument) only runs once a documentId exists, i.e. after
+		// logProcessedDocument succeeds. So fail on the storage upload (the step
+		// after logging) and then fail the cleanup itself.
+		vi.spyOn(
+			UserScopedDbService.prototype,
+			"uploadFileToStorage",
+		).mockRejectedValue(givenProcessingError);
+		vi.spyOn(UserScopedDbService.prototype, "deleteDocument").mockRejectedValue(
+			givenCleanupError,
+		);
 
 		const actualResponse = await app.fetch(createRequest(VALID_PDF_BODY));
 
-		expect(actualResponse.status).toBe(500);
+		expect(await getStatuses(actualResponse)).toContain("failed.generic");
 		expect(captureErrorMock).toHaveBeenCalledTimes(2);
 
 		expect(captureErrorMock).toHaveBeenNthCalledWith(1, givenProcessingError);

--- a/apps/backend/src/integration/routes/documents-process-error-handling.test.ts
+++ b/apps/backend/src/integration/routes/documents-process-error-handling.test.ts
@@ -54,6 +54,7 @@ const VALID_METADATA = {
 const VALID_PDF_BODY = VALID_METADATA;
 const VALID_WORD_BODY = VALID_METADATA;
 const VALID_EXCEL_BODY = VALID_METADATA;
+const VALID_CSV_BODY = VALID_METADATA;
 
 const DUMMY_BYTES = new Uint8Array([1, 2, 3]);
 
@@ -72,6 +73,12 @@ function wordFile(): File {
 function excelFile(): File {
 	return new File([DUMMY_BYTES], "some-document.xlsx", {
 		type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	});
+}
+
+function csvFile(): File {
+	return new File([DUMMY_BYTES], "some-document.csv", {
+		type: "text/csv",
 	});
 }
 
@@ -274,7 +281,6 @@ describe("POST /documents/process – captureError is called for every error cas
 	});
 
 	it("calls captureError when validateDocumentRequest throws", async () => {
-		// validateDocumentRequest no longer returns failure results — it throws.
 		const givenError = new Error("Unexpected DB error during validation");
 		vi.spyOn(
 			ValidationService.prototype,
@@ -292,11 +298,14 @@ describe("POST /documents/process – captureError is called for every error cas
 		let givenPdfRequest: Request;
 		let givenWordRequest: Request;
 		let givenExcelRequest: Request;
+		let givenCsvRequest: Request;
 
 		beforeEach(() => {
 			givenPdfRequest = createRequest(VALID_PDF_BODY, pdfFile());
 			givenWordRequest = createRequest(VALID_WORD_BODY, wordFile());
 			givenExcelRequest = createRequest(VALID_EXCEL_BODY, excelFile());
+			givenCsvRequest = createRequest(VALID_CSV_BODY, csvFile());
+
 			// For these tests, we want to test sub-functions of extractDocument,
 			// so we restore the original implementation of extractDocument
 			extractDocumentSpy.mockRestore();
@@ -317,7 +326,7 @@ describe("POST /documents/process – captureError is called for every error cas
 			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
 		});
 
-		it("calls captureError when extractExcelDocument throws", async () => {
+		it("calls captureError when extractExcelDocument throws while processing excel", async () => {
 			const givenError = new Error("Some Error");
 			vi.spyOn(
 				ExcelExtractionService.prototype,
@@ -325,6 +334,20 @@ describe("POST /documents/process – captureError is called for every error cas
 			).mockRejectedValueOnce(givenError);
 
 			const actualResponse = await app.fetch(givenExcelRequest);
+
+			expect(await getStatuses(actualResponse)).toContain("failed.generic");
+			expect(captureErrorMock).toHaveBeenCalledOnce();
+			expect(captureErrorMock).toHaveBeenCalledWith(givenError);
+		});
+
+		it("calls captureError when extractExcelDocument throws while processing csv", async () => {
+			const givenError = new Error("Some Error");
+			vi.spyOn(
+				ExcelExtractionService.prototype,
+				"extractExcelDocument",
+			).mockRejectedValueOnce(givenError);
+
+			const actualResponse = await app.fetch(givenCsvRequest);
 
 			expect(await getStatuses(actualResponse)).toContain("failed.generic");
 			expect(captureErrorMock).toHaveBeenCalledOnce();

--- a/apps/backend/src/integration/routes/documents-security.integration.test.ts
+++ b/apps/backend/src/integration/routes/documents-security.integration.test.ts
@@ -22,6 +22,49 @@ const USER_B_PASSWORD = "SecurePassword456!";
 let userAToken: string;
 let userBToken: string;
 
+const PROCESS_URL = "http://localhost/documents/process";
+
+function pdfFile(): File {
+	return new File([new Uint8Array([1, 2, 3])], "test.pdf", {
+		type: "application/pdf",
+	});
+}
+
+// The route now takes multipart (file + metadata) and generates the storage
+// path itself, so security is enforced on the metadata, not a client source_url.
+function createProcessRequest(
+	metadata: unknown,
+	token: string,
+	file: File = pdfFile(),
+): Request {
+	const form = new FormData();
+	form.append("file", file);
+	form.append(
+		"metadata",
+		typeof metadata === "string" ? metadata : JSON.stringify(metadata),
+	);
+
+	return new Request(PROCESS_URL, {
+		method: "POST",
+		headers: { authorization: `Bearer ${token}` },
+		body: form,
+	});
+}
+
+// Failures are delivered in-band as `{ status: "failed.*", error }` SSE events
+// on a 200 response. Returns the parsed events (heartbeat pings are empty).
+async function readSseEvents(
+	response: Response,
+): Promise<Array<{ status: string; error?: string }>> {
+	const text = await response.text();
+	return text
+		.split("\n")
+		.filter((line) => line.startsWith("data: "))
+		.map((line) => line.slice(6).trim())
+		.filter((payload) => payload.length > 0)
+		.map((payload) => JSON.parse(payload));
+}
+
 describe("Document Process Security Tests", () => {
 	beforeAll(async () => {
 		// Create test users
@@ -65,156 +108,72 @@ describe("Document Process Security Tests", () => {
 	});
 
 	describe("Request Validation", () => {
-		it("should reject requests with invalid source_type", async () => {
-			const payload = {
+		it("should reject requests with invalid sourceType", async () => {
+			const metadata = {
 				document: {
-					source_url: `${USER_A_ID}/test.pdf`,
-					source_type: "malicious_type", // Invalid
-					owned_by_user_id: USER_A_ID,
+					folderId: null,
+					sourceType: "malicious_type", // Invalid
 				},
+				llmModel: config.defaultDocumentProcessingModel,
 			};
 
-			const res = await app.request("/documents/process", {
-				method: "POST",
-				body: JSON.stringify(payload),
-				headers: new Headers({
-					"Content-Type": "application/json",
-					authorization: `Bearer ${userAToken}`,
-				}),
-			});
+			const res = await app.fetch(createProcessRequest(metadata, userAToken));
 
-			expect(res.status).toBe(400);
-			const body = await res.json();
-			expect(body.error).toContain("Validation failed");
+			const events = await readSseEvents(res);
+			const statuses = events.map((e) => e.status);
+			expect(statuses).toContain("failed.generic");
+			// Validation must fail before processing begins.
+			expect(statuses).not.toContain("processing");
 		});
 
-		it("should reject requests with path traversal in source_url", async () => {
-			const maliciousUrls = [
-				`../../../etc/passwd`,
-				`${USER_A_ID}/../../../etc/passwd`,
-				`./test.pdf`,
-				`//double/slash`,
-				`/absolute/path.pdf`,
+		it("should reject path traversal in the (user-supplied) access_group_id", async () => {
+			// For public/default documents the storage path prefix comes from the
+			// client-supplied accessGroupId. The z.uuid() schema is what prevents a
+			// traversal payload from ever reaching the storage path.
+			const maliciousAccessGroupIds = [
+				"../../../etc/passwd",
+				"../../secrets",
+				"./nested",
+				"//double/slash",
+				"/absolute/path",
 			];
 
-			for (const sourceUrl of maliciousUrls) {
-				const payload = {
+			for (const accessGroupId of maliciousAccessGroupIds) {
+				const metadata = {
 					document: {
-						source_url: sourceUrl,
-						source_type: "personal_document",
-						owned_by_user_id: USER_A_ID,
+						folderId: null,
+						sourceType: "public_document",
+						accessGroupId,
 					},
+					llmModel: config.defaultDocumentProcessingModel,
 				};
 
-				const res = await app.request("/documents/process", {
-					method: "POST",
-					body: JSON.stringify(payload),
-					headers: new Headers({
-						"Content-Type": "application/json",
-						authorization: `Bearer ${userAToken}`,
-					}),
-				});
+				const res = await app.fetch(createProcessRequest(metadata, userAToken));
 
-				expect(res.status).toBe(400);
-				const body = await res.json();
-				expect(body.error).toContain("Validation failed");
+				const events = await readSseEvents(res);
+				const statuses = events.map((e) => e.status);
+				expect(statuses).toContain("failed.generic");
+				// Validation must fail before processing begins.
+				expect(statuses).not.toContain("processing");
 			}
 		});
 
-		it("should reject requests with empty source_url", async () => {
-			const payload = {
-				document: {
-					source_url: "",
-					source_type: "personal_document",
-					owned_by_user_id: USER_A_ID,
-				},
-			};
-
-			const res = await app.request("/documents/process", {
-				method: "POST",
-				body: JSON.stringify(payload),
-				headers: new Headers({
-					"Content-Type": "application/json",
-					authorization: `Bearer ${userAToken}`,
-				}),
-			});
-
-			expect(res.status).toBe(400);
-		});
-
 		it("should reject requests missing required fields", async () => {
-			const payload = {
+			const metadata = {
 				document: {
-					// Missing source_url and source_type
-					owned_by_user_id: USER_A_ID,
+					// Missing sourceType
+					folderId: null,
 				},
+				// llmModel missing
 			};
 
-			const res = await app.request("/documents/process", {
-				method: "POST",
-				body: JSON.stringify(payload),
-				headers: new Headers({
-					"Content-Type": "application/json",
-					authorization: `Bearer ${userAToken}`,
-				}),
-			});
+			const res = await app.fetch(createProcessRequest(metadata, userAToken));
 
-			expect(res.status).toBe(400);
-		});
-	});
-
-	describe("User ID Spoofing Prevention", () => {
-		it("should reject processing documents in another user's storage folder", async () => {
-			// User A tries to process a document claiming it's in User B's folder
-			const payload = {
-				document: {
-					source_url: `${USER_B_ID}/stolen-doc.pdf`, // Trying to access User B's storage
-					source_type: "personal_document",
-					owned_by_user_id: USER_B_ID, // Trying to spoof as User B
-					folder_id: null,
-				},
-				llm_model: config.defaultDocumentProcessingModel,
-			};
-
-			const res = await app.request("/documents/process", {
-				method: "POST",
-				body: JSON.stringify(payload),
-				headers: new Headers({
-					"Content-Type": "application/json",
-					authorization: `Bearer ${userAToken}`, // But authenticating as User A
-				}),
-			});
-
-			// Should be rejected because the authenticated user (A) doesn't match the path prefix (B)
-			expect(res.status).toBe(403);
-			const body = await res.json();
-			expect(body.error).toContain("Unauthorized");
-		});
-
-		it("should reject processing document with spoofed owned_by_user_id even if file doesn't exist", async () => {
-			// User A tries to claim ownership for User B
-			const payload = {
-				document: {
-					source_url: `${USER_A_ID}/my-doc.pdf`, // User A's folder
-					source_type: "personal_document",
-					owned_by_user_id: USER_B_ID, // Trying to assign to User B
-					folder_id: null,
-				},
-				llm_model: config.defaultDocumentProcessingModel,
-			};
-
-			const res = await app.request("/documents/process", {
-				method: "POST",
-				body: JSON.stringify(payload),
-				headers: new Headers({
-					"Content-Type": "application/json",
-					authorization: `Bearer ${userAToken}`,
-				}),
-			});
-
-			// Should fail with 404 because file doesn't exist (but importantly,
-			// even if it succeeded, the document would be owned by User A, not User B)
-			expect(res.status).toBe(404);
+			const events = await readSseEvents(res);
+			const statuses = events.map((e) => e.status);
+			expect(statuses).toContain("failed.generic");
+			// Validation must fail before processing begins.
+			expect(statuses).not.toContain("processing");
 		});
 	});
 
@@ -249,85 +208,47 @@ describe("Document Process Security Tests", () => {
 
 		it("should reject processing document into another user's folder", async () => {
 			// User B tries to process a document into User A's folder
-			const payload = {
+			const metadata = {
 				document: {
-					source_url: `${USER_B_ID}/test-doc.pdf`,
-					source_type: "personal_document",
-					folder_id: userAFolderId,
-					owned_by_user_id: USER_B_ID,
+					folderId: userAFolderId,
+					sourceType: "personal_document",
 				},
-				llm_model: config.defaultDocumentProcessingModel,
+				llmModel: config.defaultDocumentProcessingModel,
 			};
 
-			const res = await app.request("/documents/process", {
-				method: "POST",
-				body: JSON.stringify(payload),
-				headers: new Headers({
-					"Content-Type": "application/json",
-					authorization: `Bearer ${userBToken}`,
-				}),
-			});
+			const res = await app.fetch(createProcessRequest(metadata, userBToken));
 
-			expect(res.status).toBe(403);
-			const body = await res.json();
-			expect(body.error).toContain(
-				"folder_id does not belong to the authenticated user",
-			);
+			const events = await readSseEvents(res);
+			const statuses = events.map((e) => e.status);
+			// The route surfaces validation failures as a generic in-band error
+			// (the specific reason is only captured server-side, not exposed to the
+			// client), so we assert the failure status rather than the message.
+			expect(statuses).toContain("failed.generic");
+			// Validation must fail before processing begins.
+			expect(statuses).not.toContain("processing");
 		});
 
 		it("should reject non-existent folder_id", async () => {
-			const payload = {
+			const metadata = {
 				document: {
-					source_url: `${USER_A_ID}/test-doc.pdf`,
-					source_type: "personal_document",
-					folder_id: 999999, // Non-existent folder
-					owned_by_user_id: USER_A_ID,
+					folderId: 999999, // Non-existent folder
+					sourceType: "personal_document",
 				},
-				llm_model: config.defaultDocumentProcessingModel,
+				llmModel: config.defaultDocumentProcessingModel,
 			};
 
-			const res = await app.request("/documents/process", {
-				method: "POST",
-				body: JSON.stringify(payload),
-				headers: new Headers({
-					"Content-Type": "application/json",
-					authorization: `Bearer ${userAToken}`,
-				}),
-			});
+			const res = await app.fetch(createProcessRequest(metadata, userAToken));
 
-			expect(res.status).toBe(403);
-		});
-	});
-
-	describe("File Existence Validation", () => {
-		it("should reject processing non-existent file", async () => {
-			const payload = {
-				document: {
-					source_url: `${USER_A_ID}/non-existent-file.pdf`,
-					source_type: "personal_document",
-					owned_by_user_id: USER_A_ID,
-					folder_id: null,
-				},
-				llm_model: config.defaultDocumentProcessingModel,
-			};
-
-			const res = await app.request("/documents/process", {
-				method: "POST",
-				body: JSON.stringify(payload),
-				headers: new Headers({
-					"Content-Type": "application/json",
-					authorization: `Bearer ${userAToken}`,
-				}),
-			});
-
-			expect(res.status).toBe(404);
-			const body = await res.json();
-			expect(body.error).toContain("File not found");
+			const events = await readSseEvents(res);
+			const statuses = events.map((e) => e.status);
+			expect(statuses).toContain("failed.generic");
+			// Validation must fail before processing begins.
+			expect(statuses).not.toContain("processing");
 		});
 	});
 
 	describe("Source Type Restrictions", () => {
-		it("should only accept valid source_type values", async () => {
+		it("should only accept valid sourceType values", async () => {
 			const invalidTypes = [
 				"admin_document",
 				"system",
@@ -336,24 +257,21 @@ describe("Document Process Security Tests", () => {
 			];
 
 			for (const invalidType of invalidTypes) {
-				const payload = {
+				const metadata = {
 					document: {
-						source_url: `${USER_A_ID}/test.pdf`,
-						source_type: invalidType,
-						owned_by_user_id: USER_A_ID,
+						folderId: null,
+						sourceType: invalidType,
 					},
+					llmModel: config.defaultDocumentProcessingModel,
 				};
 
-				const res = await app.request("/documents/process", {
-					method: "POST",
-					body: JSON.stringify(payload),
-					headers: new Headers({
-						"Content-Type": "application/json",
-						authorization: `Bearer ${userAToken}`,
-					}),
-				});
+				const res = await app.fetch(createProcessRequest(metadata, userAToken));
 
-				expect(res.status).toBe(400);
+				const events = await readSseEvents(res);
+				const statuses = events.map((e) => e.status);
+				expect(statuses).toContain("failed.generic");
+				// Validation must fail before processing begins.
+				expect(statuses).not.toContain("processing");
 			}
 		});
 	});

--- a/apps/backend/src/integration/routes/documents.integration.test.ts
+++ b/apps/backend/src/integration/routes/documents.integration.test.ts
@@ -4,16 +4,18 @@ import {
 	expect,
 	vi,
 	beforeEach,
+	afterEach,
 	beforeAll,
 	afterAll,
 } from "vitest";
 import app from "../../index";
-import { serviceRoleDbClient } from "../../supabase";
+import { createUserScopedDbClient, serviceRoleDbClient } from "../../supabase";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@repo/db-schema";
 import { config } from "../../config";
 import { GenerationService } from "../../services/generation-service";
 import { UserScopedDbService } from "../../services/db-service/user-scoped-db-service";
+import { WordDocumentExtractionService } from "../../services/document-extraction-service";
 import {
 	defaultDocumentName,
 	defaultDocumentPath,
@@ -117,4 +119,90 @@ describe("Documents Route Integration", () => {
 		extractSpy.mockRestore();
 		summarizeSpy.mockRestore();
 	}, 20_000);
+
+	describe("uploadFileToStorage – docx preview generation", () => {
+		const bucket = "documents";
+		const docxPath = `${givenUserId}/preview-int-test.docx`;
+		const pdfPath = `${givenUserId}/preview-int-test.pdf`;
+		const xlsxPath = `${givenUserId}/preview-int-test.xlsx`;
+
+		function buildService() {
+			return new UserScopedDbService(createUserScopedDbClient(accessToken));
+		}
+
+		// Best-effort cleanup before and after so a stale file from a crashed run
+		// can't cause a duplicate-upload error.
+		const removeAll = () =>
+			serviceRoleDbClient.storage
+				.from(bucket)
+				.remove([docxPath, pdfPath, xlsxPath]);
+		beforeEach(removeAll);
+		afterEach(removeAll);
+
+		it("uploads the docx and generates a .pdf preview in the same bucket", async () => {
+			const file = new File(
+				[new Uint8Array([1, 2, 3])],
+				"preview-int-test.docx",
+				{
+					type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+				},
+			);
+
+			await buildService().uploadFileToStorage(docxPath, file, bucket);
+
+			const { data } = await serviceRoleDbClient.storage
+				.from(bucket)
+				.list(givenUserId);
+			const names = data?.map((f) => f.name) ?? [];
+			expect(names).toContain("preview-int-test.docx");
+			expect(names).toContain("preview-int-test.pdf");
+		}, 20_000);
+
+		it("does not generate a preview for a non-docx file", async () => {
+			const file = new File(
+				[new Uint8Array([1, 2, 3])],
+				"preview-int-test.xlsx",
+				{
+					type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+				},
+			);
+
+			await buildService().uploadFileToStorage(xlsxPath, file, bucket);
+
+			const { data } = await serviceRoleDbClient.storage
+				.from(bucket)
+				.list(givenUserId);
+			const names = data?.map((f) => f.name) ?? [];
+			expect(names).toContain("preview-int-test.xlsx");
+			expect(names).not.toContain("preview-int-test.pdf");
+		}, 20_000);
+
+		it("propagates the error when preview generation fails, leaving no preview", async () => {
+			const givenError = new Error("Some Error");
+			const spy = vi
+				.spyOn(WordDocumentExtractionService.prototype, "convertWordToPdf")
+				.mockRejectedValue(givenError);
+			const file = new File(
+				[new Uint8Array([1, 2, 3])],
+				"preview-int-test.docx",
+				{
+					type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+				},
+			);
+
+			await expect(
+				buildService().uploadFileToStorage(docxPath, file, bucket),
+			).rejects.toThrow(givenError);
+
+			// The original docx uploaded before the preview step failed; no .pdf exists.
+			const { data } = await serviceRoleDbClient.storage
+				.from(bucket)
+				.list(givenUserId);
+			const names = data?.map((f) => f.name) ?? [];
+			expect(names).toContain("preview-int-test.docx");
+			expect(names).not.toContain("preview-int-test.pdf");
+
+			spy.mockRestore();
+		}, 20_000);
+	});
 });

--- a/apps/backend/src/integration/routes/documents.integration.test.ts
+++ b/apps/backend/src/integration/routes/documents.integration.test.ts
@@ -13,6 +13,7 @@ import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@repo/db-schema";
 import { config } from "../../config";
 import { GenerationService } from "../../services/generation-service";
+import { UserScopedDbService } from "../../services/db-service/user-scoped-db-service";
 import {
 	defaultDocumentName,
 	defaultDocumentPath,
@@ -55,62 +56,65 @@ describe("Documents Route Integration", () => {
 		accessToken = data.session?.access_token || "";
 	});
 
-	it("should remove storage file if processing fails", async () => {
-		// 1. Upload file to storage
-		const sourceUrl = `${givenUserId}/${defaultDocumentName}`;
-		const file = readFileSync(defaultDocumentPath);
-		const { error: uploadError } = await supabaseAnonClient.storage
-			.from("documents")
-			.upload(sourceUrl, file, {
-				contentType: "application/pdf",
-				upsert: true,
-			});
-		expect(uploadError).toBeNull();
+	it("should not leave an orphaned storage file when processing fails", async () => {
+		// The route uploads to storage only as the LAST step (after logging the
+		// document). If processing fails before that, nothing should have been
+		// written to storage.
 
-		// Verify it exists
+		// Baseline: whatever is already in the user's folder.
 		const { data: listBefore } = await serviceRoleDbClient.storage
 			.from("documents")
 			.list(givenUserId);
-		expect(
-			listBefore?.find((f) => f.name === defaultDocumentName),
-		).toBeDefined();
+		const countBefore = listBefore?.length ?? 0;
 
-		// 2. Mock GenerationService to fail
-		// We use spyOn on the prototype because the service is instantiated inside the route module
+		// Mock extraction (avoid real OCR) and force summarize to fail.
+		const extractSpy = vi
+			.spyOn(UserScopedDbService.prototype, "extractDocument")
+			.mockResolvedValue({
+				parsedPages: [{ content: "content", tokenCount: 1, pageNumber: 1 }],
+				checksum: "checksum",
+				fileSize: 1,
+				numPages: 1,
+			} as never);
 		const summarizeSpy = vi
 			.spyOn(GenerationService.prototype, "summarize")
 			.mockRejectedValue(new Error("Forced Failure"));
 
-		// 3. Call /process
-		const req = new Request("http://localhost/documents/process", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${accessToken}`,
-			},
-			body: JSON.stringify({
-				document: {
-					source_url: sourceUrl,
-					source_type: "personal_document",
-					folder_id: null,
-					owned_by_user_id: givenUserId,
-					created_at: new Date().toISOString(),
-				},
-				llm_model: config.defaultDocumentProcessingModel,
+		// Send the file through the combined upload+process route (multipart).
+		const file = new File(
+			[new Uint8Array(readFileSync(defaultDocumentPath))],
+			defaultDocumentName,
+			{ type: "application/pdf" },
+		);
+		const form = new FormData();
+		form.append("file", file);
+		form.append(
+			"metadata",
+			JSON.stringify({
+				document: { folderId: null, sourceType: "personal_document" },
+				llmModel: config.defaultDocumentProcessingModel,
 			}),
-		});
+		);
 
-		const res = await app.fetch(req);
-		expect(res.status).toBe(500);
+		const res = await app.fetch(
+			new Request("http://localhost/documents/process", {
+				method: "POST",
+				headers: { Authorization: `Bearer ${accessToken}` },
+				body: form,
+			}),
+		);
 
-		// 4. Verify file is gone
+		// Failure is delivered in-band as an SSE event, not an HTTP error code.
+		const text = await res.text();
+		expect(text).toContain("failed.generic");
 
+		// No new file should have been written to storage.
 		const { data: listAfter } = await serviceRoleDbClient.storage
 			.from("documents")
 			.list(givenUserId);
-		const found = listAfter?.find((f) => f.name === defaultDocumentName);
-		expect(found).toBeUndefined();
+		expect(listAfter?.length ?? 0).toBe(countBefore);
 
+		extractSpy.mockRestore();
 		summarizeSpy.mockRestore();
-	}, 30_000);
+	}, 20_000);
 });

--- a/apps/backend/src/integration/routes/user.integration.test.ts
+++ b/apps/backend/src/integration/routes/user.integration.test.ts
@@ -81,7 +81,7 @@ const personalMetadata = {
 };
 
 // Mocked processing outputs so the tests exercise the route + real DB/storage
-// without hitting Mistral. The chunk embedding must match the vector(1024)
+// without hitting the API. The chunk embedding must match the vector(1024)
 // column, otherwise the real insert fails.
 const MOCK_EXTRACTION_RESULT = {
 	parsedPages: [{ content: "page content", tokenCount: 10, pageNumber: 1 }],
@@ -264,7 +264,7 @@ describe("Integration Tests for Routes", () => {
 	});
 
 	// Mock the expensive processing steps (OCR/summary/embeddings) so the tests
-	// exercise the route + real DB/storage without hitting Mistral. The route
+	// exercise the route + real DB/storage without hitting the API. The route
 	// still uploads the file and writes real rows via logProcessedDocument.
 	beforeEach(() => {
 		vi.spyOn(
@@ -316,7 +316,7 @@ describe("Integration Tests for Routes", () => {
 	}, 20_000);
 
 	it("POST /llm/just-chatting should handle a valid request", async () => {
-		// Mock prompt assembly (Langfuse) and the LLM stream (Mistral) so the
+		// Mock prompt assembly and the LLM stream so the
 		// route smoke-test is deterministic and never depends on external APIs.
 		vi.spyOn(GenerationService.prototype, "createPrompt").mockResolvedValue({
 			messages: [],

--- a/apps/backend/src/integration/routes/user.integration.test.ts
+++ b/apps/backend/src/integration/routes/user.integration.test.ts
@@ -1,10 +1,22 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+	describe,
+	it,
+	expect,
+	beforeAll,
+	afterAll,
+	beforeEach,
+	afterEach,
+	vi,
+} from "vitest";
 import { createClient } from "@supabase/supabase-js";
 import app from "../../index";
 import { config } from "../../config";
 import { PDFDocument } from "pdf-lib";
 import { serviceRoleDbClient } from "../../supabase";
 import { Database } from "@repo/db-schema";
+import { UserScopedDbService } from "../../services/db-service/user-scoped-db-service";
+import { GenerationService } from "../../services/generation-service";
+import { EmbeddingService } from "../../services/embedding-service";
 
 const supabaseAnonClient = createClient<Database>(
 	config.supabaseUrl,
@@ -16,9 +28,6 @@ let validToken: string;
 const OWNER_USER_ID = "11111111-1111-4111-8111-111111111111";
 const OTHER_USER_ID = "22222222-2222-4222-8222-222222222222";
 
-const UPLOAD_DELAY_MS = 1_000;
-const RATE_LIMIT_RETRY_DELAY_MS = 5_000;
-
 // Generate a PDF from text and return bytes
 const generatePdfBytesFromText = async (text: string): Promise<Uint8Array> => {
 	const doc = await PDFDocument.create();
@@ -27,32 +36,72 @@ const generatePdfBytesFromText = async (text: string): Promise<Uint8Array> => {
 	return await doc.save({ useObjectStreams: false });
 };
 
-// Upload bytes directly to Supabase storage
-const uploadToStorage = async (args: {
-	bytes: Uint8Array;
-	sourceUrl: string;
-	fileName: string;
-	userToken: string;
-}): Promise<void> => {
-	const { bytes, sourceUrl, fileName, userToken } = args;
-	const file = new File([bytes.slice()], fileName, { type: "application/pdf" });
+// Build a File from raw PDF bytes.
+const pdfFileFromBytes = (bytes: Uint8Array, fileName: string): File =>
+	new File([bytes.slice()], fileName, { type: "application/pdf" });
 
-	const userClient = createClient(
-		process.env.SUPABASE_URL as string,
-		process.env.SUPABASE_ANON_KEY as string,
-		{ global: { headers: { Authorization: `Bearer ${userToken}` } } },
-	);
+type SseEvent = { status: string; error?: string; documentId?: number };
 
-	const { error } = await userClient.storage
-		.from("documents")
-		.upload(sourceUrl, file, {
-			contentType: "application/pdf",
-		});
-
-	if (error) {
-		throw new Error(`Storage upload error: ${error.message}`);
-	}
+// Failures/success are delivered in-band as SSE events on a 200 response.
+const readSseEvents = async (response: Response): Promise<SseEvent[]> => {
+	const text = await response.text();
+	return text
+		.split("\n")
+		.filter((line) => line.startsWith("data: "))
+		.map((line) => line.slice(6).trim())
+		.filter((payload) => payload.length > 0)
+		.map((payload) => JSON.parse(payload));
 };
+
+// Send a document through the combined upload+process route (multipart) and
+// return the emitted SSE events. The route uploads the file to storage itself.
+const processViaRoute = async (args: {
+	metadata: unknown;
+	token: string;
+	file: File;
+}): Promise<SseEvent[]> => {
+	const { metadata, token, file } = args;
+	const form = new FormData();
+	form.append("file", file);
+	form.append("metadata", JSON.stringify(metadata));
+
+	const res = await app.fetch(
+		new Request("http://localhost/documents/process", {
+			method: "POST",
+			headers: { authorization: `Bearer ${token}` },
+			body: form,
+		}),
+	);
+	return readSseEvents(res);
+};
+
+const personalMetadata = {
+	document: { folderId: null, sourceType: "personal_document" },
+	llmModel: config.defaultDocumentProcessingModel,
+};
+
+// Mocked processing outputs so the tests exercise the route + real DB/storage
+// without hitting Mistral. The chunk embedding must match the vector(1024)
+// column, otherwise the real insert fails.
+const MOCK_EXTRACTION_RESULT = {
+	parsedPages: [{ content: "page content", tokenCount: 10, pageNumber: 1 }],
+	checksum: "test-checksum",
+	fileSize: 1234,
+	numPages: 1,
+};
+const MOCK_SUMMARY_DATA = {
+	summary: "A summary",
+	shortSummary: "Short",
+	tags: ["tag"],
+};
+const MOCK_EMBEDDINGS = [
+	{
+		content: "chunk",
+		embedding: new Array(config.mistralEmbeddingDimensions).fill(0),
+		chunkIndex: 0,
+		page: 1,
+	},
+];
 
 const deleteDocument = async (
 	documentId: number,
@@ -82,21 +131,6 @@ const deleteDocument = async (
 		error: body.error || "Unknown error",
 	};
 };
-
-async function getLatestDocumentIdBySourceUrl(
-	ownerId: string,
-	sourceUrl: string,
-): Promise<number | undefined> {
-	const { data } = await serviceRoleDbClient
-		.from("documents")
-		.select("id")
-		.eq("source_url", sourceUrl)
-		.eq("owned_by_user_id", ownerId)
-		.order("created_at", { ascending: false })
-		.limit(1);
-
-	return data && data.length > 0 ? data[0].id : undefined;
-}
 
 /**
  * Comprehensive cleanup function to delete all potentially conflicting document records
@@ -147,13 +181,6 @@ const cleanupTestDocuments = async () => {
 	} catch (error) {
 		console.error("Error during test documents cleanup:", error);
 	}
-};
-
-/**
- * Helper function to add delay between API calls
- */
-const delay = (ms: number): Promise<void> => {
-	return new Promise((resolve) => setTimeout(resolve, ms));
 };
 
 /**
@@ -236,46 +263,37 @@ describe("Integration Tests for Routes", () => {
 		await deleteTestUser();
 	});
 
-	it("POST /documents/process should process a document and return 204", async () => {
-		const fileName = "example.pdf";
-		const sourceUrl = `${OWNER_USER_ID}/${fileName}`;
+	// Mock the expensive processing steps (OCR/summary/embeddings) so the tests
+	// exercise the route + real DB/storage without hitting Mistral. The route
+	// still uploads the file and writes real rows via logProcessedDocument.
+	beforeEach(() => {
+		vi.spyOn(
+			UserScopedDbService.prototype,
+			"extractDocument",
+		).mockResolvedValue(MOCK_EXTRACTION_RESULT as never);
+		vi.spyOn(GenerationService.prototype, "summarize").mockResolvedValue(
+			MOCK_SUMMARY_DATA as never,
+		);
+		vi.spyOn(EmbeddingService.prototype, "batchEmbed").mockResolvedValue(
+			MOCK_EMBEDDINGS as never,
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("POST /documents/process should process a document and emit a successful event", async () => {
 		const pdfBytes = await generatePdfBytesFromText("Test Document");
 
-		await uploadToStorage({
-			bytes: pdfBytes,
-			sourceUrl,
-			fileName,
-			userToken: validToken,
+		const events = await processViaRoute({
+			metadata: personalMetadata,
+			token: validToken,
+			file: pdfFileFromBytes(pdfBytes, "example.pdf"),
 		});
 
-		const payload = {
-			document: {
-				file_name: fileName,
-				owned_by_user_id: OWNER_USER_ID,
-				registered_at: new Date().toISOString(),
-				source_type: "personal_document",
-				source_url: sourceUrl,
-				folder_id: null,
-			},
-			llm_model: "mistral-small",
-		};
-
-		const res = await app.request("/documents/process", {
-			method: "POST",
-			body: JSON.stringify(payload),
-			headers: new Headers({
-				"Content-Type": "application/json",
-				authorization: `Bearer ${validToken}`,
-			}),
-		});
-
-		if (res.status !== 204) {
-			const responseText = await res.text();
-			console.error(`Test failed with status ${res.status}:`, responseText);
-		}
-
-		expect(res.status).toBe(204);
-	}, 400_000);
+		expect(events.map((e) => e.status)).toContain("successful");
+	}, 20_000);
 
 	it("POST /documents/process should handle multiple document uploads", async () => {
 		const texts = [
@@ -283,65 +301,39 @@ describe("Integration Tests for Routes", () => {
 			"Here is the second document for testing.",
 		];
 		const fileNames = ["example-1.pdf", "example-2.pdf"];
-		const sourceUrls = fileNames.map(
-			(fileName) => `${OWNER_USER_ID}/${fileName}`,
-		);
 
 		for (let i = 0; i < texts.length; i++) {
 			const pdfBytes = await generatePdfBytesFromText(texts[i]);
 
-			await uploadToStorage({
-				bytes: pdfBytes,
-				sourceUrl: sourceUrls[i],
-				fileName: fileNames[i],
-				userToken: validToken,
+			const events = await processViaRoute({
+				metadata: personalMetadata,
+				token: validToken,
+				file: pdfFileFromBytes(pdfBytes, fileNames[i]),
 			});
 
-			const payload = {
-				document: {
-					file_name: fileNames[i],
-					owned_by_user_id: OWNER_USER_ID,
-					registered_at: new Date().toISOString(),
-					source_type: "personal_document",
-					source_url: sourceUrls[i],
-					folder_id: null,
-				},
-				llm_model: config.defaultDocumentProcessingModel,
-			};
-
-			const res = await app.request("/documents/process", {
-				method: "POST",
-				body: JSON.stringify(payload),
-				headers: new Headers({
-					"Content-Type": "application/json",
-					authorization: `Bearer ${validToken}`,
-				}),
-			});
-			await delay(UPLOAD_DELAY_MS);
-			if (res.status !== 204) {
-				const responseText = await res.text();
-				if (res.status === 429) {
-					console.warn("Rate limit hit, retrying after delay...");
-					await delay(RATE_LIMIT_RETRY_DELAY_MS);
-					const retryRes = await app.request("/documents/process", {
-						method: "POST",
-						body: JSON.stringify(payload),
-						headers: new Headers({
-							"Content-Type": "application/json",
-							authorization: `Bearer ${validToken}`,
-						}),
-					});
-					expect(retryRes.status).toBe(204);
-				} else {
-					throw new Error(`Unexpected status ${res.status}: ${responseText}`);
-				}
-			} else {
-				expect(res.status).toBe(204);
-			}
+			expect(events.map((e) => e.status)).toContain("successful");
 		}
-	}, 600_000);
+	}, 20_000);
 
 	it("POST /llm/just-chatting should handle a valid request", async () => {
+		// Mock prompt assembly (Langfuse) and the LLM stream (Mistral) so the
+		// route smoke-test is deterministic and never depends on external APIs.
+		vi.spyOn(GenerationService.prototype, "createPrompt").mockResolvedValue({
+			messages: [],
+			promptClient: null,
+		} as never);
+		vi.spyOn(
+			GenerationService.prototype,
+			"generateTextStreamResponse",
+		).mockResolvedValue(
+			new Response(
+				'data: {"type":"text-delta","delta":"hi"}\n\ndata: [DONE]\n\n',
+				{
+					status: 200,
+				},
+			),
+		);
+
 		const payload = {
 			messages: [
 				{
@@ -365,46 +357,20 @@ describe("Integration Tests for Routes", () => {
 			}),
 		});
 		expect(res.status).toBe(200);
-	}, 80_000);
+	}, 20_000);
 
 	it("should return no errors when deleting a document with valid document ID", async () => {
-		const fileName = "delete-me.pdf";
-		const sourceUrl = `${OWNER_USER_ID}/${fileName}`;
 		const pdfBytes = await generatePdfBytesFromText("Document to be deleted");
 
-		await uploadToStorage({
-			bytes: pdfBytes,
-			sourceUrl,
-			fileName,
-			userToken: validToken,
+		const events = await processViaRoute({
+			metadata: personalMetadata,
+			token: validToken,
+			file: pdfFileFromBytes(pdfBytes, "delete-me.pdf"),
 		});
 
-		const newDocPayload = {
-			document: {
-				file_name: fileName,
-				owned_by_user_id: OWNER_USER_ID,
-				registered_at: new Date().toISOString(),
-				source_type: "personal_document",
-				source_url: sourceUrl,
-				folder_id: null,
-			},
-			llm_model: config.defaultDocumentProcessingModel,
-		};
-		const uploadRes = await app.request("/documents/process", {
-			method: "POST",
-			body: JSON.stringify(newDocPayload),
-			headers: new Headers({
-				"Content-Type": "application/json",
-				authorization: `Bearer ${validToken}`,
-			}),
-		});
-		expect(uploadRes.status).toBe(204);
-
-		// Get the uploaded document ID
-		const documentId = await getLatestDocumentIdBySourceUrl(
-			OWNER_USER_ID,
-			sourceUrl,
-		);
+		const documentId = events.find(
+			(e) => e.status === "successful",
+		)?.documentId;
 		expect(documentId).toBeDefined();
 
 		// Delete the uploaded document as the authenticated owner
@@ -416,54 +382,25 @@ describe("Integration Tests for Routes", () => {
 		const { data: deletedDocuments } = await serviceRoleDbClient
 			.from("documents")
 			.select("id")
-			.eq("source_url", sourceUrl)
-			.eq("owned_by_user_id", OWNER_USER_ID)
-			.order("created_at", { ascending: false })
-			.limit(1);
+			.eq("id", documentId as number);
 		expect(deletedDocuments).toBeDefined();
 		expect(deletedDocuments && deletedDocuments.length).toBe(0);
-	}, 100_000);
+	}, 20_000);
 
 	it("should cascade document deletion to also delete summaries and chunks", async () => {
-		const fileName = "delete-cascade.pdf";
-		const sourceUrl = `${OWNER_USER_ID}/${fileName}`;
 		const pdfBytes = await generatePdfBytesFromText(
 			"Document to be deleted with cascade",
 		);
 
-		await uploadToStorage({
-			bytes: pdfBytes,
-			sourceUrl,
-			fileName,
-			userToken: validToken,
+		const events = await processViaRoute({
+			metadata: personalMetadata,
+			token: validToken,
+			file: pdfFileFromBytes(pdfBytes, "delete-cascade.pdf"),
 		});
 
-		const newDocPayload = {
-			document: {
-				file_name: fileName,
-				owned_by_user_id: OWNER_USER_ID,
-				registered_at: new Date().toISOString(),
-				source_type: "personal_document",
-				source_url: sourceUrl,
-				folder_id: null,
-			},
-			llm_model: config.defaultDocumentProcessingModel,
-		};
-		const uploadRes = await app.request("/documents/process", {
-			method: "POST",
-			body: JSON.stringify(newDocPayload),
-			headers: new Headers({
-				"Content-Type": "application/json",
-				authorization: `Bearer ${validToken}`,
-			}),
-		});
-		expect(uploadRes.status).toBe(204);
-
-		// Get the uploaded document ID
-		const documentId = await getLatestDocumentIdBySourceUrl(
-			OWNER_USER_ID,
-			sourceUrl,
-		);
+		const documentId = events.find(
+			(e) => e.status === "successful",
+		)?.documentId;
 		expect(documentId).toBeDefined();
 
 		// Verify the summaries and chunks exist
@@ -494,13 +431,13 @@ describe("Integration Tests for Routes", () => {
 			.select("document_id")
 			.eq("document_id", documentId as number);
 		expect(postChunks?.length ?? 0).toBe(0);
-	}, 80_000);
+	}, 20_000);
 
 	it("should return error when deleting for non-existent document ID", async () => {
 		const deleteResult = await deleteDocument(999, validToken);
 		expect(deleteResult.success).toBe(false);
 		expect(deleteResult.status).toBe(404);
-	}, 80_000);
+	}, 20_000);
 
 	it("should return error when deleting documents if document ID is missing", async () => {
 		const deleteResult = await deleteDocument(
@@ -533,43 +470,18 @@ describe("Integration Tests for Routes", () => {
 
 		const validToken2 = await createValidJwtToken(otherUserEmail, password);
 
-		const fileName = "delete-me-2.pdf";
-		const sourceUrl = `${OTHER_USER_ID}/${fileName}`;
 		const pdfBytes = await generatePdfBytesFromText("Document to be deleted");
 
-		await uploadToStorage({
-			bytes: pdfBytes,
-			sourceUrl,
-			fileName,
-			userToken: validToken2,
+		// Process a document owned by the OTHER user
+		const events = await processViaRoute({
+			metadata: personalMetadata,
+			token: validToken2,
+			file: pdfFileFromBytes(pdfBytes, "delete-me-2.pdf"),
 		});
-
-		const payload2 = {
-			document: {
-				file_name: fileName,
-				owned_by_user_id: OTHER_USER_ID,
-				registered_at: new Date().toISOString(),
-				source_type: "personal_document",
-				source_url: sourceUrl,
-				folder_id: null,
-			},
-			llm_model: config.defaultDocumentProcessingModel,
-		};
-
-		const uploadRes = await app.request("/documents/process", {
-			method: "POST",
-			body: JSON.stringify(payload2),
-			headers: new Headers({
-				"Content-Type": "application/json",
-				authorization: `Bearer ${validToken2}`,
-			}),
-		});
-		expect(uploadRes.status).toBe(204);
-		const docId = await getLatestDocumentIdBySourceUrl(
-			OTHER_USER_ID,
-			sourceUrl,
-		);
+		const docId = events.find((e) => e.status === "successful")?.documentId;
 		expect(docId).toBeDefined();
+
+		// The OWNER user must not be able to delete the OTHER user's document
 		const deleteResult = await deleteDocument(docId as number, validToken);
 		expect(deleteResult.success).toBe(false);
 		expect(deleteResult.status).toBe(404);
@@ -578,5 +490,5 @@ describe("Integration Tests for Routes", () => {
 			.from("documents")
 			.delete()
 			.eq("id", docId as number);
-	}, 60_000);
+	}, 20_000);
 });

--- a/apps/backend/src/routes/documents.ts
+++ b/apps/backend/src/routes/documents.ts
@@ -14,7 +14,6 @@ import { ZodError } from "zod";
 import { ValidationService } from "../services/validation-service";
 import { logMemory } from "../monitoring/memory-logger";
 import { config } from "../config";
-import { clearInterval } from "node:timers";
 
 const documents = new Hono();
 
@@ -27,27 +26,12 @@ documents.post("/process", async (c: Context) =>
 		const validationService = new ValidationService(userScopedDbService);
 
 		let documentId: number | null = null;
-		let sourceUrl: string | null = null;
-		let bucket: string | null = null;
 
 		const userId: string = c.get("authenticatedUserId");
 		const reqId =
 			config.nodeEnv === "production"
 				? crypto.randomUUID().slice(0, 8)
 				: (userId?.slice(0, 8) ?? "no-user");
-
-		/**
-		 * CloudFoundry might kill the request when there is a long silence
-		 * So we add a new line every 10 seconds
-		 */
-		const heartbeat = setInterval(async () => {
-			try {
-				await stream.writeSSE({ data: "" });
-			} catch (error) {
-				captureError(error);
-				clearInterval(heartbeat);
-			}
-		}, 10_000);
 
 		try {
 			logMemory("doc:start", reqId);
@@ -56,11 +40,11 @@ documents.post("/process", async (c: Context) =>
 
 			// Validate document request (path, folder ownership, file existence)
 			const {
-				sourceUrl: generatedSourceUrl,
+				sourceUrl,
 				sourceType,
 				createdAt,
 				llmModel,
-				bucket: foundBucket,
+				bucket,
 				file,
 				folderId,
 				accessGroupId,
@@ -68,9 +52,6 @@ documents.post("/process", async (c: Context) =>
 				body,
 				userId,
 			});
-
-			sourceUrl = generatedSourceUrl;
-			bucket = foundBucket;
 
 			await stream.writeSSE({
 				data: JSON.stringify({
@@ -143,8 +124,6 @@ documents.post("/process", async (c: Context) =>
 					userScopedDbService,
 					userId,
 					documentId,
-					sourceUrl,
-					bucket,
 				});
 				return stream.writeSSE({
 					data: JSON.stringify({
@@ -196,8 +175,6 @@ documents.post("/process", async (c: Context) =>
 				userScopedDbService,
 				userId,
 				documentId,
-				sourceUrl,
-				bucket,
 			});
 
 			return stream.writeSSE({
@@ -206,8 +183,6 @@ documents.post("/process", async (c: Context) =>
 					error: "Internal Server Error",
 				}),
 			});
-		} finally {
-			clearInterval(heartbeat);
 		}
 	}),
 );
@@ -247,32 +222,15 @@ documents.delete("/:documentId", async (c: Context) => {
 async function cleanup(args: {
 	userScopedDbService: UserScopedDbService;
 	userId: string;
-	sourceUrl: string | null;
-	bucket: string | null;
 	documentId: number | null;
 }) {
-	const { userScopedDbService, userId, documentId, sourceUrl, bucket } = args;
+	const { userScopedDbService, userId, documentId } = args;
 
 	if (documentId !== null) {
 		try {
 			await userScopedDbService.deleteDocument(documentId, userId);
 		} catch (deleteDocumentError) {
 			captureError(deleteDocumentError);
-		}
-	}
-
-	/**
-	 * You might wonder why deleteFileFromStorage is called on top
-	 * of deleteDocument (which calls deleteFileFromStorage):
-	 * extractDocument generates a preview for docx documents.
-	 * If another step fails before saving the data in the DB (we won't have a documentId),
-	 * we'll have an orphan preview document in storage that needs to be cleaned up.
-	 */
-	if (sourceUrl !== null && bucket !== null) {
-		try {
-			await userScopedDbService.deleteFileFromStorage(sourceUrl, bucket);
-		} catch (deleteFileError) {
-			captureError(deleteFileError);
 		}
 	}
 }

--- a/apps/backend/src/routes/documents.ts
+++ b/apps/backend/src/routes/documents.ts
@@ -142,7 +142,7 @@ documents.post("/process", async (c: Context) =>
 			logMemory("doc:error", reqId);
 			captureError(error);
 
-			if (error.message === "failed.format") {
+			if (error instanceof Error && error.message === "failed.format") {
 				return stream.writeSSE({
 					data: JSON.stringify({
 						status: "failed.format",
@@ -150,7 +150,7 @@ documents.post("/process", async (c: Context) =>
 				});
 			}
 
-			if (error.message === "failed.size") {
+			if (error instanceof Error && error.message === "failed.size") {
 				return stream.writeSSE({
 					data: JSON.stringify({
 						status: "failed.size",

--- a/apps/backend/src/routes/documents.ts
+++ b/apps/backend/src/routes/documents.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
-import { Hono } from "hono";
-import type { Context } from "hono";
+import { Hono, type Context } from "hono";
+import { streamSSE } from "hono/streaming";
 import { UserScopedDbService } from "../services/db-service/user-scoped-db-service";
 import { EmbeddingService } from "../services/embedding-service";
 import { GenerationService } from "../services/generation-service";
@@ -10,128 +10,207 @@ import {
 	DefaultDocumentDeletionError,
 	DocumentNotFoundError,
 } from "../types/common";
-import { documentProcessSchema } from "../schemas/document-process-schema";
 import { ZodError } from "zod";
 import { ValidationService } from "../services/validation-service";
 import { logMemory } from "../monitoring/memory-logger";
 import { config } from "../config";
+import { clearInterval } from "node:timers";
 
 const documents = new Hono();
 
-documents.post("/process", async (c: Context) => {
-	const userClient = c.get("UserScopedDbClient");
-	const userScopedDbService = new UserScopedDbService(userClient);
-	const embeddingService = new EmbeddingService(userScopedDbService);
-	const generationService = new GenerationService(userScopedDbService);
-	const validationService = new ValidationService(userScopedDbService);
+documents.post("/process", async (c: Context) =>
+	streamSSE(c, async (stream) => {
+		const userClient = c.get("UserScopedDbClient");
+		const userScopedDbService = new UserScopedDbService(userClient);
+		const embeddingService = new EmbeddingService(userScopedDbService);
+		const generationService = new GenerationService(userScopedDbService);
+		const validationService = new ValidationService(userScopedDbService);
 
-	let sourceUrl: string | null = null;
-	let bucket: string | null = null;
-	const authenticatedUserId = c.get("authenticatedUserId");
-	const reqId =
-		config.nodeEnv === "production"
-			? crypto.randomUUID().slice(0, 8)
-			: ((authenticatedUserId as string)?.slice(0, 8) ?? "no-user");
+		let documentId: number | null = null;
+		let sourceUrl: string | null = null;
+		let bucket: string | null = null;
 
-	try {
-		logMemory("doc:start", reqId);
-		// Parse and validate request body
-		const body = await c.req.json();
-		const parseResult = documentProcessSchema.parse(body);
+		const userId: string = c.get("authenticatedUserId");
+		const reqId =
+			config.nodeEnv === "production"
+				? crypto.randomUUID().slice(0, 8)
+				: (userId?.slice(0, 8) ?? "no-user");
 
-		const { document: inputDocument, llm_model: llmIdentifier } = parseResult;
-		sourceUrl = inputDocument.source_url;
-
-		// Validate document request (path, folder ownership, file existence)
-		const validationResult = await validationService.validateDocumentRequest(
-			inputDocument,
-			authenticatedUserId,
-		);
-		if (validationResult.success === false) {
-			captureError(new Error(validationResult.error));
-			return c.json({ error: validationResult.error }, validationResult.status);
-		}
-		bucket = validationResult.bucket;
-
-		// Step 1: Extract document content (no DB record created yet)
-		const documentForExtraction: Document = {
-			source_url: sourceUrl,
-			source_type: inputDocument.source_type,
-			created_at: inputDocument.created_at || new Date().toISOString(),
-		};
-		const extractionResult = await userScopedDbService.extractDocument(
-			documentForExtraction,
-		);
-		logMemory(
-			`doc:after-extract (pages=${extractionResult.numPages}, size=${extractionResult.fileSize})`,
-			reqId,
-		);
-
-		// Step 2: Process document (embed and summarize)
-		// Always use authenticated user ID, never trust client input for owned_by_user_id
-		const documentForProcessing: Document = {
-			folder_id: inputDocument.folder_id ?? undefined,
-			owned_by_user_id:
-				inputDocument.source_type === "personal_document"
-					? authenticatedUserId
-					: undefined,
-			created_at: inputDocument.created_at || new Date().toISOString(),
-			access_group_id: inputDocument.access_group_id ?? undefined,
-			uploaded_by_user_id:
-				inputDocument.source_type !== "personal_document"
-					? authenticatedUserId
-					: undefined,
-			source_url: sourceUrl,
-			file_name: inputDocument.file_name,
-			source_type: inputDocument.source_type,
-			file_checksum: extractionResult.checksum,
-			file_size: extractionResult.fileSize,
-			num_pages: extractionResult.numPages,
-		};
-
-		const parsedPages = extractionResult.parsedPages;
-		const [summaryData, embeddings] = await Promise.all([
-			generationService.summarize(
-				parsedPages,
-				llmIdentifier,
-				documentForProcessing,
-			),
-			embeddingService.batchEmbed(parsedPages, documentForProcessing),
-		]);
-
-		logMemory(`doc:after-embed+summarize (chunks=${embeddings.length})`, reqId);
-		// Step 3: Create complete document record
-		await userScopedDbService.logProcessedDocument(
-			documentForProcessing,
-			summaryData,
-			embeddings,
-		);
-
-		logMemory("doc:complete", reqId);
-		return c.body(null, 204);
-	} catch (error) {
-		logMemory("doc:error", reqId);
-		captureError(error);
-
-		// Handle Zod validation errors separately
-		if (error instanceof ZodError) {
-			const errors = error.issues
-				.map((e) => `${e.path.join(".")}: ${e.message}`)
-				.join("; ");
-			return c.json({ error: `Validation failed: ${errors}` }, 400);
-		}
-
-		// If processing failed, clean up the storage file
-		if (sourceUrl !== null && bucket !== null) {
+		/**
+		 * CloudFoundry might kill the request when there is a long silence
+		 * So we add a new line every 10 seconds
+		 */
+		const heartbeat = setInterval(async () => {
 			try {
-				await userScopedDbService.deleteFileFromStorage(sourceUrl, bucket);
-			} catch (cleanupError) {
-				captureError(cleanupError);
+				await stream.writeSSE({ data: "" });
+			} catch (error) {
+				captureError(error);
+				clearInterval(heartbeat);
 			}
+		}, 10_000);
+
+		try {
+			logMemory("doc:start", reqId);
+			// Parse and validate request body
+			const body = await c.req.parseBody();
+
+			// Validate document request (path, folder ownership, file existence)
+			const {
+				sourceUrl: generatedSourceUrl,
+				sourceType,
+				createdAt,
+				llmModel,
+				bucket: foundBucket,
+				file,
+				folderId,
+				accessGroupId,
+			} = await validationService.validateDocumentRequest({
+				body,
+				userId,
+			});
+
+			sourceUrl = generatedSourceUrl;
+			bucket = foundBucket;
+
+			await stream.writeSSE({
+				data: JSON.stringify({
+					status: "processing",
+				}),
+			});
+
+			// Step 1: Extract document content (no DB record created yet)
+			const documentForExtraction = {
+				source_url: sourceUrl,
+				source_type: sourceType,
+				created_at: createdAt,
+			};
+
+			const extractionResult = await userScopedDbService.extractDocument(
+				documentForExtraction,
+				file,
+			);
+
+			logMemory(
+				`doc:after-extract (pages=${extractionResult.numPages}, size=${extractionResult.fileSize})`,
+				reqId,
+			);
+
+			// Step 2: Process document (embed and summarize)
+			// Always use authenticated user ID, never trust client input for owned_by_user_id
+			const documentForProcessing: Document = {
+				folder_id: folderId ?? undefined,
+				owned_by_user_id:
+					sourceType === "personal_document" ? userId : undefined,
+				created_at: createdAt,
+				access_group_id: accessGroupId,
+				uploaded_by_user_id:
+					sourceType !== "personal_document" ? userId : undefined,
+				source_url: sourceUrl,
+				file_name: file.name,
+				source_type: sourceType,
+				file_checksum: extractionResult.checksum,
+				file_size: extractionResult.fileSize,
+				num_pages: extractionResult.numPages,
+			};
+
+			const parsedPages = extractionResult.parsedPages;
+			const [summaryData, embeddings] = await Promise.all([
+				generationService.summarize(
+					parsedPages,
+					llmModel,
+					documentForProcessing,
+				),
+				embeddingService.batchEmbed(parsedPages, documentForProcessing),
+			]);
+
+			logMemory(
+				`doc:after-embed+summarize (chunks=${embeddings.length})`,
+				reqId,
+			);
+
+			// Step 3: Create complete document record
+			documentId = await userScopedDbService.logProcessedDocument(
+				documentForProcessing,
+				summaryData,
+				embeddings,
+			);
+
+			// Step 4: Upload file to storage
+			await userScopedDbService.uploadFileToStorage(sourceUrl, file, bucket);
+
+			if (c.req.raw.signal.aborted) {
+				await cleanup({
+					userScopedDbService,
+					userId,
+					documentId,
+					sourceUrl,
+					bucket,
+				});
+				return stream.writeSSE({
+					data: JSON.stringify({
+						status: "canceled",
+					}),
+				});
+			}
+
+			return stream.writeSSE({
+				data: JSON.stringify({
+					status: "successful",
+					documentId,
+				}),
+			});
+		} catch (error) {
+			logMemory("doc:error", reqId);
+			captureError(error);
+
+			if (error.message === "failed.format") {
+				return stream.writeSSE({
+					data: JSON.stringify({
+						status: "failed.format",
+					}),
+				});
+			}
+
+			if (error.message === "failed.size") {
+				return stream.writeSSE({
+					data: JSON.stringify({
+						status: "failed.size",
+					}),
+				});
+			}
+
+			// Handle Zod validation errors separately
+			if (error instanceof ZodError) {
+				const errors = error.issues
+					.map((e) => `${e.path.join(".")}: ${e.message}`)
+					.join("; ");
+				return stream.writeSSE({
+					data: JSON.stringify({
+						status: "failed.generic",
+						error: `Validation failed: ${errors}`,
+					}),
+				});
+			}
+
+			await cleanup({
+				userScopedDbService,
+				userId,
+				documentId,
+				sourceUrl,
+				bucket,
+			});
+
+			return stream.writeSSE({
+				data: JSON.stringify({
+					status: "failed.generic",
+					error: "Internal Server Error",
+				}),
+			});
+		} finally {
+			clearInterval(heartbeat);
 		}
-		return c.json({ error: "Internal Server Error" }, 500);
-	}
-});
+	}),
+);
 
 documents.delete("/:documentId", async (c: Context) => {
 	const userClient = c.get("UserScopedDbClient");
@@ -164,5 +243,38 @@ documents.delete("/:documentId", async (c: Context) => {
 		return c.json({ error: "Internal Server Error" }, 500);
 	}
 });
+
+async function cleanup(args: {
+	userScopedDbService: UserScopedDbService;
+	userId: string;
+	sourceUrl: string | null;
+	bucket: string | null;
+	documentId: number | null;
+}) {
+	const { userScopedDbService, userId, documentId, sourceUrl, bucket } = args;
+
+	if (documentId !== null) {
+		try {
+			await userScopedDbService.deleteDocument(documentId, userId);
+		} catch (deleteDocumentError) {
+			captureError(deleteDocumentError);
+		}
+	}
+
+	/**
+	 * You might wonder why deleteFileFromStorage is called on top
+	 * of deleteDocument (which calls deleteFileFromStorage):
+	 * extractDocument generates a preview for docx documents.
+	 * If another step fails before saving the data in the DB (we won't have a documentId),
+	 * we'll have an orphan preview document in storage that needs to be cleaned up.
+	 */
+	if (sourceUrl !== null && bucket !== null) {
+		try {
+			await userScopedDbService.deleteFileFromStorage(sourceUrl, bucket);
+		} catch (deleteFileError) {
+			captureError(deleteFileError);
+		}
+	}
+}
 
 export default documents;

--- a/apps/backend/src/schemas/document-process-schema.ts
+++ b/apps/backend/src/schemas/document-process-schema.ts
@@ -2,69 +2,16 @@ import { z } from "zod";
 import { allowedSourceTypes } from "../constants";
 
 /**
- * Schema for validating source_url to prevent path traversal attacks.
- * Valid patterns: "{uuid}/{filename}" or "{uuid}/{filename.ext}"
- * Invalid patterns: "../", "./", "//", absolute paths, etc.
- */
-const sourceUrlSchema = z
-	.string()
-	.min(1, "source_url is required")
-	.refine(
-		(url) => {
-			// Check for path traversal patterns
-			if (url.includes("..") || url.includes("./")) {
-				return false;
-			}
-			// Check for double slashes
-			if (url.includes("//")) {
-				return false;
-			}
-			// Check for absolute paths
-			if (url.startsWith("/")) {
-				return false;
-			}
-			// Must have at least one slash (user_id/filename pattern)
-			if (!url.includes("/")) {
-				return false;
-			}
-			// Must not end with a slash
-			if (url.endsWith("/")) {
-				return false;
-			}
-			return true;
-		},
-		{
-			message:
-				"Invalid source_url format: must be a valid relative path without traversal patterns",
-		},
-	);
-
-/**
  * Schema for the document object in process requests.
  * Note: owned_by_user_id is accepted but will be overridden server-side.
  */
 export const documentProcessSchema = z.object({
 	document: z.object({
-		id: z.null().optional(),
-		file_name: z.string().optional(),
-		folder_id: z.number().int().positive().nullable().optional(),
-		// Accept from client but will be overridden with authenticated user ID
-		owned_by_user_id: z.string().nullable().optional(),
-		created_at: z.iso.datetime().optional(),
-		source_type: z.enum(allowedSourceTypes),
-		source_url: sourceUrlSchema,
-		// Optional metadata - not stored directly, used for client-side info
-		metadata: z
-			.object({
-				mimeType: z.string().optional(),
-				size: z.number().optional(),
-			})
-			.optional(),
-		// Access group for public/default documents
-		access_group_id: z.uuid().nullable().optional(),
-		uploaded_by_user_id: z.uuid().nullable().optional(),
+		folderId: z.number().int().positive().nullable(),
+		sourceType: z.enum(allowedSourceTypes),
+		accessGroupId: z.uuid().nullable().optional(),
 	}),
-	llm_model: z.string().min(1, "llm_model is required"),
+	llmModel: z.string().min(1, "llm_model is required"),
 });
 
 export type DocumentProcessInput = z.infer<typeof documentProcessSchema>;

--- a/apps/backend/src/services/db-service/base-db-service.ts
+++ b/apps/backend/src/services/db-service/base-db-service.ts
@@ -89,16 +89,20 @@ export abstract class BaseContentDbService {
 	}
 
 	async uploadFileToStorage(
-		filePath: string,
+		sourceUrl: string,
 		file: File,
 		bucket: string,
 	): Promise<void> {
 		const { error: uploadError } = await this.client.storage
 			.from(bucket)
-			.upload(filePath, file);
+			.upload(sourceUrl, file);
 
 		if (uploadError) {
 			throw uploadError;
+		}
+
+		if (/\.(docx?)$/i.test(sourceUrl)) {
+			await this.savePdfPreview({ file, sourceUrl, bucket });
 		}
 	}
 
@@ -258,17 +262,7 @@ export abstract class BaseContentDbService {
 		document: Document,
 		file: File,
 	): Promise<ExtractionResult> {
-		const bucket = ["public_document", "default_document"].includes(
-			document.source_type,
-		)
-			? "public_documents"
-			: "documents";
-
 		const fileBytes = await file.bytes();
-
-		if (/\.(docx?)$/i.test(document.source_url)) {
-			await this.savePdfPreview({ fileBytes, bucket, document });
-		}
 
 		const extractionResult = await documentExtraction.extractDocument(
 			fileBytes,
@@ -279,25 +273,24 @@ export abstract class BaseContentDbService {
 	}
 
 	async savePdfPreview({
-		fileBytes,
+		file,
 		bucket,
-		document,
+		sourceUrl,
 	}: {
-		fileBytes: Uint8Array;
+		file: File;
 		bucket: string;
-		document: Document;
+		sourceUrl: string;
 	}) {
-		const pdfPreviewUrl = document.source_url.replace(/\.(docx?)$/i, ".pdf");
-		const fileName = document.source_url.split("/").pop();
+		const pdfPreviewUrl = sourceUrl.replace(/\.(docx?)$/i, ".pdf");
 
 		const pdfBuffer = await wordExtractionService.convertWordToPdf({
-			fileName,
-			wordDoc: Buffer.from(fileBytes),
+			fileName: file.name,
+			wordDoc: Buffer.from(await file.bytes()),
 		});
 
 		await this.uploadFileToStorage(
 			pdfPreviewUrl,
-			new File([pdfBuffer], fileName, {
+			new File([pdfBuffer], file.name, {
 				type: "application/pdf",
 			}),
 			bucket,

--- a/apps/backend/src/services/db-service/base-db-service.ts
+++ b/apps/backend/src/services/db-service/base-db-service.ts
@@ -158,7 +158,7 @@ export abstract class BaseContentDbService {
 			tags: string[];
 		},
 		embeddings: Embedding[],
-	): Promise<void> {
+	): Promise<number> {
 		// 1. Insert Document
 		const { data, error } = await this.client
 			.from("documents")
@@ -200,12 +200,12 @@ export abstract class BaseContentDbService {
 			if (userId) {
 				await this.updateUserDocumentCount(userId);
 			}
-
-			return null;
 		} catch (innerError) {
 			await this.deleteDocumentById(documentId);
 			throw innerError;
 		}
+
+		return documentId;
 	}
 
 	/**
@@ -254,17 +254,17 @@ export abstract class BaseContentDbService {
 		}
 	}
 
-	async extractDocument(document: Document): Promise<ExtractionResult> {
+	async extractDocument(
+		document: Document,
+		file: File,
+	): Promise<ExtractionResult> {
 		const bucket = ["public_document", "default_document"].includes(
 			document.source_type,
 		)
 			? "public_documents"
 			: "documents";
 
-		const fileBytes = await this.getDocumentBufferFromSupabase(
-			bucket,
-			document.source_url,
-		);
+		const fileBytes = await file.bytes();
 
 		if (/\.(docx?)$/i.test(document.source_url)) {
 			await this.savePdfPreview({ fileBytes, bucket, document });
@@ -302,29 +302,6 @@ export abstract class BaseContentDbService {
 			}),
 			bucket,
 		);
-	}
-
-	/**
-	 * Downloads a document from Supabase storage and returns it as a buffer
-	 * @param document Document information
-	 * @returns Buffer containing the document data
-	 */
-	async getDocumentBufferFromSupabase(
-		bucket: string,
-		sourceUrl: string,
-	): Promise<Uint8Array> {
-		const { data, error } = await this.client.storage
-			.from(bucket)
-			.download(sourceUrl);
-
-		if (!data) {
-			throw new Error(`Could not download ${sourceUrl}: ${error}`);
-		}
-
-		// Convert the Blob to a Buffer
-		const buffer = new Uint8Array(await data.arrayBuffer());
-
-		return buffer;
 	}
 
 	// Updates the user's document count in the profiles table

--- a/apps/backend/src/services/validation-service.ts
+++ b/apps/backend/src/services/validation-service.ts
@@ -1,6 +1,14 @@
-import { DocumentProcessInput } from "../schemas/document-process-schema";
-import { ValidationResult } from "../types/common";
+import { documentProcessSchema } from "../schemas/document-process-schema";
 import { BaseContentDbService } from "./db-service/base-db-service";
+import { config } from "../config";
+
+const EXTENSION_BY_MIME: Record<string, string> = {
+	"application/pdf": "pdf",
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+		"docx",
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+	"text/csv": "csv",
+};
 
 export class ValidationService {
 	private readonly dbService: BaseContentDbService;
@@ -37,71 +45,101 @@ export class ValidationService {
 		}
 		return { valid: true };
 	}
-	async validateDocumentRequest(
-		inputDocument: DocumentProcessInput["document"],
-		authenticatedUserId: string,
-	): Promise<ValidationResult> {
-		const sourceUrl = inputDocument.source_url;
+	async validateDocumentRequest({
+		body,
+		userId,
+	}: {
+		body: Record<string, string | File>;
+		userId: string;
+	}) {
+		const file = body["file"];
+
+		if (!(file instanceof File)) {
+			throw new Error("failed.format", { cause: "file not instance of File" });
+		}
+
+		const maxSize = config.fileUploadLimitMb * 1024 * 1024;
+
+		if (file.size > maxSize) {
+			throw new Error("failed.size", {
+				cause: `File is too big ${file.size} (max allowed is ${maxSize})`,
+			});
+		}
+
+		const fileExtension = EXTENSION_BY_MIME[file.type];
+
+		if (!fileExtension) {
+			throw new Error("failed.format", {
+				cause: `file extension ${file.type} not supported`,
+			});
+		}
+
+		const metadata = body["metadata"];
+
+		if (typeof metadata !== "string") {
+			throw new Error("metadata not a string");
+		}
+
+		const parseResult = documentProcessSchema.parse(JSON.parse(metadata));
+
+		const {
+			document: { sourceType, accessGroupId, folderId },
+			llmModel,
+		} = parseResult;
+
+		const prefix = sourceType === "personal_document" ? userId : accessGroupId;
+		const sourceUrl = `${prefix}/${crypto.randomUUID()}.${fileExtension}`;
+		const createdAt = new Date().toISOString();
+
 		const bucket =
-			inputDocument.source_type === "personal_document"
-				? "documents"
-				: "public_documents";
+			sourceType === "personal_document" ? "documents" : "public_documents";
 
 		// Path validation
-		if (inputDocument.source_type === "personal_document") {
+		if (sourceType === "personal_document") {
 			const pathValidation = this.validatePersonalSourceUrlPath(
 				sourceUrl,
-				authenticatedUserId,
+				userId,
 			);
 			if (!pathValidation.valid) {
-				return { success: false, error: pathValidation.error, status: 403 };
+				throw new Error(pathValidation.error);
 			}
 		} else {
-			if (!inputDocument.access_group_id) {
-				return {
-					success: false,
-					error: "access_group_id is required for public/default documents",
-					status: 400,
-				};
+			if (!accessGroupId) {
+				throw new Error(
+					"access_group_id is required for public/default documents",
+				);
 			}
 			const pathValidation = this.validatePublicSourceUrlPath(
 				sourceUrl,
-				inputDocument.access_group_id,
+				accessGroupId,
 			);
 			if (!pathValidation.valid) {
-				return { success: false, error: pathValidation.error, status: 403 };
+				throw new Error(pathValidation.error);
 			}
 		}
 
 		// Folder ownership validation
-		if (inputDocument.folder_id !== null) {
+		if (folderId !== null) {
 			const folderBelongsToUser = await this.dbService.validateFolderOwnership(
-				inputDocument.folder_id,
-				authenticatedUserId,
+				folderId,
+				userId,
 			);
 			if (!folderBelongsToUser) {
-				return {
-					success: false,
-					error:
-						"Unauthorized: folder_id does not belong to the authenticated user",
-					status: 403,
-				};
+				throw new Error(
+					"Unauthorized: folder_id does not belong to the authenticated user",
+				);
 			}
 		}
 
-		// File existence validation
-		const fileExists = await this.dbService.validateFileExistsInStorage(
+		return {
 			sourceUrl,
+			sourceType,
+			folderId,
+			createdAt,
+			accessGroupId,
+			llmModel,
 			bucket,
-		);
-		if (!fileExists) {
-			return {
-				success: false,
-				error: "File not found in storage at the specified source_url",
-				status: 404,
-			};
-		}
-
-		return { success: true, bucket };
+			file,
+		};
 	}
 }

--- a/apps/backend/src/types/common.ts
+++ b/apps/backend/src/types/common.ts
@@ -281,7 +281,3 @@ export type AllowedEmailDomain = {
 	id: number;
 	domain: string;
 };
-
-export type ValidationResult =
-	| { success: true; bucket: string }
-	| { success: false; error: string; status: 400 | 403 | 404 };

--- a/apps/backend/supabase/scripts/upload-default-documents.ts
+++ b/apps/backend/supabase/scripts/upload-default-documents.ts
@@ -112,7 +112,7 @@ async function processDocument(
 		access_group_id: accessGroupId,
 	};
 	try {
-		const extractionResult = await dbService.extractDocument(document);
+		const extractionResult = await dbService.extractDocument(document, file);
 
 		const documentForProcessing: Document = {
 			...document,

--- a/apps/frontend/src/api/documents/upload-file.ts
+++ b/apps/frontend/src/api/documents/upload-file.ts
@@ -1,69 +1,41 @@
-import { StorageApiError } from "@supabase/storage-js";
 import { useAuthStore } from "../../store/auth-store";
 import { useCurrentFolderStore } from "../../store/use-current-folder-store.ts";
-import { supabase } from "../../../supabase-client";
+import {
+	UPLOAD_STATUS_MAP,
+	type UploadStatusKeys,
+} from "../../store/use-file-uploads-store.ts";
+import { captureError } from "../../monitoring/capture-error.ts";
 
-/**
- * Uploads the file directly to Supabase Storage.
- */
-export async function uploadFileToDb(
+export async function uploadAndProcessDocument(
 	file: File,
-	filePath: string,
-): Promise<void> {
-	try {
-		const { error: uploadError } = await supabase.storage
-			.from("documents")
-			.upload(filePath, file);
-
-		if (uploadError) {
-			throw uploadError;
-		}
-	} catch (error) {
-		if (error instanceof StorageApiError && error.status === 409) {
-			throw new Error("failed.duplicate");
-		} else {
-			throw new Error("failed.generic");
-		}
-	}
-}
-
-/**
- * Process: metadata only; backend loads file bytes by sourceUrl
- */
-export async function processDocument(
-	file: File,
-	filePath: string,
-): Promise<void> {
+	updateFileUploadStatusCallback: (status: UploadStatusKeys) => void,
+): Promise<number> {
 	const { session } = useAuthStore.getState();
 	const { currentFolder } = useCurrentFolderStore.getState();
 
 	// Create document metadata
 	const documentData = {
 		document: {
-			id: null,
-			folder_id: currentFolder?.id || null,
-			owned_by_user_id: session?.user.id,
-			created_at: new Date().toISOString(),
-			source_type: "personal_document",
-			source_url: filePath,
-			file_name: file.name,
-			metadata: {
-				mimeType: file.type,
-				size: file.size,
-			},
+			folderId: currentFolder?.id || null,
+			sourceType: "personal_document",
 		},
-		llm_model: import.meta.env.VITE_DEFAULT_DOCUMENT_PROCESSING_MODEL,
+		llmModel: import.meta.env.VITE_DEFAULT_DOCUMENT_PROCESSING_MODEL,
 	};
+
+	const form = new FormData();
+	form.append("file", file);
+	form.append("metadata", JSON.stringify(documentData));
+
+	updateFileUploadStatusCallback("uploading");
 
 	const url = `${import.meta.env.VITE_API_URL}/documents/process`;
 
 	const response = await fetch(url, {
 		method: "POST",
 		headers: {
-			"Content-Type": "application/json",
 			Authorization: `Bearer ${session?.access_token}`,
 		},
-		body: JSON.stringify(documentData),
+		body: form,
 	});
 
 	if (!response.ok) {
@@ -71,12 +43,75 @@ export async function processDocument(
 			.json()
 			.catch(() => ({ message: "Unknown error" }));
 
-		// Handle specific backend error codes
-		if (response.status === 409) {
-			throw new Error("failed.duplicate");
-		}
-
-		console.error("Document processing failed:", errorResponse);
-		throw new Error("failed.generic");
+		throw new Error(
+			`Document processing failed: ${JSON.stringify(errorResponse)}`,
+		);
 	}
+
+	if (!response.body) {
+		throw new Error("Document processing response has no body");
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	let documentId: number | null = null;
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+
+			if (done) {
+				break;
+			}
+
+			buffer += decoder.decode(value, { stream: true });
+			const lines = buffer.split("\n");
+			buffer = lines.pop() ?? ""; // last line may be incomplete — keep i
+
+			for (const line of lines) {
+				if (!line.startsWith("data: ")) {
+					continue;
+				}
+
+				const payload = line.slice(6).trim();
+				if (!payload) {
+					continue;
+				}
+
+				let event;
+				try {
+					event = JSON.parse(payload);
+				} catch {
+					continue; // ignore anything unparseable, it can be just a heartbeat
+				}
+
+				const status: unknown = event?.status;
+
+				if (typeof status !== "string" || !(status in UPLOAD_STATUS_MAP)) {
+					continue;
+				}
+
+				updateFileUploadStatusCallback(status as UploadStatusKeys);
+
+				if (status.startsWith("failed")) {
+					throw new Error(status);
+				}
+
+				updateFileUploadStatusCallback(event.status);
+
+				if (event.status === "successful") {
+					documentId = event.documentId;
+				}
+			}
+		}
+	} finally {
+		reader.cancel().catch((error) => captureError(error));
+	}
+
+	if (documentId === null) {
+		throw new Error("Stream finished without receiving a documentId");
+	}
+
+	return documentId;
 }

--- a/apps/frontend/src/api/documents/upload-file.ts
+++ b/apps/frontend/src/api/documents/upload-file.ts
@@ -99,8 +99,6 @@ export async function uploadAndProcessDocument(
 					throw new Error(status);
 				}
 
-				updateFileUploadStatusCallback(event.status);
-
 				if (event.status === "successful") {
 					documentId = event.documentId;
 				}

--- a/apps/frontend/src/api/documents/upload-file.ts
+++ b/apps/frontend/src/api/documents/upload-file.ts
@@ -67,14 +67,15 @@ export async function uploadAndProcessDocument(
 
 			buffer += decoder.decode(value, { stream: true });
 			const lines = buffer.split("\n");
-			buffer = lines.pop() ?? ""; // last line may be incomplete — keep i
+			buffer = lines.pop() ?? "";
 
 			for (const line of lines) {
-				if (!line.startsWith("data: ")) {
+				const prefix = "data: ";
+				if (!line.startsWith(prefix)) {
 					continue;
 				}
 
-				const payload = line.slice(6).trim();
+				const payload = line.slice(prefix.length).trim();
 				if (!payload) {
 					continue;
 				}

--- a/apps/frontend/src/components/chat/chat-form/chat-menu/chat-menu-section.tsx
+++ b/apps/frontend/src/components/chat/chat-form/chat-menu/chat-menu-section.tsx
@@ -51,7 +51,7 @@ export const ChatMenuSection: React.FC<ChatMenuSectionProps> = ({
 		const files = event.target.files;
 
 		if (files && files.length > 0) {
-			uploadFiles(Array.from(files), { selectInChatOnSuccess: true }).catch(
+			uploadFiles(Array.from(files)).catch(
 				useErrorStore.getState().handleError,
 			);
 		}

--- a/apps/frontend/src/components/documents/file-upload/file-upload-list.tsx
+++ b/apps/frontend/src/components/documents/file-upload/file-upload-list.tsx
@@ -46,9 +46,7 @@ export function FileUploadList() {
 									</span>
 								)}
 								{/* Icons */}
-								{(status === "uploading" ||
-									status === "processing" ||
-									status === "uploaded") && (
+								{(status === "uploading" || status === "processing") && (
 									<LoadingSpinnerIcon variant="disabled" size="small" />
 								)}
 								{status === "successful" && <GreenCheckIcon size="small" />}

--- a/apps/frontend/src/components/drop-zone-wrapper-app.tsx
+++ b/apps/frontend/src/components/drop-zone-wrapper-app.tsx
@@ -25,9 +25,7 @@ export function DropZoneWrapperApp({ children }: { children: ReactNode }) {
 		if (isDropZoneDisabled) {
 			return;
 		}
-		uploadFiles(acceptedFiles, { selectInChatOnSuccess: true }).catch(
-			useErrorStore.getState().handleError,
-		);
+		uploadFiles(acceptedFiles).catch(useErrorStore.getState().handleError);
 	};
 
 	const { getRootProps, getInputProps, isDragActive } = useDropzone({

--- a/apps/frontend/src/store/use-file-uploads-store.ts
+++ b/apps/frontend/src/store/use-file-uploads-store.ts
@@ -27,18 +27,10 @@ export type FileUpload = {
 
 const SUCCESSFUL_UPLOAD_REMOVAL_DELAY_MS = 10_000;
 
-export type UploadFilesOptions = {
-	selectInChatOnSuccess?: boolean;
-};
-
 type UseFileUploadsStore = {
 	fileUploads: FileUpload[];
-	uploadFile: (args: {
-		fileUpload: FileUpload;
-		span: Span;
-		selectInChatOnSuccess?: boolean;
-	}) => Promise<void>;
-	uploadFiles: (files: File[], options?: UploadFilesOptions) => Promise<void>;
+	uploadFile: (args: { fileUpload: FileUpload; span: Span }) => Promise<void>;
+	uploadFiles: (files: File[]) => Promise<void>;
 	isUploadingOver: () => boolean;
 	hasAvailableUploadSlots: () => boolean;
 	updateFileUploadStatus: (file: File, status: UploadStatusKeys) => void;
@@ -49,7 +41,7 @@ type UseFileUploadsStore = {
 export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 	fileUploads: [],
 
-	async uploadFile({ fileUpload: { file }, span, selectInChatOnSuccess }) {
+	async uploadFile({ fileUpload: { file }, span }) {
 		const { updateFileUploadStatus } = get();
 		const { userDocuments, getUserDocuments, selectUserChatDocument } =
 			useUserDocumentStore.getState();
@@ -87,14 +79,12 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 
 			await getUserDocuments(new AbortController().signal);
 
-			if (selectInChatOnSuccess) {
-				const uploadedDocument = useUserDocumentStore
-					.getState()
-					.userDocuments.find((doc) => doc.id === id);
+			const uploadedDocument = useUserDocumentStore
+				.getState()
+				.userDocuments.find((doc) => doc.id === id);
 
-				if (uploadedDocument) {
-					selectUserChatDocument(uploadedDocument);
-				}
+			if (uploadedDocument) {
+				selectUserChatDocument(uploadedDocument);
 			}
 
 			updateFileUploadStatus(file, "successful");
@@ -114,9 +104,8 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 		}
 	},
 
-	uploadFiles: async (files: File[], options?: UploadFilesOptions) => {
+	uploadFiles: async (files: File[]) => {
 		const { fileUploads, uploadFile } = get();
-		const { selectInChatOnSuccess } = options ?? {};
 		const { userDocuments, deletedDefaultDocumentIds } =
 			useUserDocumentStore.getState();
 
@@ -185,7 +174,7 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 					Sentry.startSpan(
 						{ name: "File Upload", op: "file.upload" },
 						async (span) => {
-							await uploadFile({ fileUpload, span, selectInChatOnSuccess });
+							await uploadFile({ fileUpload, span });
 						},
 					).finally(() => {
 						queueState.activeUploads--;

--- a/apps/frontend/src/store/use-file-uploads-store.ts
+++ b/apps/frontend/src/store/use-file-uploads-store.ts
@@ -1,22 +1,15 @@
 import { create } from "zustand";
 import { useUserDocumentStore } from "./use-user-document-store.ts";
-import { useAuthStore } from "./auth-store.ts";
-import {
-	uploadFileToDb,
-	processDocument,
-} from "../api/documents/upload-file.ts";
+import { uploadAndProcessDocument } from "../api/documents/upload-file.ts";
 import { useErrorStore } from "./error-store.ts";
 import * as Sentry from "@sentry/react";
 import type { Span } from "@sentry/react";
-import { deleteFileFromStorage } from "../api/documents/delete-file-from-storage.ts";
-import { isDocumentInDatabase } from "../api/documents/is-document-in-database.ts";
 
 export const UPLOAD_STATUS_MAP = {
 	waiting: "Warte",
 	uploading: "Hochladen läuft",
-	uploaded: "Erfolgreich hochgeladen",
-	processing: "Hochladen läuft",
-	successful: "Erfolgreich hochgeladen",
+	processing: "Verarbeitung läuft",
+	successful: "Bereit zur Nutzung",
 	canceled: "Hochladen abgebrochen",
 	"failed.generic": "Hochladen fehlgeschlagen",
 	"failed.duplicate": "Datei existiert bereits",
@@ -58,15 +51,11 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 
 	async uploadFile({ fileUpload: { file }, span, selectInChatOnSuccess }) {
 		const { updateFileUploadStatus } = get();
-		const { session } = useAuthStore.getState();
 		const { userDocuments, getUserDocuments, selectUserChatDocument } =
 			useUserDocumentStore.getState();
 
 		const uploadFileSizeLimit = import.meta.env.VITE_UPLOAD_FILE_SIZE_LIMIT_MB;
-		const fileExtension = file.name.split(".").pop();
-		const filePath = `${session?.user.id}/${crypto.randomUUID()}.${fileExtension}`;
-		let storageUploadSucceeded = false;
-		let documentCreated = false;
+
 		try {
 			if (file.size > uploadFileSizeLimit * 1024 * 1024) {
 				throw new Error("failed.size");
@@ -92,21 +81,16 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 				throw new Error("failed.format");
 			}
 
-			updateFileUploadStatus(file, "uploading");
-			await uploadFileToDb(file, filePath);
-			storageUploadSucceeded = true;
-			updateFileUploadStatus(file, "uploaded");
-
-			updateFileUploadStatus(file, "processing");
-			await processDocument(file, filePath);
-			documentCreated = true;
+			const id = await uploadAndProcessDocument(file, (status) =>
+				updateFileUploadStatus(file, status),
+			);
 
 			await getUserDocuments(new AbortController().signal);
 
 			if (selectInChatOnSuccess) {
 				const uploadedDocument = useUserDocumentStore
 					.getState()
-					.userDocuments.find((doc) => doc.source_url === filePath);
+					.userDocuments.find((doc) => doc.id === id);
 
 				if (uploadedDocument) {
 					selectUserChatDocument(uploadedDocument);
@@ -120,26 +104,6 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 			}, SUCCESSFUL_UPLOAD_REMOVAL_DELAY_MS);
 		} catch (error) {
 			useErrorStore.getState().handleError(error, span);
-
-			// Storage succeeded, but /documents/process failed or its response
-			// never arrived. That doesn't guarantee no document was created,
-			// so confirm with the server before deleting the file.
-			if (storageUploadSucceeded && !documentCreated) {
-				const { data: documentExists, error: checkError } =
-					await isDocumentInDatabase(filePath);
-
-				if (checkError) {
-					useErrorStore.getState().handleError(checkError, span);
-				}
-
-				if (!checkError && documentExists === false) {
-					const { error: deleteFileError } =
-						await deleteFileFromStorage(filePath);
-					if (deleteFileError) {
-						useErrorStore.getState().handleError(deleteFileError, span);
-					}
-				}
-			}
 
 			if (isKnownError(error)) {
 				updateFileUploadStatus(file, error.message);
@@ -164,7 +128,6 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 			(upload) =>
 				upload.status === "waiting" ||
 				upload.status === "uploading" ||
-				upload.status === "uploaded" ||
 				upload.status === "processing",
 		).length;
 
@@ -239,9 +202,7 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 		const { fileUploads } = get();
 		return fileUploads.every(
 			(fileUpload) =>
-				fileUpload.status !== "uploading" &&
-				fileUpload.status !== "processing" &&
-				fileUpload.status !== "uploaded",
+				fileUpload.status !== "uploading" && fileUpload.status !== "processing",
 		);
 	},
 
@@ -252,9 +213,7 @@ export const useFileUploadsStore = create<UseFileUploadsStore>((set, get) => ({
 		);
 		const activeUploads = fileUploads.filter(
 			(fileUpload) =>
-				fileUpload.status === "uploading" ||
-				fileUpload.status === "processing" ||
-				fileUpload.status === "uploaded",
+				fileUpload.status === "uploading" || fileUpload.status === "processing",
 		);
 		return activeUploads.length < maxFileUploads;
 	},

--- a/apps/frontend/tests/e2e/chat.spec.ts
+++ b/apps/frontend/tests/e2e/chat.spec.ts
@@ -1,5 +1,7 @@
 import { Readable } from "node:stream";
+import { randomUUID } from "node:crypto";
 import {
+	fulfillProcessedDocumentSse,
 	mockDocumentProcessing,
 	mockDocumentUpload,
 	uploadFileViaDragAndDropAndWait,
@@ -185,17 +187,21 @@ test.describe("Chat", () => {
 			await page.goto("/");
 			await page.waitForLoadState("networkidle");
 
-			// Hold /documents/process open so we can control exactly when processing "finishes",
-			// and capture the real (randomUUID-based) source_url the client generated for this upload.
+			// The server generates the storage path now, so we fabricate one to key
+			// the mocked document rows on; the client no longer sends a source_url.
+			const sourceUrl = `${account.id}/${randomUUID()}.pdf`;
+
+			// Hold /documents/process open so we can control exactly when processing
+			// "finishes". The route responds with a 200 SSE stream ending in a
+			// `successful` event whose documentId must match the inserted row so the
+			// client can auto-select the freshly uploaded document into the chat.
 			let releaseProcessing: (() => void) | undefined;
-			let capturedSourceUrl: string | undefined;
+			let processedDocumentId: number | undefined;
 			await page.route("**/documents/process", async (route) => {
-				const body = route.request().postDataJSON();
-				capturedSourceUrl = body.document.source_url;
 				await new Promise<void>((resolve) => {
 					releaseProcessing = resolve;
 				});
-				await route.fulfill({ status: 204 });
+				await fulfillProcessedDocumentSse(route, processedDocumentId ?? 0);
 			});
 
 			// Attach a brand-new file via the chat input's own "+" menu,
@@ -207,7 +213,7 @@ test.describe("Chat", () => {
 				.locator("#chat-form input[type='file']")
 				.setInputFiles(secondaryDocumentPath);
 
-			// Wait until the upload is in flight (storage upload done, /documents/process held)
+			// Wait until the upload is in flight (/documents/process request held)
 			await expect
 				.poll(() => releaseProcessing !== undefined, { timeout: 15_000 })
 				.toBe(true);
@@ -225,18 +231,24 @@ test.describe("Chat", () => {
 				page.getByTestId("user-message-markdown-container"),
 			).not.toBeVisible();
 
-			// Simulate the backend finishing processing (insert matching document rows),
-			// then let the held /documents/process request resolve.
-			if (!capturedSourceUrl) {
-				throw new Error("capturedSourceUrl was not set by the route handler");
-			}
+			// Simulate the backend finishing processing (insert matching document
+			// rows), then let the held request resolve with the new document's id so
+			// the client's post-success refetch can find and auto-select it.
 			await mockDocumentProcessing({
 				userId: account.id,
-				sourceUrl: capturedSourceUrl,
+				sourceUrl,
 				accessGroupId: null,
 				fileName: secondaryDocumentName,
 				sourceType: "personal_document",
 			});
+			const { data: insertedDocument, error: insertedDocumentError } =
+				await supabaseAdminClient
+					.from("documents")
+					.select("id")
+					.eq("source_url", sourceUrl)
+					.single();
+			expect(insertedDocumentError).toBeNull();
+			processedDocumentId = insertedDocument?.id;
 			releaseProcessing?.();
 
 			// Once processing settles, the document is auto-selected into the chat

--- a/apps/frontend/tests/e2e/document.spec.ts
+++ b/apps/frontend/tests/e2e/document.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Request } from "@playwright/test";
 import { testDesktopOnly } from "../fixtures/test-desktop-only.ts";
 import {
 	deleteFileViaUI,
+	fulfillProcessedDocumentSse,
 	mockDocumentProcessing,
 	mockDocumentUpload,
 	attemptFileUploadViaFileChooser,
@@ -28,7 +29,6 @@ import {
 	secondaryDocumentType,
 	seedDefaultDocumentName,
 } from "../constants.ts";
-import { supabaseAdminClient } from "../supabase.ts";
 
 test.describe("Documents", () => {
 	testDesktopOnly(
@@ -54,14 +54,17 @@ test.describe("Documents", () => {
 
 			// Track which requests have been received and resolvers to control them
 			const requestResolvers: Array<() => void> = [];
+			let nextDocumentId = 1;
 
-			// Mock the /documents/process route to control upload completion
+			// Mock the /documents/process route to control upload completion. The
+			// route now responds with a 200 SSE stream ending in a `successful`
+			// event, so we fulfill with that shape once we release the request.
 			await page.route("**/documents/process", async (route) => {
 				// Hold each request until we manually resolve it
 				await new Promise<void>((resolve) => {
 					requestResolvers.push(resolve);
 				});
-				return route.fulfill({ status: 204 });
+				return fulfillProcessedDocumentSse(route, nextDocumentId++);
 			});
 
 			attemptMultipleFilesViaFileChooser({
@@ -147,59 +150,13 @@ test.describe("Documents", () => {
 		},
 	);
 
-	testDesktopOnly(
-		"Should delete the file from storage when the processing fails",
-		async ({ page, browserName }) => {
-			// Force the process step to fail after the file has already reached
-			// storage, so we can verify the frontend cleans up the now-orphaned
-			// storage object.
-			await page.route("**/documents/process", async (route) => {
-				return route.fulfill({ status: 500 });
-			});
-
-			// Storage paths are UUID-based now, so we need to capture the path
-			// from the actual upload request instead of predicting it. Both
-			// listeners are set up before triggering the upload so neither can
-			// fire and resolve before we start waiting for it.
-			const waitForUpload = page.waitForResponse(
-				(response) =>
-					response.url().includes("/storage/v1/object/documents/") &&
-					response.request().method() === "POST",
-			);
-			const waitForDeletion = page.waitForResponse(
-				(response) =>
-					response.url().includes("/storage/v1/object/documents") &&
-					response.request().method() === "DELETE",
-			);
-
-			await attemptFileUploadViaFileChooser({
-				page,
-				filePath: secondaryDocumentPath,
-				browserName,
-				uploadButtonName: "Datei hochladen",
-			});
-
-			const uploadResponse = await waitForUpload;
-			const uploadedPath = decodeURIComponent(
-				uploadResponse.url().split("/storage/v1/object/documents/")[1],
-			);
-
-			await waitForDeletion;
-
-			const { data: exists, error: existsError } =
-				await supabaseAdminClient.storage
-					.from(defaultBucketName)
-					.exists(uploadedPath);
-
-			/**
-			 * If the file does not exist, supabase returns false + an error:
-			 * https://github.com/supabase/supabase-js/issues/1363
-			 * So we expect an error to be defined, but we also expect exists to be false.
-			 */
-			expect(existsError).toBeDefined();
-			expect(exists).toBe(false);
-		},
-	);
+	// NOTE: The old "Should delete the file from storage when the processing
+	// fails" test was removed. Storage upload + cleanup now happen entirely
+	// server-side in the combined route (the browser no longer uploads to or
+	// deletes from storage), so there is no client-observable storage POST/DELETE
+	// to assert on. The "no orphaned storage file on failure" invariant is now
+	// covered by the backend integration test in
+	// apps/backend/src/integration/routes/documents.integration.test.ts.
 
 	testDesktopOnly(
 		"Should reject uploading a file with a name that already exists",

--- a/apps/frontend/tests/e2e/document.spec.ts
+++ b/apps/frontend/tests/e2e/document.spec.ts
@@ -150,14 +150,6 @@ test.describe("Documents", () => {
 		},
 	);
 
-	// NOTE: The old "Should delete the file from storage when the processing
-	// fails" test was removed. Storage upload + cleanup now happen entirely
-	// server-side in the combined route (the browser no longer uploads to or
-	// deletes from storage), so there is no client-observable storage POST/DELETE
-	// to assert on. The "no orphaned storage file on failure" invariant is now
-	// covered by the backend integration test in
-	// apps/backend/src/integration/routes/documents.integration.test.ts.
-
 	testDesktopOnly(
 		"Should reject uploading a file with a name that already exists",
 		async ({ page, browserName }) => {

--- a/apps/frontend/tests/fixtures/test-with-documents.ts
+++ b/apps/frontend/tests/fixtures/test-with-documents.ts
@@ -1,6 +1,6 @@
 import { supabaseAdminClient } from "../supabase.ts";
 import { testWithMockedLlm } from "./test-with-mocked-llm.ts";
-import { expect, Page } from "@playwright/test";
+import { expect, Page, type Route } from "@playwright/test";
 import { createClient, Session } from "@supabase/supabase-js";
 import { config } from "../config.ts";
 import type { Database } from "@repo/db-schema";
@@ -316,6 +316,35 @@ export async function mockDocumentProcessing({
 }
 
 /**
+ * The combined upload+process route responds with a 200 SSE stream; a success
+ * is delivered in-band as a `successful` event carrying the document id. This
+ * fulfills a mocked `/documents/process` route with that shape so the client's
+ * stream reader resolves with a document id.
+ */
+export function fulfillProcessedDocumentSse(route: Route, documentId: number) {
+	return route.fulfill({
+		status: 200,
+		headers: { "content-type": "text/event-stream; charset=utf-8" },
+		body: `data: ${JSON.stringify({ status: "successful", documentId })}\n\n`,
+	});
+}
+
+/**
+ * Waits for a POST to `/documents/process`. The combined route flushes its 200
+ * SSE headers immediately (before processing finishes), so this MUST be called
+ * before the upload is triggered — otherwise the response can arrive first and
+ * be missed.
+ */
+export function waitForProcessResponse(page: Page) {
+	return page.waitForResponse(
+		(response) =>
+			response.url().includes("/documents/process") &&
+			response.request().method() === "POST",
+		{ timeout: 60_000 },
+	);
+}
+
+/**
  * Makes a real file upload of a single file via the file chooser and waits for
  * the file to be fully processed and appear in the document list.
  */
@@ -335,6 +364,11 @@ export async function uploadFileViaFileChooserAndWait({
 	await page.goto("/");
 
 	await page.waitForLoadState("networkidle");
+
+	// Register the response waiter BEFORE triggering the upload: the combined
+	// route flushes its 200 SSE headers immediately, so the response can arrive
+	// before we'd otherwise start listening and be missed (→ timeout).
+	const responsePromise = waitForProcessResponse(page);
 
 	if (browserName === "firefox") {
 		// Firefox: setup file chooser handler and use input element directly
@@ -361,16 +395,9 @@ export async function uploadFileViaFileChooserAndWait({
 		)
 		.toBeVisible();
 
-	const response = await page.waitForResponse(
-		(givenResponse) =>
-			givenResponse.url().includes("/documents/process") &&
-			givenResponse.request().method() === "POST",
-		{
-			timeout: 60_000,
-		},
-	);
+	const response = await responsePromise;
 
-	expect(response.status()).toBe(204);
+	expect(response.status()).toBe(200);
 
 	// Wait for the file to appear in the document list (scope to desktop panel)
 	const uploadedFile = page
@@ -451,6 +478,20 @@ export async function uploadMultipleFilesViaFileChooserAndWait({
 
 	const filePaths = files.map((file) => file.path);
 
+	// Collect the process responses via a listener registered BEFORE the upload:
+	// the route flushes its 200 SSE headers immediately, and several uploads run
+	// in parallel, so N separate waitForResponse() calls after the fact would
+	// race (and would all resolve to the same first response).
+	const uploadResponses: Array<import("@playwright/test").Response> = [];
+	page.on("response", (response) => {
+		if (
+			response.url().includes("/documents/process") &&
+			response.request().method() === "POST"
+		) {
+			uploadResponses.push(response);
+		}
+	});
+
 	if (browserName === "firefox") {
 		// Firefox: setup file chooser handler and use input element directly
 		page.on("filechooser", async (fileChooser) => {
@@ -479,19 +520,12 @@ export async function uploadMultipleFilesViaFileChooserAndWait({
 			.toBeVisible();
 	}
 
-	// Wait for all upload responses
-	const uploadResponses = [];
-	for (let i = 0; i < files.length; i++) {
-		const response = await page.waitForResponse(
-			(givenResponse) =>
-				givenResponse.url().includes("/documents/process") &&
-				givenResponse.request().method() === "POST",
-			{
-				timeout: 60_000,
-			},
-		);
-		uploadResponses.push(response);
-		expect(response.status()).toBe(204);
+	// Wait until every upload's response has been observed
+	await expect
+		.poll(() => uploadResponses.length, { timeout: 60_000 })
+		.toBe(files.length);
+	for (const response of uploadResponses) {
+		expect(response.status()).toBe(200);
 	}
 
 	// Wait for all files to appear in the document list (scope to desktop panel)
@@ -593,20 +627,17 @@ export async function uploadFileViaDragAndDropAndWait({
 
 	const dropZone = page.locator("#drop-zone-file-upload");
 
+	// Register the waiter before the drop that triggers the upload (the route's
+	// 200 SSE headers arrive immediately).
+	const responsePromise = waitForProcessResponse(page);
+
 	await dropZone.dispatchEvent("dragenter", { dataTransfer });
 	await dropZone.dispatchEvent("dragover", { dataTransfer });
 	await dropZone.dispatchEvent("drop", { dataTransfer });
 
-	const response = await page.waitForResponse(
-		(givenResponse) =>
-			givenResponse.url().includes("/documents/process") &&
-			givenResponse.request().method() === "POST",
-		{
-			timeout: 60_000,
-		},
-	);
+	const response = await responsePromise;
 
-	expect(response.status()).toBe(204);
+	expect(response.status()).toBe(200);
 
 	// Wait for the file to appear in the document list (scope to desktop panel)
 	const uploadedFile = page


### PR DESCRIPTION
We've been having many document/storage orphans recently and we hope that moving the file upload back to the backend will reduce complexity and edge cases (e.g. currently  the frontend uploads document to storage, asks backend to process it, when processing fails, frontend has to cleanup (sometimes also a preview?) -> very long and complex to get all edge cases right.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Document uploads and processing are now completed in one step.
* Uploads support PDF, Word, Excel, and CSV files.
* Real-time progress, success, cancellation, and error updates are available.
* Word documents automatically receive PDF previews.

## Bug Fixes
* Improved validation for file types, sizes, metadata, and duplicate filenames.
* Failed processing now performs server-side cleanup.
* Upload indicators now accurately reflect active uploads and processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216523425320954