### PR TITLE
feat: update OTP length to 10 digits and adjust related placeholders …

### DIFF
--- a/apps/admin-panel/src/content.ts
+++ b/apps/admin-panel/src/content.ts
@@ -29,7 +29,7 @@ export const Content = {
 	"confirmOtp.description":
 		"Bitte geben Sie den Sicherheitscode aus Ihrer E-Mail ein.",
 	"confirmOtp.token.label": "Sicherheitscode",
-	"confirmOtp.token.placeholder": "z. B. 123456",
+	"confirmOtp.token.placeholder": "z. B. 1234567890",
 	"confirmOtp.button.submit": "Weiter",
 	"confirmOtp.button.loading": "Überprüfe …",
 	"confirmOtp.error.missingFields":

--- a/apps/admin-panel/src/routes/confirm-otp/index.tsx
+++ b/apps/admin-panel/src/routes/confirm-otp/index.tsx
@@ -102,7 +102,7 @@ export function ConfirmOtpPage() {
 								name="token"
 								type="text"
 								inputMode="numeric"
-								pattern="\d{6}"
+								pattern="\d{10}"
 								required
 								className="border border-schwarz-40 rounded-3px px-3 py-2 focus-visible:outline-default uppercase tracking-[0.3em]"
 								placeholder={Content["confirmOtp.token.placeholder"]}

--- a/apps/admin-panel/tests/fixtures/confirm-otp.ts
+++ b/apps/admin-panel/tests/fixtures/confirm-otp.ts
@@ -64,7 +64,7 @@ async function waitForLatestMessageTo(
 export async function enterLoginOtp(page: Page, email: string) {
 	const { id, text } = await waitForLatestMessageTo(page, email);
 
-	const code = text.match(/^\s*(\d{6})\s*$/m)?.[1];
+	const code = text.match(/^\s*(\d{10})\s*$/m)?.[1];
 	if (!code) {
 		throw new Error(
 			`Could not read a security code from Mailpit message ${id}:\n${text}`,

--- a/apps/backend/supabase/config.toml
+++ b/apps/backend/supabase/config.toml
@@ -109,9 +109,9 @@ enable_confirmations = true
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
 max_frequency = "1ms"
 # Number of digits in the emailed one-time code (login + confirmation OTPs).
-otp_length = 6
-# How long an emailed one-time code stays valid, in seconds (60 minutes).
-otp_expiry = 3600
+otp_length = 10
+# How long an emailed one-time code stays valid, in seconds (30 minutes).
+otp_expiry = 1800
 
 [auth.rate_limit]
 email_sent = 1000

--- a/apps/backend/supabase/templates/confirmation.html
+++ b/apps/backend/supabase/templates/confirmation.html
@@ -137,7 +137,7 @@
 										margin-top: 30px;
 									"
 								>
-									Der Link und der Code sind aus Sicherheitsgründen jeweils 60
+									Der Link und der Code sind aus Sicherheitsgründen jeweils 30
 									Minuten gültig. Wenn Sie sich nicht bei BärGPT registriert
 									haben, können Sie diese Nachricht ignorieren.
 								</p>

--- a/apps/backend/supabase/templates/email_change.html
+++ b/apps/backend/supabase/templates/email_change.html
@@ -138,7 +138,8 @@
 										rel="noopener noreferrer"
 										style="color: #0c2753; word-break: break-word"
 									>
-										{{ .SiteURL }}/confirm-otp/?type=email_change&email={{ .NewEmail }}&
+										{{ .SiteURL }}/confirm-otp/?type=email_change&email={{
+										.NewEmail }}&
 									</a>
 									<br /><br />
 									Ihr Code (bitte im Formular eingeben):
@@ -153,7 +154,7 @@
 										margin-top: 30px;
 									"
 								>
-									Link und Code verfallen nach 60 Minuten. Falls Sie die
+									Link und Code verfallen nach 30 Minuten. Falls Sie die
 									Änderung nicht angefordert haben, ignorieren Sie diese E-Mail.
 								</p>
 

--- a/apps/backend/supabase/templates/magic_link.html
+++ b/apps/backend/supabase/templates/magic_link.html
@@ -137,7 +137,7 @@
 										margin-top: 30px;
 									"
 								>
-									Der Link und der Code sind aus Sicherheitsgründen jeweils 60
+									Der Link und der Code sind aus Sicherheitsgründen jeweils 30
 									Minuten gültig. Wenn Sie sich nicht bei BärGPT anmelden
 									wollten, können Sie diese Nachricht ignorieren.
 								</p>

--- a/apps/backend/supabase/templates/recovery.html
+++ b/apps/backend/supabase/templates/recovery.html
@@ -139,7 +139,7 @@
 										margin-top: 30px;
 									"
 								>
-									Der Link und der Code sind aus Sicherheitsgründen jeweils 60
+									Der Link und der Code sind aus Sicherheitsgründen jeweils 30
 									Minuten gültig. Wenn Sie nichts angefordert haben, können Sie
 									diese Nachricht ignorieren.
 								</p>

--- a/apps/frontend/src/content.ts
+++ b/apps/frontend/src/content.ts
@@ -1180,7 +1180,7 @@ export const Content = {
 	"confirmOtp.notRegistered.question": "Noch nicht registriert?",
 	"confirmOtp.notRegistered.registerLink": "Zur Registrierung",
 	"confirmOtp.token.label": "Sicherheitscode",
-	"confirmOtp.token.placeholder": "z. B. 123456",
+	"confirmOtp.token.placeholder": "z. B. 1234567890",
 	"confirmOtp.button.submit": "Weiter",
 	"confirmOtp.button.loading": "Überprüfe …",
 	"confirmOtp.error.missingFields":

--- a/apps/frontend/src/routes/confirm-otp/index.tsx
+++ b/apps/frontend/src/routes/confirm-otp/index.tsx
@@ -149,7 +149,7 @@ export function ConfirmOtpPage() {
 								name="token"
 								type="text"
 								inputMode="numeric"
-								pattern="\d{6}"
+								pattern="\d{10}"
 								className="border border-schwarz-40 rounded-3px px-3 py-2 focus-visible:outline-default uppercase tracking-[0.3em]"
 								placeholder={Content["confirmOtp.token.placeholder"]}
 								onPaste={handlePaste}

--- a/apps/frontend/tests/fixtures/test-with-registered-user.ts
+++ b/apps/frontend/tests/fixtures/test-with-registered-user.ts
@@ -152,7 +152,7 @@ export async function confirmOtp({
 	const { id, text } = await waitForLatestMessageTo(page, account.email);
 
 	// The security code sits on its own line; the button's href is the first confirm-otp link.
-	const recoveryOtp = text.match(/^\s*(\d{6})\s*$/m)?.[1];
+	const recoveryOtp = text.match(/^\s*(\d{10})\s*$/m)?.[1];
 	const confirmUrl = text.match(/(https?:\/\/\S*?\/confirm-otp\/\S*)/)?.[1];
 
 	if (!recoveryOtp || !confirmUrl) {

--- a/infra/ansible/roles/supabase/tasks/main.yml
+++ b/infra/ansible/roles/supabase/tasks/main.yml
@@ -51,8 +51,8 @@
 
 # The .env is rendered fresh from 1Password on every run, so these GoTrue
 # hardening overrides are (re)applied here to guarantee they are present.
-# docker-compose.yml already carries safe defaults (:-5 / :-3600); these lines
-# make the intended values explicit and tunable without a code change.
+# these lines make the intended values explicit and tunable without a
+# code change.
 - name: Ensure GoTrue OTP hardening vars in .env
   ansible.builtin.lineinfile:
     path: "{{ supabase_dir }}/.env"
@@ -60,7 +60,8 @@
     line: "{{ item.key }}={{ item.value }}"
     state: present
   loop:
-    - { key: "GOTRUE_MAILER_OTP_EXP", value: "3600" } # 60 min instead of 24h
+    - { key: "GOTRUE_MAILER_OTP_EXP", value: "1800" } # 30 min instead of 24h
+    - { key: "GOTRUE_MAILER_OTP_LENGTH", value: "10" } # numeric-only OTP; length is the entropy lever
     - { key: "GOTRUE_RATE_LIMIT_VERIFY", value: "5" } # low; only meaningful once RATE_LIMIT_HEADER is set
   loop_control:
     label: "{{ item.key }}"

--- a/infra/supabase/.env.example
+++ b/infra/supabase/.env.example
@@ -37,9 +37,11 @@ ENABLE_PHONE_AUTOCONFIRM=false
 FUNCTIONS_VERIFY_JWT=true
 JWT_EXPIRY=3600
 # How long an emailed one-time code (login + confirmation OTP) stays valid, in seconds.
-GOTRUE_MAILER_OTP_EXP=3600
+GOTRUE_MAILER_OTP_EXP=1800
+# Length of emailed one-time codes. OTPs are numeric-only, so length is the entropy lever.
+GOTRUE_MAILER_OTP_LENGTH=10
 # Rate limit for the OTP/verify endpoint (requests per 5 min per client).
-GOTRUE_RATE_LIMIT_VERIFY=30
+GOTRUE_RATE_LIMIT_VERIFY=5
 
 # PostgREST
 PGRST_DB_SCHEMAS=public

--- a/infra/supabase/docker-compose.yml
+++ b/infra/supabase/docker-compose.yml
@@ -171,7 +171,7 @@ services:
       GOTRUE_RATE_LIMIT_HEADER: X-Forwarded-For
       GOTRUE_RATE_LIMIT_VERIFY: ${GOTRUE_RATE_LIMIT_VERIFY}
       GOTRUE_MAILER_OTP_EXP: ${GOTRUE_MAILER_OTP_EXP}
-      GOTRUE_MAILER_OTP_LENGTH: ${GOTRUE_MAILER_OTP_LENGTH}
+      GOTRUE_MAILER_OTP_LENGTH: ${GOTRUE_MAILER_OTP_LENGTH:-10}
 
       # Uncomment to enable custom access token hook. Please see: https://supabase.com/docs/guides/auth/auth-hooks for full list of hooks and additional details about custom_access_token_hook
 

--- a/infra/supabase/docker-compose.yml
+++ b/infra/supabase/docker-compose.yml
@@ -171,6 +171,8 @@ services:
       GOTRUE_RATE_LIMIT_HEADER: X-Forwarded-For
       GOTRUE_RATE_LIMIT_VERIFY: ${GOTRUE_RATE_LIMIT_VERIFY}
       GOTRUE_MAILER_OTP_EXP: ${GOTRUE_MAILER_OTP_EXP}
+      GOTRUE_MAILER_OTP_LENGTH: ${GOTRUE_MAILER_OTP_LENGTH}
+
       # Uncomment to enable custom access token hook. Please see: https://supabase.com/docs/guides/auth/auth-hooks for full list of hooks and additional details about custom_access_token_hook
 
       # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED: "true"


### PR DESCRIPTION
…and patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Improvements**
  - Email one-time codes now use 10 digits instead of 6.
  - One-time codes and authentication links expire after 30 minutes instead of 60 minutes.
  - OTP verification requests are limited to 5 attempts per 5-minute period per client.

- **User Experience**
  - OTP entry fields and instructions now reflect the 10-digit code format.
  - Confirmation, recovery, and magic link emails now display the updated 30-minute validity period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->