### PR TITLE
fix: close login-flow account-enumeration leak and redesign confirm-o…

### DIFF
--- a/apps/admin-panel/src/store/use-auth-store.ts
+++ b/apps/admin-panel/src/store/use-auth-store.ts
@@ -149,7 +149,10 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 				options: { shouldCreateUser: false },
 			});
 
-			if (error) {
+			// GoTrue's otp_disabled error means the email has no account — treated
+			// as success so an attacker can't tell registered emails apart from
+			// unregistered ones by whether the page navigates or shows an error.
+			if (error && error.code !== "otp_disabled") {
 				console.error("Login error:", error);
 				useAuthErrorStore.getState().handleError(new Error(error.message));
 				return { error: new Error(error.message) };

--- a/apps/frontend/src/content.ts
+++ b/apps/frontend/src/content.ts
@@ -1155,9 +1155,21 @@ export const Content = {
 	"loginPage.registerLink": "Jetzt registrieren",
 
 	/* ---------------------- OTP Confirmation Page ---------------------- */
-	"confirmOtp.title": "Aktion bestätigen",
+	"confirmOtp.title": "Fast geschafft!",
 	"confirmOtp.description":
 		"Bitte geben Sie den Sicherheitscode aus Ihrer E-Mail ein.",
+	"confirmOtp.description.sent":
+		"Wir haben eine E-Mail an folgende Adresse geschickt:",
+	"confirmOtp.description.instruction":
+		"Bitte geben Sie den Code aus der E-Mail hier ein, um fortzufahren:",
+	"confirmOtp.resend.question": "Keinen Code erhalten oder Code ungültig?",
+	"confirmOtp.checkSpam": "Bitte überprüfen Sie auch Ihren Spam-Ordner.",
+	"confirmOtp.typo.question": "Tippfehler?",
+	"confirmOtp.typo.or": "oder",
+	"confirmOtp.typo.registerLink": "Zurück zur Registrierung",
+	"confirmOtp.typo.loginLink": "Zurück zum Login",
+	"confirmOtp.notRegistered.question": "Noch nicht registriert?",
+	"confirmOtp.notRegistered.registerLink": "Zur Registrierung",
 	"confirmOtp.token.label": "Sicherheitscode",
 	"confirmOtp.token.placeholder": "z. B. 123456",
 	"confirmOtp.button.submit": "Weiter",

--- a/apps/frontend/src/routes/confirm-otp/index.tsx
+++ b/apps/frontend/src/routes/confirm-otp/index.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent, type ClipboardEvent } from "react";
-import { useNavigate, useSearchParams } from "react-router";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import Content from "../../content";
 import { ConfirmationLayout } from "../../layouts/confirmation-layout.tsx";
 import { supabase } from "../../../supabase-client";
@@ -27,6 +27,7 @@ export function ConfirmOtpPage() {
 
 	const email = searchParams.get("email");
 	const otpType = searchParams.get("type");
+	const origin = searchParams.get("origin");
 
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
@@ -125,7 +126,16 @@ export function ConfirmOtpPage() {
 						{Content["confirmOtp.title"]}
 					</h1>
 					<p className="text-base mt-4 text-schwarz-100">
-						{Content["confirmOtp.description"]}
+						{email ? (
+							<>
+								{Content["confirmOtp.description.sent"]}{" "}
+								<strong>{email}</strong>
+								<br />
+								{Content["confirmOtp.description.instruction"]}
+							</>
+						) : (
+							Content["confirmOtp.description"]
+						)}
 					</p>
 
 					<form className="flex flex-col mt-8 gap-6" onSubmit={handleSubmit}>
@@ -162,23 +172,63 @@ export function ConfirmOtpPage() {
 								: Content["confirmOtp.button.submit"]}
 						</button>
 
-						<p>
-							{Content["unconfirmedEmail.otp.resend"]}
-							{hasEmailBeenRecentlySent && (
-								<span className="ml-5 leading-6 md:text-lg md:leading-7 font-semibold text-mittelgruen">
-									{Content["unconfirmedEmail.resend.success"]}
-								</span>
+						<div className="flex flex-col gap-1">
+							<p className="text-base text-schwarz-100">
+								{Content["confirmOtp.resend.question"]}{" "}
+								{hasEmailBeenRecentlySent ? (
+									<span className="text-base font-semibold text-mittelgruen">
+										{Content["unconfirmedEmail.resend.success"]}
+									</span>
+								) : (
+									<button
+										className="text-base font-semibold underline hover:no-underline"
+										type="button"
+										onClick={handleResendEmail}
+									>
+										{Content["unconfirmedEmail.resendButton"]}
+									</button>
+								)}
+							</p>
+
+							<p className="text-base text-schwarz-100">
+								{Content["confirmOtp.checkSpam"]}
+							</p>
+
+							<p className="text-base text-schwarz-100">
+								{Content["confirmOtp.typo.question"]}{" "}
+								{origin !== "register" && (
+									<Link
+										to="/login/"
+										className="text-base font-semibold underline hover:no-underline"
+									>
+										{Content["confirmOtp.typo.loginLink"]}
+									</Link>
+								)}
+								{origin !== "login" && origin !== "register" && (
+									<> {Content["confirmOtp.typo.or"]} </>
+								)}
+								{origin !== "login" && (
+									<Link
+										to="/register/"
+										className="text-base font-semibold underline hover:no-underline"
+									>
+										{Content["confirmOtp.typo.registerLink"]}
+									</Link>
+								)}
+							</p>
+
+							{origin === "login" && (
+								<p className="text-base text-schwarz-100">
+									{Content["confirmOtp.notRegistered.question"]}{" "}
+									<Link
+										to="/register/"
+										className="text-base font-semibold underline hover:no-underline"
+									>
+										{Content["confirmOtp.notRegistered.registerLink"]}
+									</Link>
+								</p>
 							)}
-							{!hasEmailBeenRecentlySent && (
-								<button
-									className="ml-5 leading-6 md:text-lg md:leading-7 font-semibold underline hover:no-underline"
-									type="button"
-									onClick={handleResendEmail}
-								>
-									{Content["unconfirmedEmail.resendButton"]}
-								</button>
-							)}
-						</p>
+						</div>
 					</form>
 				</div>
 			</div>

--- a/apps/frontend/src/routes/login-page/index.tsx
+++ b/apps/frontend/src/routes/login-page/index.tsx
@@ -26,7 +26,7 @@ export function LoginPage() {
 
 				if (!loginError) {
 					navigate(
-						`/confirm-otp/?type=email&email=${encodeURIComponent(email)}`,
+						`/confirm-otp/?type=email&email=${encodeURIComponent(email)}&origin=login`,
 					);
 				}
 			},

--- a/apps/frontend/src/routes/register-page/index.tsx
+++ b/apps/frontend/src/routes/register-page/index.tsx
@@ -41,7 +41,7 @@ export function RegisterPage() {
 
 				if (!registerError) {
 					navigate(
-						`/confirm-otp/?type=email&email=${encodeURIComponent(email)}`,
+						`/confirm-otp/?type=email&email=${encodeURIComponent(email)}&origin=register`,
 					);
 				}
 			},

--- a/apps/frontend/src/store/auth-store.ts
+++ b/apps/frontend/src/store/auth-store.ts
@@ -252,7 +252,10 @@ export const useAuthStore = create<AuthStore>()((set, get) => {
 				options: { shouldCreateUser: false },
 			});
 
-			if (error) {
+			// GoTrue's otp_disabled error means the email has no account — treated
+			// as success so an attacker can't tell registered emails apart from
+			// unregistered ones by whether the page navigates or shows an error.
+			if (error && error.code !== "otp_disabled") {
 				useAuthErrorStore.getState().handleError(error, span);
 				return { error };
 			}

--- a/apps/frontend/tests/e2e/auth.spec.ts
+++ b/apps/frontend/tests/e2e/auth.spec.ts
@@ -69,6 +69,64 @@ test.describe("Login", () => {
 		// Email field should show a format validation error
 		await expect(page.getByText("Das E-Mail-Format ist falsch.")).toBeVisible();
 	});
+
+	test("Login with an unregistered email is indistinguishable from a registered one", async ({
+		page,
+	}) => {
+		// Regression test: an unregistered email must navigate to /confirm-otp/
+		// exactly like a registered one, so the login form can't be used to probe
+		// which emails have accounts (see requestLoginOtp's otp_disabled handling).
+		const nonExistentEmail = "nonexistent-login-attempt@ts.berlin";
+
+		const { data: listUsersDataBefore } =
+			await supabaseAdminClient.auth.admin.listUsers();
+		expect(
+			listUsersDataBefore?.users.some(
+				({ email }) => email === nonExistentEmail,
+			),
+		).toBe(false);
+
+		await page.goto("/login/");
+		await page
+			.getByRole("textbox", { name: "E-Mail-Adresse" })
+			.fill(nonExistentEmail);
+		await page.getByRole("button", { name: "Code anfordern" }).click();
+
+		await expect(page).toHaveURL(/\/confirm-otp\//);
+
+		// shouldCreateUser:false must still hold — navigating must not have
+		// silently created an account for the unregistered email.
+		const { data: listUsersDataAfter } =
+			await supabaseAdminClient.auth.admin.listUsers();
+		expect(
+			listUsersDataAfter?.users.some(({ email }) => email === nonExistentEmail),
+		).toBe(false);
+	});
+
+	test("Confirm-otp page reached via login shows the login-specific footer links", async ({
+		page,
+	}) => {
+		// Regression test: the confirm-otp page tailors its "wrong email" /
+		// "not registered" footer links based on the ?origin= param set by
+		// login-page/register-page. Reaching it via login must never show the
+		// "not yet registered" escape hatch. See confirm-otp/index.tsx.
+		await page.goto("/login/");
+		await page
+			.getByRole("textbox", { name: "E-Mail-Adresse" })
+			.fill("confirm-otp-footer-check@ts.berlin");
+		await page.getByRole("button", { name: "Code anfordern" }).click();
+
+		await expect(page).toHaveURL(/[?&]origin=login(&|$)/);
+		await expect(
+			page.getByRole("link", { name: "Zurück zum Login" }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("link", { name: "Zurück zur Registrierung" }),
+		).not.toBeVisible();
+		await expect(
+			page.getByRole("link", { name: "Zur Registrierung" }),
+		).toBeVisible();
+	});
 });
 
 async function fillAndSubmitRegistrationForm(
@@ -188,7 +246,7 @@ test.describe("User Registration (uses different user to prevent side-effects on
 			// The uniform confirm-code screen must be shown -
 			// never an error revealing that the account already exists.
 			await expect(
-				page.getByRole("heading", { name: "Aktion bestätigen" }),
+				page.getByRole("heading", { name: "Fast geschafft!" }),
 			).toBeVisible({ timeout: 10_000 });
 			await expect(
 				page.getByText("Benutzer ist bereits registriert."),
@@ -217,7 +275,7 @@ test.describe("User Registration (uses different user to prevent side-effects on
 			// Behaviorally indistinguishable from the "new user" case from the UI -
 			// that's expected, the whole point is uniformity.
 			await expect(
-				page.getByRole("heading", { name: "Aktion bestätigen" }),
+				page.getByRole("heading", { name: "Fast geschafft!" }),
 			).toBeVisible({ timeout: 10_000 });
 			await expect(
 				page.getByText("Benutzer ist bereits registriert."),
@@ -236,7 +294,7 @@ test.describe("User Registration (uses different user to prevent side-effects on
 
 			// Registration navigates straight to the confirm-code screen.
 			await expect(
-				page.getByRole("heading", { name: "Aktion bestätigen" }),
+				page.getByRole("heading", { name: "Fast geschafft!" }),
 			).toBeVisible({ timeout: 10_000 });
 
 			const resendButton = page.getByRole("button", {

--- a/apps/frontend/tests/e2e/auth.spec.ts
+++ b/apps/frontend/tests/e2e/auth.spec.ts
@@ -78,8 +78,9 @@ test.describe("Login", () => {
 		// which emails have accounts (see requestLoginOtp's otp_disabled handling).
 		const nonExistentEmail = "nonexistent-login-attempt@ts.berlin";
 
-		const { data: listUsersDataBefore } =
+		const { data: listUsersDataBefore, error: listUsersErrorBefore } =
 			await supabaseAdminClient.auth.admin.listUsers();
+		expect(listUsersErrorBefore).toBeNull();
 		expect(
 			listUsersDataBefore?.users.some(
 				({ email }) => email === nonExistentEmail,
@@ -96,8 +97,9 @@ test.describe("Login", () => {
 
 		// shouldCreateUser:false must still hold — navigating must not have
 		// silently created an account for the unregistered email.
-		const { data: listUsersDataAfter } =
+		const { data: listUsersDataAfter, error: listUsersErrorAfter } =
 			await supabaseAdminClient.auth.admin.listUsers();
+		expect(listUsersErrorAfter).toBeNull();
 		expect(
 			listUsersDataAfter?.users.some(({ email }) => email === nonExistentEmail),
 		).toBe(false);

--- a/apps/frontend/tests/fixtures/test-with-registered-user.ts
+++ b/apps/frontend/tests/fixtures/test-with-registered-user.ts
@@ -176,7 +176,7 @@ export async function confirmOtp({
 	await page1.goto(confirmUrl);
 
 	await expect(
-		page1.getByRole("heading", { name: "Aktion bestätigen" }),
+		page1.getByRole("heading", { name: "Fast geschafft!" }),
 	).toBeVisible();
 
 	await page1


### PR DESCRIPTION
…tp guidance

requestLoginOtp's shouldCreateUser:false path let an unauthenticated visitor tell registered emails apart from unregistered ones, since GoTrue's otp_disabled error for non-existent accounts wasn't mapped to any visible message — the login form silently stayed put instead of navigating, while a real account always navigated to /confirm-otp/. That error is now treated the same as success, so both cases behave identically. Alongside that, the confirm-otp screen still had leftover password-era copy and gave no indication of which flow (login vs. registration) someone actually needed next; it's been redesigned with a friendlier title, the destination email shown inline, and origin-aware footer links so someone who tries logging in before ever registering gets pointed at registration instead of silently waiting for a code that will never arrive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved OTP confirmation guidance with clearer instructions, email details, resend options, spam-folder reminders, and registration/login links.
  - Confirmation pages now provide context-specific navigation for login and registration flows.

- **Bug Fixes**
  - Login requests for unregistered email addresses now continue to the confirmation screen without revealing account existence.
  - Updated confirmation messaging to “Fast geschafft!” for a clearer experience.

- **Tests**
  - Added coverage for unregistered-email login behavior and context-specific confirmation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->