### PR TITLE
feat: enable reasoning traces (backend)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -33,7 +33,7 @@
 	},
 	"dependencies": {
 		"@ai-sdk/mcp": "2.0.34",
-		"@ai-sdk/mistral": "4.0.31",
+		"@ai-sdk/mistral": "4.0.43",
 		"@dqbd/tiktoken": "1.0.22",
 		"@hono/node-server": "2.0.12",
 		"@langfuse/client": "5.10.0",

--- a/apps/backend/src/constants.ts
+++ b/apps/backend/src/constants.ts
@@ -28,6 +28,13 @@ export const retryDelay = 1000;
 
 export const EXPERIMENTAL_MAX_TOOL_CALL_STEPS = 3;
 
+/**
+ * Reasoning tokens are billed against the same output budget as the answer, so
+ * extended thinking gets a larger cap to avoid truncating the actual answer.
+ */
+export const MAX_OUTPUT_TOKENS = 8192;
+export const MAX_OUTPUT_TOKENS_EXTENDED_THINKING = 24_576;
+
 export const allowedSourceTypes = [
 	"personal_document",
 	"public_document",

--- a/apps/backend/src/integration/routes/llms.integration.test.ts
+++ b/apps/backend/src/integration/routes/llms.integration.test.ts
@@ -24,6 +24,7 @@ const externalToolEnabled: Partial<Record<ActiveTools, boolean>> = {
 	datawrapperMCPTools: config.featureFlagMcpDatawrapperAllowed,
 };
 const enabledExternalTool =
+	// @ts-expect-error ts-config excludes test files atm, leading to a type error here
 	[...EXTERNAL_TOOLS].find((tool) => externalToolEnabled[tool]) ?? null;
 
 let userToken: string;
@@ -92,4 +93,40 @@ describe("POST /llm/just-chatting active_tools validation", () => {
 			);
 		},
 	);
+
+	it("rejects a non-boolean extended_thinking with 400", async () => {
+		const res = await postJustChatting({
+			llm_model: "mistral-small",
+			messages: [{ role: "user", content: "hallo" }],
+			extended_thinking: "yes",
+		});
+
+		expect(res.status).toBe(400);
+		const responseBody = await res.json();
+		expect(responseBody.error).toContain("extended_thinking must be a boolean");
+	});
+
+	it("streams reasoning parts when extended_thinking is true", async () => {
+		const res = await postJustChatting({
+			llm_model: "mistral-small",
+			messages: [{ role: "user", content: "hallo" }],
+			extended_thinking: true,
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.text();
+		expect(body).toContain('"type":"reasoning-delta"');
+		expect(body).toContain("mock reasoning");
+	});
+
+	it("streams no reasoning parts when extended_thinking is omitted", async () => {
+		const res = await postJustChatting({
+			llm_model: "mistral-small",
+			messages: [{ role: "user", content: "hallo" }],
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.text();
+		expect(body).not.toContain("reasoning");
+	});
 });

--- a/apps/backend/src/routes/llms.ts
+++ b/apps/backend/src/routes/llms.ts
@@ -84,6 +84,14 @@ llms.post("/just-chatting", async (c: Context) => {
 			);
 		}
 
+		const extendedThinking = body.extended_thinking ?? false;
+		if (typeof extendedThinking !== "boolean") {
+			return c.json(
+				{ error: "Invalid request: extended_thinking must be a boolean" },
+				400,
+			);
+		}
+
 		const rawActiveTools = body.active_tools ?? [];
 
 		if (
@@ -143,6 +151,7 @@ llms.post("/just-chatting", async (c: Context) => {
 			allowedDocumentIds: allowedDocumentIds,
 			allowedFolderIds: allowedFolderIds,
 			activeTools,
+			extendedThinking,
 		});
 
 		response.headers.set("Content-Type", "text/event-stream; charset=utf-8");

--- a/apps/backend/src/services/external-mocks.ts
+++ b/apps/backend/src/services/external-mocks.ts
@@ -59,10 +59,17 @@ export function mockLanguageModel(): LanguageModel {
 			usage: MOCK_USAGE,
 			warnings: [],
 		}),
-		doStream: async (): Promise<LanguageModelV4StreamResult> => ({
+		doStream: async (options): Promise<LanguageModelV4StreamResult> => ({
 			stream: simulateReadableStream<LanguageModelV4StreamPart>({
 				chunks: [
 					{ type: "stream-start", warnings: [] },
+					...(options.reasoning !== undefined && options.reasoning !== "none"
+						? ([
+								{ type: "reasoning-start", id: "r0" },
+								{ type: "reasoning-delta", id: "r0", delta: "mock reasoning" },
+								{ type: "reasoning-end", id: "r0" },
+							] satisfies LanguageModelV4StreamPart[])
+						: []),
 					{ type: "text-start", id: "0" },
 					{ type: "text-delta", id: "0", delta: "mock response" },
 					{ type: "text-end", id: "0" },

--- a/apps/backend/src/services/generation-service.ts
+++ b/apps/backend/src/services/generation-service.ts
@@ -25,7 +25,12 @@ import { propagateAttributes } from "@langfuse/tracing";
 import { getChatPrompt, getTextPrompt } from "./prompt-provider";
 import { type Document, type LLMHandler } from "../types/common";
 import { BaseContentDbService } from "./db-service/base-db-service";
-import { LLM_PARAMETERS, EXPERIMENTAL_MAX_TOOL_CALL_STEPS } from "../constants";
+import {
+	LLM_PARAMETERS,
+	EXPERIMENTAL_MAX_TOOL_CALL_STEPS,
+	MAX_OUTPUT_TOKENS,
+	MAX_OUTPUT_TOKENS_EXTENDED_THINKING,
+} from "../constants";
 import type {
 	ActiveTools,
 	IncomingChatMessage,
@@ -300,6 +305,7 @@ export class GenerationService {
 		allowedDocumentIds: number[];
 		allowedFolderIds: number[];
 		activeTools: ActiveTools[];
+		extendedThinking: boolean;
 	}): Promise<Response> {
 		const {
 			messages,
@@ -310,6 +316,7 @@ export class GenerationService {
 			allowedDocumentIds,
 			allowedFolderIds,
 			activeTools,
+			extendedThinking,
 		} = args;
 
 		const memoryLogId =
@@ -341,8 +348,13 @@ export class GenerationService {
 							model: llmHandler.languageModel,
 							messages: messages.filter(nonEmptyAssistantMessage),
 							allowSystemInMessages: true,
-							maxOutputTokens: 8192,
+							maxOutputTokens: extendedThinking
+								? MAX_OUTPUT_TOKENS_EXTENDED_THINKING
+								: MAX_OUTPUT_TOKENS,
 							temperature: LLM_PARAMETERS.temperature,
+							// Mistral only knows "high" and "none"; left unset when the
+							// toggle is off, which is the API default anyway.
+							reasoning: extendedThinking ? "high" : undefined,
 							tools,
 							toolChoice,
 							stopWhen:

--- a/apps/backend/src/types/common.ts
+++ b/apps/backend/src/types/common.ts
@@ -82,6 +82,7 @@ export type ChatMessageBody = {
 	user_name: string;
 	active_tools: ActiveTools[];
 	llm_model: string;
+	extended_thinking?: boolean;
 };
 
 export type ActiveTools =

--- a/apps/backend/supabase/migrations/20260911090122_add_traces.sql
+++ b/apps/backend/supabase/migrations/20260911090122_add_traces.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."chat_messages"
+ADD COLUMN "traces" JSONB;

--- a/apps/backend/supabase/schemas/04_tables/07_chat_messages.sql
+++ b/apps/backend/supabase/schemas/04_tables/07_chat_messages.sql
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS "public"."chat_messages" (
     "web_citations" "jsonb",
     "parla_citations" "jsonb",
     "open_data_citations" "jsonb",
-    "external_tool_context" BOOLEAN DEFAULT FALSE NOT NULL
+    "external_tool_context" BOOLEAN DEFAULT FALSE NOT NULL,
+    "traces" "jsonb"
 );
 
 ALTER TABLE "public"."chat_messages" OWNER TO "postgres";

--- a/apps/frontend/src/api/chat/get-completion.ts
+++ b/apps/frontend/src/api/chat/get-completion.ts
@@ -39,6 +39,7 @@ export type OpenDataCitationSource = {
 
 type StreamEvent =
 	| { type: "text-delta"; id: string; delta: string }
+	| { type: "reasoning-delta"; id: string; delta: string }
 	| { type: "data-citations"; data: number[] }
 	| { type: "data-web-citations"; data: WebCitationSource[] }
 	| { type: "data-parla-citations"; data: ParlaCitationSource[] }
@@ -168,10 +169,12 @@ export async function getCompletion(
 			parla_citations: null,
 			open_data_citations: null,
 			external_tool_context: isExternalToolContext,
+			thinking_traces: null,
 		});
 		messageIdForCleanup = localMessageId;
 
 		let currentText = "";
+		let currentThinkingTraces = "";
 		let documentCitations: number[] = [];
 		let webCitations: WebCitationSource[] = [];
 		let parlaCitations: ParlaCitationSource[] = [];
@@ -190,6 +193,7 @@ export async function getCompletion(
 				open_data_citations: openDataCitations.length
 					? openDataCitations
 					: null,
+				thinking_traces: currentThinkingTraces || null,
 			});
 
 		await parseStream(response.body, {
@@ -201,6 +205,10 @@ export async function getCompletion(
 				}
 
 				currentText += delta;
+				writeMessage();
+			},
+			onReasoningDelta: (delta: string) => {
+				currentThinkingTraces += delta;
 				writeMessage();
 			},
 			onCitations: (chunkIds: number[]) => {
@@ -247,6 +255,7 @@ export async function getCompletion(
 								? openDataCitations
 								: null,
 							external_tool_context: isExternalToolContext,
+							thinking_traces: currentThinkingTraces || null,
 						});
 					} catch (error) {
 						removePendingMessageFromMemory(currentChat, localMessageId);
@@ -281,6 +290,7 @@ async function processStreamLine(
 	line: string,
 	callbacks: {
 		onTextDelta: (delta: string) => void;
+		onReasoningDelta: (delta: string) => void;
 		onCitations: (chunkIds: number[]) => void;
 		onWebCitations: (webCitationSources: WebCitationSource[]) => void;
 		onParlaCitations: (sources: ParlaCitationSource[]) => void;
@@ -304,6 +314,11 @@ async function processStreamLine(
 
 		if (event.type === "text-delta") {
 			callbacks.onTextDelta(event.delta);
+			return false;
+		}
+
+		if (event.type === "reasoning-delta") {
+			callbacks.onReasoningDelta(event.delta);
 			return false;
 		}
 
@@ -340,6 +355,7 @@ async function parseStream(
 	body: ReadableStream<Uint8Array>,
 	callbacks: {
 		onTextDelta: (delta: string) => void;
+		onReasoningDelta: (delta: string) => void;
 		onCitations: (chunkIds: number[]) => void;
 		onWebCitations: (webCitationSources: WebCitationSource[]) => void;
 		onParlaCitations: (sources: ParlaCitationSource[]) => void;

--- a/apps/frontend/src/api/message/insert-message.ts
+++ b/apps/frontend/src/api/message/insert-message.ts
@@ -20,6 +20,7 @@ export async function insertMessage(
 			parla_citations: chatMessage.parla_citations,
 			open_data_citations: chatMessage.open_data_citations,
 			external_tool_context: chatMessage.external_tool_context,
+			thinking_traces: chatMessage.thinking_traces,
 		})
 		.select("*")
 		.single();

--- a/apps/frontend/src/common.ts
+++ b/apps/frontend/src/common.ts
@@ -21,6 +21,7 @@ export type NewChatMessage = Pick<
 	| "parla_citations"
 	| "open_data_citations"
 	| "external_tool_context"
+	| "thinking_traces"
 >;
 
 export type ChatWithMessages = Chat & { messages: ChatMessage[] };
@@ -49,6 +50,8 @@ export type ChatMessage = {
 	open_data_citations: OpenDataCitationSource[] | null;
 	created_at: string;
 	external_tool_context: boolean;
+	// Reasoning trace streamed by the model when extended thinking is on.
+	thinking_traces: string | null;
 	id: number;
 	// Stable identity to avoid remounting the message's DOM node.
 	clientKey: number;

--- a/apps/frontend/src/components/chat/chat-form/chat-form.tsx
+++ b/apps/frontend/src/components/chat/chat-form/chat-form.tsx
@@ -194,6 +194,7 @@ export const ChatForm: React.FC<ChatFormProps> = ({
 			external_tool_context: selectedChatTools.some((tool) =>
 				externalChatTools.includes(tool),
 			),
+			thinking_traces: null,
 		};
 
 		const model = useChatsStore.getState().selectedLlmModel;

--- a/apps/frontend/src/store/use-chats-store.ts
+++ b/apps/frontend/src/store/use-chats-store.ts
@@ -97,6 +97,7 @@ interface ChatStore {
 		web_citations: WebCitationSource[] | null;
 		parla_citations: ParlaCitationSource[] | null;
 		open_data_citations: OpenDataCitationSource[] | null;
+		thinking_traces: string | null;
 	}): void;
 	visibleInfoMessage: VisibleChatInfoMessage;
 	showInfoMessage(infoMessage: VisibleChatInfoMessage): void;
@@ -424,6 +425,7 @@ export const useChatsStore = create<ChatStore>()((set, get) => ({
 		web_citations,
 		parla_citations,
 		open_data_citations,
+		thinking_traces,
 	}) => {
 		const foundMessage = chat.messages.find(({ id }) => id === messageId);
 		if (!foundMessage) {
@@ -435,6 +437,7 @@ export const useChatsStore = create<ChatStore>()((set, get) => ({
 		foundMessage.web_citations = web_citations;
 		foundMessage.parla_citations = parla_citations;
 		foundMessage.open_data_citations = open_data_citations;
+		foundMessage.thinking_traces = thinking_traces;
 		get().updateChats(chat);
 	},
 

--- a/libs/db-schema/index.ts
+++ b/libs/db-schema/index.ts
@@ -174,6 +174,7 @@ export type Database = {
 					open_data_citations: Json | null;
 					parla_citations: Json | null;
 					role: string;
+					traces: Json | null;
 					type: string;
 					web_citations: Json | null;
 				};
@@ -189,6 +190,7 @@ export type Database = {
 					open_data_citations?: Json | null;
 					parla_citations?: Json | null;
 					role: string;
+					traces?: Json | null;
 					type: string;
 					web_citations?: Json | null;
 				};
@@ -204,6 +206,7 @@ export type Database = {
 					open_data_citations?: Json | null;
 					parla_citations?: Json | null;
 					role?: string;
+					traces?: Json | null;
 					type?: string;
 					web_citations?: Json | null;
 				};

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@ai-sdk/mcp": "2.0.34",
-        "@ai-sdk/mistral": "4.0.31",
+        "@ai-sdk/mistral": "4.0.43",
         "@dqbd/tiktoken": "1.0.22",
         "@hono/node-server": "2.0.12",
         "@langfuse/client": "5.10.0",
@@ -555,19 +555,59 @@
       }
     },
     "node_modules/@ai-sdk/mistral": {
-      "version": "4.0.31",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/mistral/-/mistral-4.0.31.tgz",
-      "integrity": "sha512-T203RydStVxVmAZq3DejqbqpBT4/hah0d+dyJtksu5dHiSGyK1nBcs0wudLBy5kIbSEvnevEz6WiLwiZaREWvw==",
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mistral/-/mistral-4.0.43.tgz",
+      "integrity": "sha512-QnJYogzXG3AYpOGTHlKQw9ybPv4oNQWHBehEwQJrgp5n2JM6mzu2BVvmR6nIXLHZQlZ7tkIyKlZN4zoL1rASbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.7",
-        "@ai-sdk/provider-utils": "5.0.28"
+        "@ai-sdk/provider": "4.0.14",
+        "@ai-sdk/provider-utils": "5.0.40"
       },
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mistral/node_modules/@ai-sdk/provider": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.14.tgz",
+      "integrity": "sha512-yukP2tbcQQErG5gLCMBGvpvb/rM3D3KlTKG6eKKOdNHLHqtNNDEeBxdYrY/JL+O76B2ig5dXY19H/f1HFSvRiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/mistral/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.40",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.40.tgz",
+      "integrity": "sha512-zsXPwSAQ9mRJ2hvyITaLOYUyuGrBmzFhJXOg4mllGmla1PfNxZcm4GwqMiV2xQaDgcgBMdUGxXkp9xekZZNIkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mistral/node_modules/undici": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@ai-sdk/otel": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional extended-thinking mode for chat responses.
  * Reasoning traces can now stream during generation and be retained with chat messages.
  * Extended thinking uses an increased response capacity to reduce truncated answers.

* **Bug Fixes**
  * Invalid extended-thinking values now return a clear request error.

* **Tests**
  * Added coverage for validation, reasoning streaming, and standard responses without reasoning output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217989390958471