### PR TITLE
[PAUSED] feat: prefill login OTP field from email link

### DIFF
--- a/apps/backend/supabase/templates/magic_link.html
+++ b/apps/backend/supabase/templates/magic_link.html
@@ -100,7 +100,11 @@
 									<p style="margin: 0">{{ .Token }}</p>
 								</div>
 
-								<!-- Trailing "&" prevents Brevo click tracking from corrupting the email param -->
+								<!--
+									Trailing "&" guards the email param from Brevo click-tracking. The token
+									rides in the #fragment (client-only, so it stays out of server logs) and
+									prefills the field; if a rewriter strips it, the user types the code below.
+								-->
 								<table
 									cellpadding="0"
 									cellspacing="0"
@@ -110,7 +114,7 @@
 									<tr>
 										<td align="left">
 											<a
-												href="{{ .SiteURL }}/confirm-otp/?type=email&email={{ .Email }}&"
+												href="{{ .SiteURL }}/confirm-otp/?type=email&email={{ .Email }}&amp;#token={{ .Token }}"
 												target="_blank"
 												rel="noopener noreferrer"
 												style="
@@ -147,12 +151,13 @@
 									manuell:
 									<br />
 									<a
-										href="{{ .SiteURL }}/confirm-otp/?type=email&email={{ .Email }}&"
+										href="{{ .SiteURL }}/confirm-otp/?type=email&email={{ .Email }}&amp;#token={{ .Token }}"
 										target="_blank"
 										rel="noopener noreferrer"
 										style="color: #0c2753; word-break: break-word"
 									>
-										{{ .SiteURL }}/confirm-otp/?type=email&email={{ .Email }}&
+										{{ .SiteURL }}/confirm-otp/?type=email&email={{ .Email
+										}}&amp;#token={{ .Token }}
 									</a>
 									<br /><br />
 									Ihr Code (bitte im Formular eingeben):

--- a/apps/frontend/src/routes/confirm-otp/index.tsx
+++ b/apps/frontend/src/routes/confirm-otp/index.tsx
@@ -1,4 +1,9 @@
-import { useState, type FormEvent, type ClipboardEvent } from "react";
+import {
+	useEffect,
+	useState,
+	type FormEvent,
+	type ClipboardEvent,
+} from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
 import Content from "../../content";
 import { ConfirmationLayout } from "../../layouts/confirmation-layout.tsx";
@@ -28,6 +33,30 @@ export function ConfirmOtpPage() {
 	const email = searchParams.get("email");
 	const otpType = searchParams.get("type");
 	const origin = searchParams.get("origin");
+
+	// Prefill from the token in the email link's URL fragment (#token=…). A
+	// fragment never hits the server, so it stays out of access logs and Referer.
+	const [initialToken] = useState(() => {
+		if (typeof window === "undefined") {
+			return "";
+		}
+		const hashParams = new URLSearchParams(
+			window.location.hash.replace(/^#/, ""),
+		);
+		return hashParams.get("token") ?? "";
+	});
+
+	// Strip the token from the URL so it doesn't linger in the address bar or
+	// history. Local-device hygiene only.
+	useEffect(() => {
+		if (window.location.hash) {
+			window.history.replaceState(
+				null,
+				"",
+				window.location.pathname + window.location.search,
+			);
+		}
+	}, []);
 
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
@@ -150,6 +179,7 @@ export function ConfirmOtpPage() {
 								type="text"
 								inputMode="numeric"
 								pattern="\d{6}"
+								defaultValue={initialToken}
 								className="border border-schwarz-40 rounded-3px px-3 py-2 focus-visible:outline-default uppercase tracking-[0.3em]"
 								placeholder={Content["confirmOtp.token.placeholder"]}
 								onPaste={handlePaste}

--- a/apps/frontend/src/routes/confirm-otp/index.tsx
+++ b/apps/frontend/src/routes/confirm-otp/index.tsx
@@ -1,10 +1,11 @@
+import { useState, type FormEvent, type ClipboardEvent } from "react";
 import {
-	useEffect,
-	useState,
-	type FormEvent,
-	type ClipboardEvent,
-} from "react";
-import { Link, useNavigate, useSearchParams } from "react-router";
+	Link,
+	Navigate,
+	useLocation,
+	useNavigate,
+	useSearchParams,
+} from "react-router";
 import Content from "../../content";
 import { ConfirmationLayout } from "../../layouts/confirmation-layout.tsx";
 import { supabase } from "../../../supabase-client";
@@ -28,6 +29,7 @@ export function ConfirmOtpPage() {
 	const [hasEmailBeenRecentlySent, setHasEmailBeenRecentlySent] =
 		useState(false);
 	const navigate = useNavigate();
+	const location = useLocation();
 	const [searchParams] = useSearchParams();
 
 	const email = searchParams.get("email");
@@ -36,27 +38,21 @@ export function ConfirmOtpPage() {
 
 	// Prefill from the token in the email link's URL fragment (#token=…). A
 	// fragment never hits the server, so it stays out of access logs and Referer.
-	const [initialToken] = useState(() => {
-		if (typeof window === "undefined") {
-			return "";
-		}
-		const hashParams = new URLSearchParams(
-			window.location.hash.replace(/^#/, ""),
-		);
-		return hashParams.get("token") ?? "";
-	});
+	const [initialToken] = useState(
+		() =>
+			new URLSearchParams(location.hash.replace(/^#/, "")).get("token") ?? "",
+	);
 
 	// Strip the token from the URL so it doesn't linger in the address bar or
 	// history. Local-device hygiene only.
-	useEffect(() => {
-		if (window.location.hash) {
-			window.history.replaceState(
-				null,
-				"",
-				window.location.pathname + window.location.search,
-			);
-		}
-	}, []);
+	if (location.hash) {
+		return (
+			<Navigate
+				to={{ pathname: location.pathname, search: location.search }}
+				replace
+			/>
+		);
+	}
 
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();

--- a/apps/frontend/tests/e2e/confirm-otp-prefill.spec.ts
+++ b/apps/frontend/tests/e2e/confirm-otp-prefill.spec.ts
@@ -1,0 +1,50 @@
+import { expect } from "@playwright/test";
+import {
+	testWithRegisteredUser,
+	waitForLatestMessageTo,
+} from "../fixtures/test-with-registered-user.ts";
+
+/**
+ * The login email links to the confirm-otp page with the one-time code in the
+ * URL fragment (#token=...). The page reads it client-side and prefills the code
+ * field; the user still submits manually. This exercises the whole chain from
+ * Mailpit, so it guards the template<->frontend contract (both must agree on the
+ * "token" fragment key) and the after-mount strip.
+ */
+testWithRegisteredUser.describe("Login OTP email link prefill", () => {
+	testWithRegisteredUser(
+		"the login email link carries the code in a #token fragment and prefills the field",
+		async ({ page, account }) => {
+			// Request a login code the normal way.
+			await page.goto("/login/");
+			await page
+				.getByRole("textbox", { name: "E-Mail-Adresse" })
+				.fill(account.email);
+			await page.getByRole("button", { name: "Code anfordern" }).click();
+
+			// Read the emailed code and link straight from Mailpit.
+			const { text } = await waitForLatestMessageTo(page, account.email);
+			const code = text.match(/^\s*(\d{6})\s*$/m)?.[1];
+			const confirmUrl = text.match(/(https?:\/\/\S*?\/confirm-otp\/\S*)/)?.[1];
+			if (!code || !confirmUrl) {
+				throw new Error(
+					`Could not read a security code and link from the email:\n${text}`,
+				);
+			}
+
+			// The code must ride in the URL fragment (kept off the server), not a
+			// query param. This is the template<->frontend "token" contract.
+			expect(confirmUrl).toContain(`#token=${code}`);
+
+			// Opening the link prefills the code field — no manual typing.
+			const page1 = await page.context().newPage();
+			await page1.goto(confirmUrl);
+			await expect(
+				page1.getByRole("textbox", { name: "Sicherheitscode" }),
+			).toHaveValue(code);
+
+			// ...and the token is stripped from the URL so it doesn't linger.
+			await expect(page1).not.toHaveURL(/#token/);
+		},
+	);
+});

--- a/apps/frontend/tests/fixtures/test-with-registered-user.ts
+++ b/apps/frontend/tests/fixtures/test-with-registered-user.ts
@@ -87,7 +87,7 @@ type MailpitSummary = {
  *
  * @param cutoffTime Only consider messages created after this UTC timestamp (ms-since-epoch).
  */
-async function waitForLatestMessageTo(
+export async function waitForLatestMessageTo(
 	page: Page,
 	recipient: string,
 	timeoutMs = 30_000,


### PR DESCRIPTION
The login email now links to the confirm-otp page with the one-time token in the URL fragment (#token=...). The page reads it client-side and prefills the code field; the user still submits manually, so an email link-scanner that pre-fetches the URL cannot consume the code. The token rides in the fragment rather than a query param so it never reaches the server and stays out of access logs and Referer headers; the fragment is stripped from the URL after mount as local-device hygiene. If a link-rewriter drops the fragment, the field stays empty and the user types the plaintext code still printed in the email. The trailing "&" Brevo click-tracking guard on the email param is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Magic link emails now prefill the confirmation code on the OTP page.
  * Added a manual fallback link for entering the code when needed.

* **Security & Privacy**
  * OTP tokens are passed in the URL fragment rather than query parameters, helping keep them out of server logs.
  * Tokens are removed from the browser address bar after the confirmation page loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->