### PR TITLE
chore: update Renovate configuration for lock file maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,20 +2,23 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["github>technologiestiftung/renovate-config"],
 	"baseBranches": ["staging"],
-	
-	"vulnerabilityAlerts": {
-	  "enabled": true,
-	  "minimumReleaseAge": null,
-	  "schedule": ["at any time"],
-	  "labels": ["security"],
-	  "automerge": true
+
+	"lockFileMaintenance": {
+		"enabled": true
 	},
-  
-	"packageRules": [
-	  {
-		"matchUpdateTypes": ["patch", "minor"],
+
+	"vulnerabilityAlerts": {
+		"enabled": true,
+		"minimumReleaseAge": null,
+		"schedule": ["at any time"],
+		"labels": ["security"],
 		"automerge": true
-	  }
+	},
+
+	"packageRules": [
+		{
+			"matchUpdateTypes": ["patch", "minor"],
+			"automerge": true
+		}
 	]
-  }
-  
+}


### PR DESCRIPTION
Looks like Renovate was not updating the package-lock.json which would make the github actions fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated lock-file maintenance.
  * Standardized dependency update and vulnerability alert settings for more consistent maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->