### PR TITLE
feat: increase cf staging total memory

### DIFF
--- a/infra/terraform/cloud-foundry/variables.tf
+++ b/infra/terraform/cloud-foundry/variables.tf
@@ -35,7 +35,7 @@ variable "spaces" {
     total_routes        = number
   }))
   default = {
-    staging = { allow_ssh = true, total_memory = 8192, total_app_instances = 10, total_routes = 10 }
+    staging = { allow_ssh = true, total_memory = 20480, total_app_instances = 10, total_routes = 10 }
     prod    = { allow_ssh = false, total_memory = 18432, total_app_instances = 20, total_routes = 20 }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Infrastructure**
  - Increased the staging environment’s memory capacity from 8 GB to 20 GB.
  - All other staging environment settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->