### PR TITLE
fix: combine simultaneous tool-deactivation banners into one

### DIFF
--- a/apps/frontend/src/components/chat/chat-message/chat-info-message.tsx
+++ b/apps/frontend/src/components/chat/chat-message/chat-info-message.tsx
@@ -1,6 +1,15 @@
 import React from "react";
 import Content from "../../../content.ts";
 import { useChatsStore } from "../../../store/use-chats-store.ts";
+import type { ChatTool } from "../../../common.ts";
+
+const joinToolLabels = (tools: ChatTool[]): string => {
+	const labels = tools.map((tool) => Content[`chat.contextPill.${tool}.label`]);
+	if (labels.length < 2) {
+		return labels.join("");
+	}
+	return `${labels.slice(0, -1).join(", ")} und ${labels[labels.length - 1]}`;
+};
 
 export const ChatInfoMessage: React.FC = () => {
 	const { visibleInfoMessage } = useChatsStore();
@@ -10,30 +19,31 @@ export const ChatInfoMessage: React.FC = () => {
 	}
 
 	if (visibleInfoMessage.type === "toolDeactivated") {
+		const { tools } = visibleInfoMessage;
+		const title =
+			tools.length > 1
+				? `${joinToolLabels(tools)} wurden automatisch deaktiviert.`
+				: Content[`chat.${tools[0]}.infoText.title`];
+		const body =
+			tools.length > 1
+				? Content["chat.toolsDeactivated.infoText.p1"]
+				: Content[`chat.${tools[0]}.infoText.p1`];
+
 		return (
-			<>
-				{visibleInfoMessage.tools.map((tool) => (
-					<div
-						key={tool}
-						role="alert"
-						className="flex flex-col gap-1 w-full px-3 py-[18px] text-dunkelblau-100 rounded-[3px] bg-hellblau-50"
-					>
-						<span className="flex gap-1 items-center">
-							<img
-								src="/icons/info-icon-blue.svg"
-								alt={Content["chat.infoText.imgAlt"]}
-								className="w-4 h-4"
-							/>
-							<h3 className="text-sm leading-5 font-semibold">
-								{Content[`chat.${tool}.infoText.title`]}
-							</h3>
-						</span>
-						<p className="text-sm leading-5 font-normal">
-							{Content[`chat.${tool}.infoText.p1`]}
-						</p>
-					</div>
-				))}
-			</>
+			<div
+				role="alert"
+				className="flex flex-col gap-1 w-full px-3 py-[18px] text-dunkelblau-100 rounded-[3px] bg-hellblau-50"
+			>
+				<span className="flex gap-1 items-center">
+					<img
+						src="/icons/info-icon-blue.svg"
+						alt={Content["chat.infoText.imgAlt"]}
+						className="w-4 h-4"
+					/>
+					<h3 className="text-sm leading-5 font-semibold">{title}</h3>
+				</span>
+				<p className="text-sm leading-5 font-normal">{body}</p>
+			</div>
 		);
 	}
 	// Chat history paused info message when external sources are active

--- a/apps/frontend/src/content.ts
+++ b/apps/frontend/src/content.ts
@@ -932,6 +932,9 @@ export const Content = {
 		"Berlin Open Data wurde automatisch deaktiviert.",
 	"chat.openData.infoText.p1":
 		"Ein Dokument wurde hinzugefügt. Aus Datenschutzgründen wird Berlin Open Data deaktiviert, damit Ihre Inhalte nicht an externe Dienste übermittelt werden. Um Open Data wieder zu aktivieren, klicken Sie auf +.",
+	// Chat info text for automated deactivation of multiple external tools at once
+	"chat.toolsDeactivated.infoText.p1":
+		"Ein Dokument wurde hinzugefügt. Aus Datenschutzgründen wurden die Werkzeuge deaktiviert, damit Ihre Inhalte nicht an externe Dienste übermittelt werden. Um die Werkzeuge zu reaktivieren, klicken Sie auf +.",
 	"chat.infoText.imgAlt": "Ein Ausrufezeichen-Icon",
 
 	"chat.textarea.placeholder": "Stellen Sie eine Frage",


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217713409128874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notifications when external tools are deactivated.
  * Multiple deactivated tools are now summarized in a single alert.
  * Single-tool alerts continue to show tool-specific details.
* **Documentation**
  * Added German text explaining that tools may be deactivated for privacy reasons when a document is added, including how to reactivate them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->