### PR TITLE
fix: chat history "load more" spinner never resolving on tall windows

### DIFF
--- a/apps/frontend/src/components/sidebar/history/hooks/use-intersection-observer.tsx
+++ b/apps/frontend/src/components/sidebar/history/hooks/use-intersection-observer.tsx
@@ -5,12 +5,14 @@ type UseIntersectionObserverArgs = {
 	containerRef: RefObject<HTMLDivElement>;
 	ref: RefObject<HTMLDivElement>;
 	hasLoadedAllChats: boolean;
+	chatsCount: number;
 };
 
 export function useIntersectionObserver({
 	containerRef,
 	ref,
 	hasLoadedAllChats,
+	chatsCount,
 }: UseIntersectionObserverArgs) {
 	useEffect(() => {
 		const spinnerElement = ref.current;
@@ -39,5 +41,5 @@ export function useIntersectionObserver({
 		observer.observe(spinnerElement);
 
 		return () => observer.disconnect();
-	}, [containerRef, ref, hasLoadedAllChats]);
+	}, [containerRef, ref, hasLoadedAllChats, chatsCount]);
 }

--- a/apps/frontend/src/components/sidebar/history/load-more-chats-spinner.tsx
+++ b/apps/frontend/src/components/sidebar/history/load-more-chats-spinner.tsx
@@ -11,12 +11,17 @@ type LoadMoreChatsSpinnerProps = {
 export function LoadMoreChatsSpinner({
 	containerRef,
 }: LoadMoreChatsSpinnerProps) {
-	const { hasMoreChats } = useChatsStore();
+	const { chats, hasMoreChats } = useChatsStore();
 	const ref = useRef<HTMLDivElement>(null);
 
 	const hasLoadedAllChats = !hasMoreChats;
 
-	useIntersectionObserver({ containerRef, ref, hasLoadedAllChats });
+	useIntersectionObserver({
+		containerRef,
+		ref,
+		hasLoadedAllChats,
+		chatsCount: chats.length,
+	});
 
 	return (
 		<div className="flex justify-center pl-2 text-dunkelblau-50 text-xs mt-2 pb-8">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading of additional chat history as new chats are added.
  - Ensured the “load more” trigger updates reliably when the chat list changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->